### PR TITLE
feat: add Cloudflare Radar source

### DIFF
--- a/docs/supported-sources/cloudflare-radar.md
+++ b/docs/supported-sources/cloudflare-radar.md
@@ -1,0 +1,90 @@
+# Cloudflare Radar
+
+[Cloudflare Radar](https://radar.cloudflare.com/) provides aggregated Internet traffic, routing, outage, bot, and certificate transparency data. ingestr supports Cloudflare Radar as a source.
+
+## URI format
+
+```plaintext
+cloudflare-radar://?api_token=<api-token>
+```
+
+Create an API token that can read Cloudflare Radar data. Radar's data endpoints are global, so the Cloudflare account ID is not part of the source URI.
+
+## Named tables
+
+The connector provides aliases for commonly loaded catalog and event datasets:
+
+| Table | Primary key | Description |
+| --- | --- | --- |
+| `annotations` | `id` | Internet events, outages, and traffic anomalies published by Radar. |
+| `autonomous_systems` | `asn` | Autonomous systems known to Radar. |
+| `bgp_hijacks` | `id` | Detected BGP route hijack events. |
+| `bgp_leaks` | `id` | Detected BGP route leak events. |
+| `bots` | `slug` | Radar's catalog of known bots and their user-agent patterns. |
+| `certificate_authorities` | `sha256Fingerprint` | Certificate authorities tracked through Certificate Transparency. |
+| `certificate_logs` | `slug` | Certificate Transparency logs and their current states. |
+| `datasets` | `id` | Downloadable Radar ranking and report datasets. |
+| `geolocations` | `geoId` | Radar's geographic location catalog. |
+| `locations` | `alpha2` | Countries and regions available as Radar filters. |
+| `outages` | `id` | Internet outage annotations. |
+| `origins` | `slug` | Origins available in Radar's origin metrics. |
+| `tlds` | `tld` | Top-level domains and their managers. |
+| `traffic_anomalies` | `uuid` | Recent Internet traffic anomalies. |
+
+Named collection tables are automatically paginated. `datasets` loads both ranking-bucket and report datasets.
+
+```sh
+ingestr ingest \
+    --source-uri 'cloudflare-radar://?api_token=your-api-token' \
+    --source-table 'annotations' \
+    --dest-uri 'duckdb:///radar.duckdb' \
+    --dest-table 'main.annotations'
+```
+
+`annotations`, `outages`, `bgp_hijacks`, `bgp_leaks`, and `traffic_anomalies` accept `--interval-start` and `--interval-end`. Without an interval, annotations and outages cover the maximum API-supported trailing range of 364 days; BGP event tables return all events exposed by the API; traffic anomalies cover the trailing seven days.
+
+## All Radar API endpoints
+
+Every GET endpoint in the [Cloudflare Radar API](https://developers.cloudflare.com/api/resources/radar/) is available as a dynamic table. Set `--source-table` to `api:` followed by the endpoint path after `/radar/`. Add the endpoint's query parameters directly to the table name.
+
+For example, the API route `/radar/http/timeseries` becomes:
+
+```sh
+ingestr ingest \
+    --source-uri 'cloudflare-radar://?api_token=your-api-token' \
+    --source-table 'api:http/timeseries?dateRange=7d&location=US' \
+    --dest-uri 'duckdb:///radar.duckdb' \
+    --dest-table 'main.http_requests'
+```
+
+Parameterized route segments are filled in as part of the path:
+
+```sh
+# /radar/http/summary/{dimension}
+--source-table 'api:http/summary/http_protocol?dateRange=7d'
+
+# /radar/entities/asns/{asn}
+--source-table 'api:entities/asns/13335'
+
+# /radar/ranking/domain/{domain}
+--source-table 'api:ranking/domain/cloudflare.com'
+```
+
+This covers all Radar families, including agent readiness, AI, annotations, AS112, attacks, BGP, bots, Certificate Transparency, datasets, DNS, email, entities, geolocations, HTTP, leaked credential checks, netflows, origins, post-quantum, quality, ranking, robots.txt, search, TCP resets and timeouts, TLDs, and traffic anomalies. Because the endpoint path and parameters are passed through, newly added Radar GET endpoints work without a connector release as long as they use Radar's standard JSON response envelope or return CSV.
+
+The source table must be shell-quoted because query strings contain `&`. Repeated parameters are supported, for example `location=US&location=GB`. JSON is used for normal API responses. The `/radar/datasets/{alias}` download endpoint returns CSV, which the connector parses into one row per record.
+
+Dynamic list endpoints are automatically paginated when Radar exposes offset or page pagination. Analytics, top, detail, search, and other non-list endpoints make one request using the supplied parameters. Use the endpoint's `limit` parameter where applicable.
+
+### Response rows
+
+Dynamic endpoint responses are converted to relational rows as follows:
+
+- list and top responses produce one row per item;
+- time-series responses produce one row per timestamp, with each metric as a column;
+- grouped or multiple series include `_series` when needed;
+- summary responses produce `dimension` and `value` columns;
+- detail responses produce one row;
+- nested values and Radar response metadata remain JSON columns.
+
+Dynamic tables default to the `replace` strategy. To merge them, provide the endpoint's stable key with `--primary-key` and select the merge strategy. `--interval-start` and `--interval-end` are forwarded as `dateStart` and `dateEnd` unless those parameters are already present in the source-table query string.

--- a/docs/supported-sources/cloudflare-radar.md
+++ b/docs/supported-sources/cloudflare-radar.md
@@ -87,4 +87,4 @@ Dynamic endpoint responses are converted to relational rows as follows:
 - detail responses produce one row;
 - nested values and Radar response metadata remain JSON columns.
 
-Dynamic tables default to the `replace` strategy. To merge them, provide the endpoint's stable key with `--primary-key` and select the merge strategy. `--interval-start` and `--interval-end` are forwarded as `dateStart` and `dateEnd` unless those parameters are already present in the source-table query string.
+Dynamic tables default to the `replace` strategy. To merge them, provide the endpoint's stable key with `--primary-key` and select the merge strategy. For endpoints that support date filters, `--interval-start` and `--interval-end` are forwarded as `dateStart` and `dateEnd` unless those parameters are already present in the source-table query string. Endpoints that only support `dateEnd` receive only the interval end.

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -90,6 +90,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Anthropic](/supported-sources/anthropic.md)
 - [Azure Data Lake Storage Gen2](/supported-sources/adls.md)
 - [Bruin](/supported-sources/bruin.md)
+- [Cloudflare Radar](/supported-sources/cloudflare-radar.md)
 - [Cursor](/supported-sources/cursor.md)
 - [Dune](/supported-sources/dune.md)
 - [GitHub](/supported-sources/github.md)

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -304,6 +304,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("clevertap", "CleverTap", []string{"clevertap"}, true, false),
 		genericURIConnector("clickhouse", "ClickHouse", []string{"clickhouse"}, true, true),
 		genericURIConnector("clickup", "ClickUp", []string{"clickup"}, true, false),
+		genericURIConnector("cloudflareradar", "Cloudflare Radar", []string{"cloudflare-radar", "cloudflareradar"}, true, false),
 		genericURIConnector("couchbase", "Couchbase", []string{"couchbase"}, true, false),
 		genericURIConnector("cratedb", "CrateDB", []string{"cratedb"}, true, true),
 		genericURIConnector("cursor", "Cursor", []string{"cursor"}, true, false),

--- a/pkg/source/cloudflareradar/api.go
+++ b/pkg/source/cloudflareradar/api.go
@@ -44,6 +44,57 @@ var paginatedAPIEndpoints = map[string]tableConfig{
 	"traffic_anomalies":                {resultField: "trafficAnomalies", maxPageSize: 1000},
 }
 
+var nonDateAPIEndpoints = []string{
+	"agent_readiness/summary/{dimension}",
+	"bgp/ips/top/ases",
+	"bgp/routes/ases",
+	"bgp/routes/moas",
+	"bgp/routes/paths/{asn}",
+	"bgp/routes/pfx2as",
+	"bgp/routes/realtime",
+	"bgp/routes/stats",
+	"bgp/rpki/aspa/snapshot",
+	"bgp/top/ases/prefixes",
+	"bots",
+	"bots/{bot_slug}",
+	"ct/authorities",
+	"ct/authorities/{ca_slug}",
+	"ct/logs",
+	"ct/logs/{log_slug}",
+	"datasets",
+	"datasets/{alias}",
+	"entities/asns",
+	"entities/asns/botnet_threat_feed",
+	"entities/asns/ip",
+	"entities/asns/{asn}",
+	"entities/asns/{asn}/as_set",
+	"entities/asns/{asn}/rel",
+	"entities/ip",
+	"entities/locations",
+	"entities/locations/{location}",
+	"geolocations",
+	"geolocations/{geo_id}",
+	"origins",
+	"origins/{slug}",
+	"post_quantum/tls/support",
+	"ranking/domain/{domain}",
+	"ranking/internet_services/categories",
+	"ranking/internet_services/top",
+	"ranking/top",
+	"robots_txt/top/domain_categories",
+	"robots_txt/top/user_agents/directive",
+	"search/global",
+	"tlds",
+	"tlds/{tld}",
+}
+
+var dateEndOnlyAPIEndpoints = map[string]struct{}{
+	"quality/speed/histogram":     {},
+	"quality/speed/summary":       {},
+	"quality/speed/top/ases":      {},
+	"quality/speed/top/locations": {},
+}
+
 func (s *CloudflareRadarSource) getAPITable(req source.TableRequest) (source.SourceTable, error) {
 	table, err := parseAPITable(req.Name)
 	if err != nil {
@@ -112,7 +163,7 @@ func (s *CloudflareRadarSource) readAPI(ctx context.Context, name string, table 
 
 func (s *CloudflareRadarSource) fetchAPI(ctx context.Context, name string, table apiTable, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	query := cloneValues(table.query)
-	setAPIDateRange(query, opts)
+	setAPIDateRange(table.path, query, opts)
 	limiter := &rowLimiter{limit: opts.Limit}
 	if table.config == nil {
 		items, err := s.fetchAPIRows(ctx, name, table.path, query, "")
@@ -213,17 +264,42 @@ func cloneValues(values url.Values) url.Values {
 	return cloned
 }
 
-func setAPIDateRange(query url.Values, opts source.ReadOptions) {
+func setAPIDateRange(path string, query url.Values, opts source.ReadOptions) {
 	if opts.IntervalStart == nil && opts.IntervalEnd == nil {
 		return
 	}
+	for _, pattern := range nonDateAPIEndpoints {
+		if matchAPIEndpoint(pattern, path) {
+			return
+		}
+	}
 	params := make(map[string]string, 2)
 	setDateRange(params, opts, "")
+	if _, ok := dateEndOnlyAPIEndpoints[path]; ok {
+		delete(params, "dateStart")
+	}
 	for key, value := range params {
 		if !query.Has(key) {
 			query.Set(key, value)
 		}
 	}
+}
+
+func matchAPIEndpoint(pattern, path string) bool {
+	patternParts := strings.Split(pattern, "/")
+	pathParts := strings.Split(path, "/")
+	if len(patternParts) != len(pathParts) {
+		return false
+	}
+	for i, part := range patternParts {
+		if strings.HasPrefix(part, "{") && strings.HasSuffix(part, "}") {
+			continue
+		}
+		if part != pathParts[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func decodeAPIItems(body []byte) ([]map[string]interface{}, error) {

--- a/pkg/source/cloudflareradar/api.go
+++ b/pkg/source/cloudflareradar/api.go
@@ -62,7 +62,7 @@ func (s *CloudflareRadarSource) getAPITable(req source.TableRequest) (source.Sou
 		TableStrategy:       strategy,
 		KnownSchema:         false,
 		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
-			return nil, fmt.Errorf("Cloudflare Radar API tables use schema inference")
+			return nil, fmt.Errorf("schema inference is required for Cloudflare Radar API tables")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 			return s.readAPI(ctx, req.Name, table, opts)
@@ -88,7 +88,7 @@ func parseAPITable(name string) (apiTable, error) {
 	}
 	query := parsed.Query()
 	if format := query.Get("format"); format != "" && format != "json" {
-		return apiTable{}, fmt.Errorf("Cloudflare Radar API tables only support format=json")
+		return apiTable{}, fmt.Errorf("only format=json is supported for Cloudflare Radar API tables")
 	}
 	query.Set("format", "json")
 
@@ -113,11 +113,13 @@ func (s *CloudflareRadarSource) readAPI(ctx context.Context, name string, table 
 func (s *CloudflareRadarSource) fetchAPI(ctx context.Context, name string, table apiTable, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	query := cloneValues(table.query)
 	setAPIDateRange(query, opts)
+	limiter := &rowLimiter{limit: opts.Limit}
 	if table.config == nil {
 		items, err := s.fetchAPIRows(ctx, name, table.path, query, "")
 		if err != nil {
 			return err
 		}
+		items, _ = limiter.trim(items)
 		return sendAPIItems(name, items, opts, results)
 	}
 
@@ -151,10 +153,12 @@ func (s *CloudflareRadarSource) fetchAPI(ctx context.Context, name string, table
 		if len(items) == 0 {
 			return nil
 		}
+		fetchedCount := len(items)
+		items, reachedLimit := limiter.trim(items)
 		if err := sendAPIItems(name, items, opts, results); err != nil {
 			return err
 		}
-		if len(items) < pageSize {
+		if reachedLimit || fetchedCount < pageSize {
 			return nil
 		}
 	}

--- a/pkg/source/cloudflareradar/api.go
+++ b/pkg/source/cloudflareradar/api.go
@@ -1,0 +1,492 @@
+package cloudflareradar
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const apiTablePrefix = "api:"
+
+type apiTable struct {
+	path   string
+	query  url.Values
+	config *tableConfig
+}
+
+var paginatedAPIEndpoints = map[string]tableConfig{
+	"annotations":                      {resultField: "annotations", maxPageSize: 1000},
+	"annotations/outages":              {resultField: "annotations", maxPageSize: 1000},
+	"bgp/hijacks/events":               {resultField: "events", maxPageSize: 5000, pageNumber: true},
+	"bgp/leaks/events":                 {resultField: "events", maxPageSize: 5000, pageNumber: true},
+	"bots":                             {resultField: "bots", maxPageSize: 1000},
+	"ct/authorities":                   {resultField: "certificateAuthorities", maxPageSize: 1000},
+	"ct/logs":                          {resultField: "certificateLogs", maxPageSize: 1000},
+	"datasets":                         {resultField: "datasets", maxPageSize: 100},
+	"entities/asns":                    {resultField: "asns", maxPageSize: 100},
+	"entities/asns/botnet_threat_feed": {resultField: "ases", maxPageSize: 1000},
+	"entities/locations":               {resultField: "locations", maxPageSize: 1000},
+	"geolocations":                     {resultField: "geolocations", maxPageSize: 1000},
+	"origins":                          {resultField: "origins", maxPageSize: 10},
+	"tlds":                             {resultField: "tlds", maxPageSize: 2000},
+	"traffic_anomalies":                {resultField: "trafficAnomalies", maxPageSize: 1000},
+}
+
+func (s *CloudflareRadarSource) getAPITable(req source.TableRequest) (source.SourceTable, error) {
+	table, err := parseAPITable(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	strategy := req.Strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           req.Name,
+		TablePrimaryKeys:    req.PrimaryKeys,
+		TableIncrementalKey: req.IncrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("Cloudflare Radar API tables use schema inference")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.readAPI(ctx, req.Name, table, opts)
+		},
+	}, nil
+}
+
+func parseAPITable(name string) (apiTable, error) {
+	raw := strings.TrimPrefix(name, apiTablePrefix)
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return apiTable{}, fmt.Errorf("invalid Cloudflare Radar API table: %w", err)
+	}
+	path := strings.TrimPrefix(parsed.Path, "/")
+	path = strings.TrimPrefix(path, "radar/")
+	if path == "" || parsed.IsAbs() || parsed.Host != "" || strings.Contains(path, `\`) {
+		return apiTable{}, fmt.Errorf("invalid Cloudflare Radar API table %q: expected api:<path>", name)
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return apiTable{}, fmt.Errorf("invalid Cloudflare Radar API path %q", path)
+		}
+	}
+	query := parsed.Query()
+	if format := query.Get("format"); format != "" && format != "json" {
+		return apiTable{}, fmt.Errorf("Cloudflare Radar API tables only support format=json")
+	}
+	query.Set("format", "json")
+
+	table := apiTable{path: path, query: query}
+	if cfg, ok := paginatedAPIEndpoints[path]; ok {
+		table.config = &cfg
+	}
+	return table, nil
+}
+
+func (s *CloudflareRadarSource) readAPI(ctx context.Context, name string, table apiTable, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+	go func() {
+		defer close(results)
+		if err := s.fetchAPI(ctx, name, table, opts, results); err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+	return results, nil
+}
+
+func (s *CloudflareRadarSource) fetchAPI(ctx context.Context, name string, table apiTable, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	query := cloneValues(table.query)
+	setAPIDateRange(query, opts)
+	if table.config == nil {
+		items, err := s.fetchAPIRows(ctx, name, table.path, query, "")
+		if err != nil {
+			return err
+		}
+		return sendAPIItems(name, items, opts, results)
+	}
+
+	pageSize := table.config.maxPageSize
+	if opts.PageSize > 0 && opts.PageSize < pageSize {
+		pageSize = opts.PageSize
+	}
+	if configuredLimit, err := strconv.Atoi(query.Get("limit")); err == nil && configuredLimit > 0 && configuredLimit < pageSize {
+		pageSize = configuredLimit
+	}
+	if configuredPageSize, err := strconv.Atoi(query.Get("per_page")); err == nil && configuredPageSize > 0 && configuredPageSize < pageSize {
+		pageSize = configuredPageSize
+	}
+
+	for page := 0; ; page++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if table.config.pageNumber {
+			query.Set("page", strconv.Itoa(page+1))
+			query.Set("per_page", strconv.Itoa(pageSize))
+		} else {
+			query.Set("offset", strconv.Itoa(page*pageSize))
+			query.Set("limit", strconv.Itoa(pageSize))
+		}
+
+		items, err := s.fetchAPIRows(ctx, name, table.path, query, table.config.resultField)
+		if err != nil {
+			return err
+		}
+		if len(items) == 0 {
+			return nil
+		}
+		if err := sendAPIItems(name, items, opts, results); err != nil {
+			return err
+		}
+		if len(items) < pageSize {
+			return nil
+		}
+	}
+}
+
+func (s *CloudflareRadarSource) fetchAPIRows(ctx context.Context, name, path string, query url.Values, resultField string) ([]map[string]interface{}, error) {
+	resp, err := s.client.R(ctx).SetQueryParamValues(query).Get("/radar/" + path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch Cloudflare Radar %s: %w", name, err)
+	}
+	if !resp.IsSuccess() {
+		return nil, fmt.Errorf("failed to fetch Cloudflare Radar %s: status %d: %s", name, resp.StatusCode(), resp.String())
+	}
+	if strings.Contains(resp.Header().Get("Content-Type"), "text/csv") {
+		items, err := decodeCSVItems(resp.Body())
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode Cloudflare Radar %s: %w", name, err)
+		}
+		return items, nil
+	}
+	if resultField != "" {
+		items, err := decodeItems(resp.Body(), resultField)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode Cloudflare Radar %s: %w", name, err)
+		}
+		return items, nil
+	}
+	items, err := decodeAPIItems(resp.Body())
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode Cloudflare Radar %s: %w", name, err)
+	}
+	return items, nil
+}
+
+func sendAPIItems(name string, items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert Cloudflare Radar %s to Arrow: %w", name, err)
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	return nil
+}
+
+func cloneValues(values url.Values) url.Values {
+	cloned := make(url.Values, len(values))
+	for key, value := range values {
+		cloned[key] = append([]string(nil), value...)
+	}
+	return cloned
+}
+
+func setAPIDateRange(query url.Values, opts source.ReadOptions) {
+	if opts.IntervalStart == nil && opts.IntervalEnd == nil {
+		return
+	}
+	params := make(map[string]string, 2)
+	setDateRange(params, opts, "")
+	for key, value := range params {
+		if !query.Has(key) {
+			query.Set(key, value)
+		}
+	}
+}
+
+func decodeAPIItems(body []byte) ([]map[string]interface{}, error) {
+	var envelope struct {
+		Success *bool       `json:"success"`
+		Result  interface{} `json:"result"`
+		Errors  interface{} `json:"errors"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&envelope); err != nil {
+		return nil, err
+	}
+	if envelope.Success != nil && !*envelope.Success {
+		return nil, fmt.Errorf("API response was not successful: %v", envelope.Errors)
+	}
+	if envelope.Result == nil {
+		return nil, fmt.Errorf("response is missing result")
+	}
+	return normalizeAPIResult(envelope.Result)
+}
+
+func decodeCSVItems(body []byte) ([]map[string]interface{}, error) {
+	reader := csv.NewReader(bytes.NewReader(body))
+	headers, err := reader.Read()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CSV header: %w", err)
+	}
+	seen := make(map[string]struct{}, len(headers))
+	for index, header := range headers {
+		header = strings.TrimPrefix(header, "\ufeff")
+		if header == "" {
+			return nil, fmt.Errorf("CSV column %d has an empty name", index+1)
+		}
+		if _, ok := seen[header]; ok {
+			return nil, fmt.Errorf("CSV has duplicate column %q", header)
+		}
+		headers[index] = header
+		seen[header] = struct{}{}
+	}
+
+	items := make([]map[string]interface{}, 0)
+	for {
+		values, err := reader.Read()
+		if err == io.EOF {
+			return items, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CSV row: %w", err)
+		}
+		item := make(map[string]interface{}, len(headers))
+		for index, value := range values {
+			item[headers[index]] = value
+		}
+		items = append(items, item)
+	}
+}
+
+func normalizeAPIResult(result interface{}) ([]map[string]interface{}, error) {
+	switch value := result.(type) {
+	case []interface{}:
+		return rowsFromArray(value, ""), nil
+	case map[string]interface{}:
+		return rowsFromObject(value), nil
+	default:
+		return []map[string]interface{}{{"value": value}}, nil
+	}
+}
+
+func rowsFromObject(result map[string]interface{}) []map[string]interface{} {
+	keys := sortedKeys(result)
+	seriesKeys := keysWithPrefix(keys, "serie_")
+	if len(seriesKeys) > 0 {
+		return rowsFromSeries(result, seriesKeys)
+	}
+	histogramKeys := keysWithPrefix(keys, "histogram_")
+	if len(histogramKeys) > 0 {
+		return rowsFromHistograms(result, histogramKeys)
+	}
+	summaryKeys := keysWithPrefix(keys, "summary_")
+	if len(summaryKeys) > 0 {
+		return rowsFromSummaries(result, summaryKeys)
+	}
+	topKeys := keysWithPrefix(keys, "top_")
+	if len(topKeys) > 0 {
+		return rowsFromCollections(result, topKeys)
+	}
+
+	collectionKeys := make([]string, 0)
+	objectKeys := make([]string, 0)
+	for _, key := range keys {
+		if isMetadataKey(key) {
+			continue
+		}
+		switch result[key].(type) {
+		case []interface{}:
+			collectionKeys = append(collectionKeys, key)
+		case map[string]interface{}:
+			objectKeys = append(objectKeys, key)
+		}
+	}
+	if len(collectionKeys) > 0 {
+		return rowsFromCollections(result, collectionKeys)
+	}
+	if len(objectKeys) == 1 && len(keys)-metadataKeyCount(result) == 1 {
+		row := result[objectKeys[0]].(map[string]interface{})
+		if meta := result["meta"]; meta != nil {
+			row["_meta"] = meta
+		}
+		return []map[string]interface{}{row}
+	}
+	return []map[string]interface{}{result}
+}
+
+func rowsFromSeries(result map[string]interface{}, seriesKeys []string) []map[string]interface{} {
+	rows := make([]map[string]interface{}, 0)
+	meta := result["meta"]
+	for _, seriesKey := range seriesKeys {
+		series, ok := result[seriesKey].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		timestamps, _ := series["timestamps"].([]interface{})
+		for index, timestamp := range timestamps {
+			row := map[string]interface{}{"timestamp": timestamp}
+			if len(seriesKeys) > 1 {
+				row["_series"] = seriesKey
+			}
+			for _, key := range sortedKeys(series) {
+				if key == "timestamps" {
+					continue
+				}
+				if values, ok := series[key].([]interface{}); ok && index < len(values) {
+					row[key] = values[index]
+				} else if !ok {
+					row[key] = series[key]
+				}
+			}
+			if meta != nil {
+				row["_meta"] = meta
+			}
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func rowsFromSummaries(result map[string]interface{}, summaryKeys []string) []map[string]interface{} {
+	rows := make([]map[string]interface{}, 0)
+	for _, summaryKey := range summaryKeys {
+		summary, ok := result[summaryKey].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, dimension := range sortedKeys(summary) {
+			row := map[string]interface{}{"dimension": dimension, "value": summary[dimension]}
+			if len(summaryKeys) > 1 {
+				row["_series"] = summaryKey
+			}
+			if meta := result["meta"]; meta != nil {
+				row["_meta"] = meta
+			}
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func rowsFromHistograms(result map[string]interface{}, histogramKeys []string) []map[string]interface{} {
+	rows := make([]map[string]interface{}, 0)
+	for _, histogramKey := range histogramKeys {
+		histogram, ok := result[histogramKey].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		rowCount := 0
+		for _, value := range histogram {
+			if values, ok := value.([]interface{}); ok && len(values) > rowCount {
+				rowCount = len(values)
+			}
+		}
+		for index := 0; index < rowCount; index++ {
+			row := make(map[string]interface{}, len(histogram)+2)
+			if len(histogramKeys) > 1 {
+				row["_series"] = histogramKey
+			}
+			for _, key := range sortedKeys(histogram) {
+				if values, ok := histogram[key].([]interface{}); ok && index < len(values) {
+					row[key] = values[index]
+				}
+			}
+			if meta := result["meta"]; meta != nil {
+				row["_meta"] = meta
+			}
+			rows = append(rows, row)
+		}
+	}
+	return rows
+}
+
+func rowsFromCollections(result map[string]interface{}, collectionKeys []string) []map[string]interface{} {
+	rows := make([]map[string]interface{}, 0)
+	for _, collectionKey := range collectionKeys {
+		collection, ok := result[collectionKey].([]interface{})
+		if !ok {
+			continue
+		}
+		collectionRows := rowsFromArray(collection, collectionKey)
+		if len(collectionKeys) == 1 {
+			for _, row := range collectionRows {
+				delete(row, "_collection")
+			}
+		}
+		if meta := result["meta"]; meta != nil {
+			for _, row := range collectionRows {
+				row["_meta"] = meta
+			}
+		}
+		rows = append(rows, collectionRows...)
+	}
+	return rows
+}
+
+func rowsFromArray(items []interface{}, collection string) []map[string]interface{} {
+	rows := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		row, ok := item.(map[string]interface{})
+		if !ok {
+			row = map[string]interface{}{"value": item}
+		}
+		if collection != "" {
+			row["_collection"] = collection
+		}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func sortedKeys(value map[string]interface{}) []string {
+	keys := make([]string, 0, len(value))
+	for key := range value {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func keysWithPrefix(keys []string, prefix string) []string {
+	matched := make([]string, 0)
+	for _, key := range keys {
+		if strings.HasPrefix(key, prefix) {
+			matched = append(matched, key)
+		}
+	}
+	return matched
+}
+
+func isMetadataKey(key string) bool {
+	return key == "meta" || key == "result_info" || key == "success"
+}
+
+func metadataKeyCount(result map[string]interface{}) int {
+	count := 0
+	for key := range result {
+		if isMetadataKey(key) {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/source/cloudflareradar/cloudflareradar.go
+++ b/pkg/source/cloudflareradar/cloudflareradar.go
@@ -1,0 +1,296 @@
+package cloudflareradar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	baseURL = "https://api.cloudflare.com/client/v4"
+
+	// Cloudflare's global Client API limit is 1,200 requests per five minutes.
+	rateLimit         = 3.2
+	rateLimitBurst    = 5
+	maxOffsetPageSize = 1000
+	maxPageNumberSize = 5000
+)
+
+type tableConfig struct {
+	endpoint         string
+	resultField      string
+	primaryKey       string
+	incrementalKey   string
+	defaultDateRange string
+	pageNumber       bool
+	maxPageSize      int
+}
+
+var supportedTables = map[string]tableConfig{
+	"annotations":             {endpoint: "/radar/annotations", resultField: "annotations", primaryKey: "id", incrementalKey: "startDate", defaultDateRange: "364d"},
+	"autonomous_systems":      {endpoint: "/radar/entities/asns", resultField: "asns", primaryKey: "asn", maxPageSize: 100},
+	"bgp_hijacks":             {endpoint: "/radar/bgp/hijacks/events", resultField: "events", primaryKey: "id", incrementalKey: "min_hijack_ts", pageNumber: true},
+	"bgp_leaks":               {endpoint: "/radar/bgp/leaks/events", resultField: "events", primaryKey: "id", incrementalKey: "detected_ts", pageNumber: true},
+	"bots":                    {endpoint: "/radar/bots", resultField: "bots", primaryKey: "slug"},
+	"certificate_authorities": {endpoint: "/radar/ct/authorities", resultField: "certificateAuthorities", primaryKey: "sha256Fingerprint"},
+	"certificate_logs":        {endpoint: "/radar/ct/logs", resultField: "certificateLogs", primaryKey: "slug"},
+	"datasets":                {endpoint: "/radar/datasets", resultField: "datasets", primaryKey: "id", maxPageSize: 100},
+	"geolocations":            {endpoint: "/radar/geolocations", resultField: "geolocations", primaryKey: "geoId"},
+	"locations":               {endpoint: "/radar/entities/locations", resultField: "locations", primaryKey: "alpha2"},
+	"outages":                 {endpoint: "/radar/annotations/outages", resultField: "annotations", primaryKey: "id", incrementalKey: "startDate", defaultDateRange: "364d"},
+	"origins":                 {endpoint: "/radar/origins", resultField: "origins", primaryKey: "slug", maxPageSize: 10},
+	"tlds":                    {endpoint: "/radar/tlds", resultField: "tlds", primaryKey: "tld", maxPageSize: 2000},
+	"traffic_anomalies":       {endpoint: "/radar/traffic_anomalies", resultField: "trafficAnomalies", primaryKey: "uuid", incrementalKey: "startDate", defaultDateRange: "7d"},
+}
+
+type CloudflareRadarSource struct {
+	client *httpclient.Client
+}
+
+func NewCloudflareRadarSource() *CloudflareRadarSource {
+	return &CloudflareRadarSource{}
+}
+
+func (s *CloudflareRadarSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *CloudflareRadarSource) Schemes() []string {
+	return []string{"cloudflare-radar", "cloudflareradar"}
+}
+
+func (s *CloudflareRadarSource) Connect(ctx context.Context, uri string) error {
+	apiToken, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(baseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithRetry(5, 2*time.Second, 30*time.Second),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithAuth(httpclient.NewBearerAuth(apiToken)),
+	)
+	return nil
+}
+
+func (s *CloudflareRadarSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func parseURI(uri string) (string, error) {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse Cloudflare Radar URI: %w", err)
+	}
+	if parsed.Scheme != "cloudflare-radar" && parsed.Scheme != "cloudflareradar" {
+		return "", fmt.Errorf("invalid Cloudflare Radar URI: must start with cloudflare-radar:// or cloudflareradar://")
+	}
+	if parsed.Host != "" || parsed.Path != "" {
+		return "", fmt.Errorf("invalid Cloudflare Radar URI: credentials must be query parameters")
+	}
+
+	apiToken := parsed.Query().Get("api_token")
+	if apiToken == "" {
+		return "", fmt.Errorf("api_token is required in Cloudflare Radar URI")
+	}
+	return apiToken, nil
+}
+
+func (s *CloudflareRadarSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	if strings.HasPrefix(req.Name, apiTablePrefix) {
+		return s.getAPITable(req)
+	}
+
+	table, ok := supportedTables[req.Name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported table: %s (supported named tables: %s; use api:<endpoint> for any Radar GET endpoint)", req.Name, strings.Join(tableNames(), ", "))
+	}
+
+	strategy := config.StrategyReplace
+	if table.incrementalKey != "" {
+		strategy = config.StrategyMerge
+	}
+	var primaryKeys []string
+	if table.primaryKey != "" {
+		primaryKeys = []string{table.primaryKey}
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           req.Name,
+		TablePrimaryKeys:    primaryKeys,
+		TableIncrementalKey: table.incrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("Cloudflare Radar source uses schema inference")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, req.Name, table, opts)
+		},
+	}, nil
+}
+
+func tableNames() []string {
+	return []string{
+		"annotations", "autonomous_systems", "bgp_hijacks", "bgp_leaks", "bots",
+		"certificate_authorities", "certificate_logs", "datasets", "geolocations", "locations",
+		"origins", "outages", "tlds", "traffic_anomalies",
+	}
+}
+
+func isValidTable(name string) bool {
+	_, ok := supportedTables[name]
+	return ok
+}
+
+func (s *CloudflareRadarSource) read(ctx context.Context, name string, table tableConfig, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+	go func() {
+		defer close(results)
+
+		var err error
+		if name == "datasets" {
+			err = s.readDatasets(ctx, table, opts, results)
+		} else {
+			err = s.paginateAndSend(ctx, name, table, opts, nil, results)
+		}
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+	return results, nil
+}
+
+func (s *CloudflareRadarSource) readDatasets(ctx context.Context, table tableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	for _, datasetType := range []string{"RANKING_BUCKET", "REPORT"} {
+		if err := s.paginateAndSend(ctx, "datasets", table, opts, map[string]string{"datasetType": datasetType}, results); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *CloudflareRadarSource) paginateAndSend(ctx context.Context, name string, table tableConfig, opts source.ReadOptions, extra map[string]string, results chan<- source.RecordBatchResult) error {
+	maxPageSize := maxOffsetPageSize
+	if table.pageNumber {
+		maxPageSize = maxPageNumberSize
+	} else if table.maxPageSize > 0 {
+		maxPageSize = table.maxPageSize
+	}
+	pageSize := opts.PageSize
+	if pageSize <= 0 || pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+
+	for page := 0; ; page++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		params := make(map[string]string, len(extra)+4)
+		for key, value := range extra {
+			params[key] = value
+		}
+		if table.pageNumber {
+			params["page"] = strconv.Itoa(page + 1)
+			params["per_page"] = strconv.Itoa(pageSize)
+		} else {
+			params["offset"] = strconv.Itoa(page * pageSize)
+			params["limit"] = strconv.Itoa(pageSize)
+		}
+		if table.incrementalKey != "" || table.defaultDateRange != "" {
+			setDateRange(params, opts, table.defaultDateRange)
+		}
+
+		resp, err := s.client.R(ctx).SetQueryParams(params).Get(table.endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch Cloudflare Radar %s: %w", name, err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("failed to fetch Cloudflare Radar %s: status %d: %s", name, resp.StatusCode(), resp.String())
+		}
+
+		items, err := decodeItems(resp.Body(), table.resultField)
+		if err != nil {
+			return fmt.Errorf("failed to decode Cloudflare Radar %s: %w", name, err)
+		}
+		if len(items) == 0 {
+			return nil
+		}
+
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to convert Cloudflare Radar %s to Arrow: %w", name, err)
+		}
+		results <- source.RecordBatchResult{Batch: record}
+
+		if len(items) < pageSize {
+			return nil
+		}
+	}
+}
+
+func setDateRange(params map[string]string, opts source.ReadOptions, defaultDateRange string) {
+	if opts.IntervalStart != nil && opts.IntervalEnd != nil {
+		params["dateStart"] = opts.IntervalStart.UTC().Format(time.RFC3339)
+		params["dateEnd"] = opts.IntervalEnd.UTC().Format(time.RFC3339)
+		return
+	}
+	if opts.IntervalStart != nil {
+		params["dateStart"] = opts.IntervalStart.UTC().Format(time.RFC3339)
+		params["dateEnd"] = time.Now().UTC().Format(time.RFC3339)
+		return
+	}
+	if opts.IntervalEnd != nil {
+		params["dateStart"] = opts.IntervalEnd.AddDate(-1, 0, 0).UTC().Format(time.RFC3339)
+		params["dateEnd"] = opts.IntervalEnd.UTC().Format(time.RFC3339)
+		return
+	}
+	if defaultDateRange != "" {
+		params["dateRange"] = defaultDateRange
+	}
+}
+
+func decodeItems(body []byte, field string) ([]map[string]interface{}, error) {
+	var envelope struct {
+		Success bool                       `json:"success"`
+		Result  map[string]json.RawMessage `json:"result"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&envelope); err != nil {
+		return nil, err
+	}
+	if !envelope.Success {
+		return nil, fmt.Errorf("API response was not successful")
+	}
+
+	raw, ok := envelope.Result[field]
+	if !ok {
+		return nil, fmt.Errorf("response is missing result.%s", field)
+	}
+	var items []map[string]interface{}
+	decoder = json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&items); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/pkg/source/cloudflareradar/cloudflareradar.go
+++ b/pkg/source/cloudflareradar/cloudflareradar.go
@@ -37,6 +37,30 @@ type tableConfig struct {
 	maxPageSize      int
 }
 
+type rowLimiter struct {
+	limit int
+	sent  int
+}
+
+func (l *rowLimiter) trim(items []map[string]interface{}) ([]map[string]interface{}, bool) {
+	if l.limit <= 0 {
+		return items, false
+	}
+	remaining := l.limit - l.sent
+	if remaining <= 0 {
+		return nil, true
+	}
+	if len(items) > remaining {
+		items = items[:remaining]
+	}
+	l.sent += len(items)
+	return items, l.sent >= l.limit
+}
+
+func (l *rowLimiter) reached() bool {
+	return l.limit > 0 && l.sent >= l.limit
+}
+
 var supportedTables = map[string]tableConfig{
 	"annotations":             {endpoint: "/radar/annotations", resultField: "annotations", primaryKey: "id", incrementalKey: "startDate", defaultDateRange: "364d"},
 	"autonomous_systems":      {endpoint: "/radar/entities/asns", resultField: "asns", primaryKey: "asn", maxPageSize: 100},
@@ -139,7 +163,7 @@ func (s *CloudflareRadarSource) GetTable(ctx context.Context, req source.TableRe
 		TableStrategy:       strategy,
 		KnownSchema:         false,
 		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
-			return nil, fmt.Errorf("Cloudflare Radar source uses schema inference")
+			return nil, fmt.Errorf("schema inference is required for Cloudflare Radar source")
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 			return s.read(ctx, req.Name, table, opts)
@@ -165,11 +189,12 @@ func (s *CloudflareRadarSource) read(ctx context.Context, name string, table tab
 	go func() {
 		defer close(results)
 
+		limiter := &rowLimiter{limit: opts.Limit}
 		var err error
 		if name == "datasets" {
-			err = s.readDatasets(ctx, table, opts, results)
+			err = s.readDatasets(ctx, table, opts, limiter, results)
 		} else {
-			err = s.paginateAndSend(ctx, name, table, opts, nil, results)
+			err = s.paginateAndSend(ctx, name, table, opts, nil, limiter, results)
 		}
 		if err != nil {
 			results <- source.RecordBatchResult{Err: err}
@@ -178,16 +203,19 @@ func (s *CloudflareRadarSource) read(ctx context.Context, name string, table tab
 	return results, nil
 }
 
-func (s *CloudflareRadarSource) readDatasets(ctx context.Context, table tableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *CloudflareRadarSource) readDatasets(ctx context.Context, table tableConfig, opts source.ReadOptions, limiter *rowLimiter, results chan<- source.RecordBatchResult) error {
 	for _, datasetType := range []string{"RANKING_BUCKET", "REPORT"} {
-		if err := s.paginateAndSend(ctx, "datasets", table, opts, map[string]string{"datasetType": datasetType}, results); err != nil {
+		if err := s.paginateAndSend(ctx, "datasets", table, opts, map[string]string{"datasetType": datasetType}, limiter, results); err != nil {
 			return err
+		}
+		if limiter.reached() {
+			return nil
 		}
 	}
 	return nil
 }
 
-func (s *CloudflareRadarSource) paginateAndSend(ctx context.Context, name string, table tableConfig, opts source.ReadOptions, extra map[string]string, results chan<- source.RecordBatchResult) error {
+func (s *CloudflareRadarSource) paginateAndSend(ctx context.Context, name string, table tableConfig, opts source.ReadOptions, extra map[string]string, limiter *rowLimiter, results chan<- source.RecordBatchResult) error {
 	maxPageSize := maxOffsetPageSize
 	if table.pageNumber {
 		maxPageSize = maxPageNumberSize
@@ -234,6 +262,8 @@ func (s *CloudflareRadarSource) paginateAndSend(ctx context.Context, name string
 		if len(items) == 0 {
 			return nil
 		}
+		fetchedCount := len(items)
+		items, reachedLimit := limiter.trim(items)
 
 		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
 		if err != nil {
@@ -241,7 +271,7 @@ func (s *CloudflareRadarSource) paginateAndSend(ctx context.Context, name string
 		}
 		results <- source.RecordBatchResult{Batch: record}
 
-		if len(items) < pageSize {
+		if reachedLimit || fetchedCount < pageSize {
 			return nil
 		}
 	}

--- a/pkg/source/cloudflareradar/cloudflareradar_test.go
+++ b/pkg/source/cloudflareradar/cloudflareradar_test.go
@@ -1,0 +1,222 @@
+package cloudflareradar
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		want    string
+		wantErr string
+	}{
+		{name: "hyphenated scheme", uri: "cloudflare-radar://?api_token=token", want: "token"},
+		{name: "compact scheme", uri: "cloudflareradar://?api_token=token", want: "token"},
+		{name: "escaped token", uri: "cloudflare-radar://?api_token=a%2Bb", want: "a+b"},
+		{name: "wrong scheme", uri: "cloudflare://?api_token=token", wantErr: "must start with"},
+		{name: "missing token", uri: "cloudflare-radar://", wantErr: "api_token is required"},
+		{name: "credentials in host", uri: "cloudflare-radar://token", wantErr: "query parameters"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseURI(tt.uri)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil || got != tt.want {
+				t.Fatalf("got token %q, error %v; want %q", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	for _, table := range tableNames() {
+		if !isValidTable(table) {
+			t.Errorf("expected %q to be valid", table)
+		}
+	}
+	for _, table := range []string{"", "Bots", "unknown"} {
+		if isValidTable(table) {
+			t.Errorf("expected %q to be invalid", table)
+		}
+	}
+}
+
+func TestParseAPITable(t *testing.T) {
+	tests := []struct {
+		name      string
+		table     string
+		wantPath  string
+		wantQuery map[string][]string
+		wantErr   string
+	}{
+		{
+			name:     "analytics endpoint",
+			table:    "api:http/timeseries?dateRange=7d&location=US&location=GB",
+			wantPath: "http/timeseries",
+			wantQuery: map[string][]string{
+				"dateRange": {"7d"},
+				"format":    {"json"},
+				"location":  {"US", "GB"},
+			},
+		},
+		{name: "parameterized endpoint", table: "api:ranking/domain/example.com", wantPath: "ranking/domain/example.com", wantQuery: map[string][]string{"format": {"json"}}},
+		{name: "radar prefix", table: "api:/radar/dns/summary/query_type", wantPath: "dns/summary/query_type", wantQuery: map[string][]string{"format": {"json"}}},
+		{name: "full URL", table: "api:https://example.com/radar/http/timeseries", wantErr: "expected api:<path>"},
+		{name: "parent traversal", table: "api:http/../dns/timeseries", wantErr: "invalid Cloudflare Radar API path"},
+		{name: "non-JSON format", table: "api:http/timeseries?format=csv", wantErr: "only support format=json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAPITable(tt.table)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.path != tt.wantPath {
+				t.Fatalf("got path %q, want %q", got.path, tt.wantPath)
+			}
+			for key, want := range tt.wantQuery {
+				values := got.query[key]
+				if strings.Join(values, ",") != strings.Join(want, ",") {
+					t.Errorf("query %s = %v, want %v", key, values, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDecodeItemsUsesJSONNumber(t *testing.T) {
+	items, err := decodeItems([]byte(`{"success":true,"result":{"events":[{"id":9007199254740993}]}}`), "events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := items[0]["id"].(json.Number); !ok || got.String() != "9007199254740993" {
+		t.Fatalf("expected exact json.Number, got %T %v", items[0]["id"], items[0]["id"])
+	}
+}
+
+func TestDecodeAPIItems(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want []map[string]interface{}
+	}{
+		{
+			name: "list",
+			body: `{"success":true,"result":{"asns":[{"asn":9007199254740993,"name":"Example"}]}}`,
+			want: []map[string]interface{}{{"asn": json.Number("9007199254740993"), "name": "Example"}},
+		},
+		{
+			name: "summary",
+			body: `{"success":true,"result":{"summary_0":{"IPv4":"80.5","IPv6":"19.5"}}}`,
+			want: []map[string]interface{}{{"dimension": "IPv4", "value": "80.5"}, {"dimension": "IPv6", "value": "19.5"}},
+		},
+		{
+			name: "time series",
+			body: `{"success":true,"result":{"serie_0":{"timestamps":["2026-01-01T00:00:00Z","2026-01-02T00:00:00Z"],"values":["1","2"],"IPv6":["3","4"]}}}`,
+			want: []map[string]interface{}{
+				{"timestamp": "2026-01-01T00:00:00Z", "values": "1", "IPv6": "3"},
+				{"timestamp": "2026-01-02T00:00:00Z", "values": "2", "IPv6": "4"},
+			},
+		},
+		{
+			name: "multiple time series",
+			body: `{"success":true,"result":{"serie_0":{"timestamps":["a"],"values":["1"]},"serie_1":{"timestamps":["b"],"values":["2"]}}}`,
+			want: []map[string]interface{}{
+				{"_series": "serie_0", "timestamp": "a", "values": "1"},
+				{"_series": "serie_1", "timestamp": "b", "values": "2"},
+			},
+		},
+		{
+			name: "top",
+			body: `{"success":true,"result":{"top_0":[{"rank":1,"domain":"example.com"}]}}`,
+			want: []map[string]interface{}{{"rank": json.Number("1"), "domain": "example.com"}},
+		},
+		{
+			name: "histogram",
+			body: `{"success":true,"result":{"histogram_0":{"bucketMin":["0","10"],"values":["5","2"]}}}`,
+			want: []map[string]interface{}{{"bucketMin": "0", "values": "5"}, {"bucketMin": "10", "values": "2"}},
+		},
+		{
+			name: "singleton wrapper",
+			body: `{"success":true,"result":{"bot":{"slug":"example","name":"Example"}}}`,
+			want: []map[string]interface{}{{"slug": "example", "name": "Example"}},
+		},
+		{
+			name: "primitive array",
+			body: `{"success":true,"result":["one","two"]}`,
+			want: []map[string]interface{}{{"value": "one"}, {"value": "two"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeAPIItems([]byte(tt.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotJSON, _ := json.Marshal(got)
+			wantJSON, _ := json.Marshal(tt.want)
+			if string(gotJSON) != string(wantJSON) {
+				t.Fatalf("got %s, want %s", gotJSON, wantJSON)
+			}
+		})
+	}
+}
+
+func TestDecodeAPIItemsRejectsUnsuccessfulEnvelope(t *testing.T) {
+	_, err := decodeAPIItems([]byte(`{"success":false,"errors":[{"message":"bad request"}],"result":{}}`))
+	if err == nil || !strings.Contains(err.Error(), "bad request") {
+		t.Fatalf("expected API error, got %v", err)
+	}
+}
+
+func TestDecodeCSVItems(t *testing.T) {
+	items, err := decodeCSVItems([]byte("domain,rank\nexample.com,1\ncloudflare.com,2\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []map[string]interface{}{
+		{"domain": "example.com", "rank": "1"},
+		{"domain": "cloudflare.com", "rank": "2"},
+	}
+	gotJSON, _ := json.Marshal(items)
+	wantJSON, _ := json.Marshal(want)
+	if string(gotJSON) != string(wantJSON) {
+		t.Fatalf("got %s, want %s", gotJSON, wantJSON)
+	}
+}
+
+func TestSetDateRange(t *testing.T) {
+	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	params := map[string]string{}
+	setDateRange(params, source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}, "364d")
+	if params["dateStart"] != "2026-01-02T03:04:05Z" || params["dateEnd"] != "2026-01-03T03:04:05Z" {
+		t.Fatalf("unexpected date range: %v", params)
+	}
+
+	params = map[string]string{}
+	setDateRange(params, source.ReadOptions{}, "364d")
+	if params["dateRange"] != "364d" {
+		t.Fatalf("expected default 364d range, got %v", params)
+	}
+}

--- a/pkg/source/cloudflareradar/cloudflareradar_test.go
+++ b/pkg/source/cloudflareradar/cloudflareradar_test.go
@@ -2,6 +2,7 @@ package cloudflareradar
 
 import (
 	"encoding/json"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -242,5 +243,36 @@ func TestSetDateRange(t *testing.T) {
 	setDateRange(params, source.ReadOptions{}, "364d")
 	if params["dateRange"] != "364d" {
 		t.Fatalf("expected default 364d range, got %v", params)
+	}
+}
+
+func TestSetAPIDateRange(t *testing.T) {
+	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+	opts := source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}
+	tests := []struct {
+		name      string
+		path      string
+		query     string
+		wantStart string
+		wantEnd   string
+	}{
+		{name: "date range", path: "http/timeseries", wantStart: "2026-01-02T03:04:05Z", wantEnd: "2026-01-03T03:04:05Z"},
+		{name: "date end only", path: "quality/speed/summary", wantEnd: "2026-01-03T03:04:05Z"},
+		{name: "no dates", path: "entities/asns/13335"},
+		{name: "explicit dates", path: "http/timeseries", query: "dateStart=2025-01-01T00%3A00%3A00Z&dateEnd=2025-01-02T00%3A00%3A00Z", wantStart: "2025-01-01T00:00:00Z", wantEnd: "2025-01-02T00:00:00Z"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, err := url.ParseQuery(tt.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			setAPIDateRange(tt.path, query, opts)
+			if query.Get("dateStart") != tt.wantStart || query.Get("dateEnd") != tt.wantEnd {
+				t.Fatalf("got dateStart=%q dateEnd=%q, want dateStart=%q dateEnd=%q", query.Get("dateStart"), query.Get("dateEnd"), tt.wantStart, tt.wantEnd)
+			}
+		})
 	}
 }

--- a/pkg/source/cloudflareradar/cloudflareradar_test.go
+++ b/pkg/source/cloudflareradar/cloudflareradar_test.go
@@ -53,6 +53,30 @@ func TestIsValidTable(t *testing.T) {
 	}
 }
 
+func TestRowLimiter(t *testing.T) {
+	items := []map[string]interface{}{{"id": 1}, {"id": 2}}
+	limiter := &rowLimiter{limit: 3}
+
+	first, reached := limiter.trim(items)
+	if len(first) != 2 || reached {
+		t.Fatalf("first page: got %d items and reached=%t", len(first), reached)
+	}
+	second, reached := limiter.trim(items)
+	if len(second) != 1 || !reached || second[0]["id"] != 1 {
+		t.Fatalf("second page: got %v and reached=%t", second, reached)
+	}
+	third, reached := limiter.trim(items)
+	if len(third) != 0 || !reached {
+		t.Fatalf("third page: got %d items and reached=%t", len(third), reached)
+	}
+
+	unlimited := &rowLimiter{}
+	got, reached := unlimited.trim(items)
+	if len(got) != len(items) || reached {
+		t.Fatalf("unlimited: got %d items and reached=%t", len(got), reached)
+	}
+}
+
 func TestParseAPITable(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -75,7 +99,7 @@ func TestParseAPITable(t *testing.T) {
 		{name: "radar prefix", table: "api:/radar/dns/summary/query_type", wantPath: "dns/summary/query_type", wantQuery: map[string][]string{"format": {"json"}}},
 		{name: "full URL", table: "api:https://example.com/radar/http/timeseries", wantErr: "expected api:<path>"},
 		{name: "parent traversal", table: "api:http/../dns/timeseries", wantErr: "invalid Cloudflare Radar API path"},
-		{name: "non-JSON format", table: "api:http/timeseries?format=csv", wantErr: "only support format=json"},
+		{name: "non-JSON format", table: "api:http/timeseries?format=csv", wantErr: "only format=json is supported"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/source/cloudflareradar/register.go
+++ b/pkg/source/cloudflareradar/register.go
@@ -1,0 +1,10 @@
+package cloudflareradar
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"cloudflare-radar", "cloudflareradar"},
+		func() interface{} { return NewCloudflareRadarSource() },
+	)
+}


### PR DESCRIPTION
## What
Add Cloudflare Radar as an ingestr source, with named warehouse-friendly tables and access to every Radar GET endpoint through a generic API table syntax.

## Changes
- Add `cloudflare-radar://?api_token=...` source registration, authentication, rate limiting, retries, and schema inference.
- Add 14 named, fully paginated catalog/event tables with merge metadata where stable keys exist.
- Add `api:<radar-path>?<params>` dynamic tables for all current and future Radar GET endpoints.
- Normalize list, top, summary, time-series, grouped-series, histogram, singleton, heterogeneous collection, and CSV dataset responses into relational rows.
- Preserve exact JSON numbers, forward repeated query parameters and incremental date bounds, and reject unsafe endpoint paths.
- Register the connector in the server catalog and document named/dynamic usage.

## How to test
1. Run `make format`.
2. Run `make lint`.
3. Run `make test TEST_CONCURRENCY=1`.
4. Set a Radar API token and ingest a dynamic endpoint, for example:
   ```sh
   ingestr ingest \
     --source-uri 'cloudflare-radar://?api_token=...' \
     --source-table 'api:http/timeseries?dateRange=7d&location=US' \
     --dest-uri 'duckdb:///radar.duckdb' \
     --dest-table main.http_timeseries
   ```

Live verification covered all 149 non-deprecated Radar GET endpoints against the current Cloudflare OpenAPI catalog, each producing a non-empty DuckDB table. Named pagination was also exercised against large collections, including 122,307 autonomous systems.

## Risk & rollback
- **Risk:** Medium. This is a new external API source; Cloudflare may add response shapes beyond the standard Radar envelope. Existing connectors are unaffected.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues
None.
