### PR TITLE
fix(clickhouse): read decimal precision and scale in GetTableSchema

### DIFF
--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -645,6 +645,9 @@ func (d *ClickHouseDestination) GetTableSchema(ctx context.Context, table string
 			DataType: mapClickHouseTypeToSchema(colType),
 			Nullable: strings.HasPrefix(colType, "Nullable("),
 		}
+		if col.DataType == schema.TypeDecimal {
+			col.Precision, col.Scale = parseClickHouseDecimal(colType)
+		}
 
 		columns = append(columns, col)
 	}
@@ -662,6 +665,52 @@ func (d *ClickHouseDestination) GetTableSchema(ctx context.Context, table string
 		Schema:  database,
 		Columns: columns,
 	}, nil
+}
+
+var (
+	// DESCRIBE renders this form with a space after the comma.
+	clickHouseDecimalPS = regexp.MustCompile(`(?i)^Decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)$`)
+	clickHouseDecimalW  = regexp.MustCompile(`(?i)^Decimal(32|64|128|256)\(\s*(\d+)\s*\)$`)
+)
+
+// parseClickHouseDecimal extracts precision and scale from a ClickHouse decimal type.
+//
+// Leaving them at zero makes schemaevolution.normalizedDecimal read the column back as a
+// phantom Decimal(38, 0); widening a real Decimal(38, 9) against that asks for precision
+// 38+9=47 and fails every sync after the first.
+func parseClickHouseDecimal(colType string) (precision, scale int) {
+	t := strings.TrimSpace(colType)
+unwrap:
+	for {
+		switch {
+		case strings.HasPrefix(t, "Nullable("):
+			t = strings.TrimSuffix(strings.TrimPrefix(t, "Nullable("), ")")
+		case strings.HasPrefix(t, "LowCardinality("):
+			t = strings.TrimSuffix(strings.TrimPrefix(t, "LowCardinality("), ")")
+		default:
+			break unwrap
+		}
+		t = strings.TrimSpace(t)
+	}
+	if m := clickHouseDecimalPS.FindStringSubmatch(t); m != nil {
+		p, _ := strconv.Atoi(m[1])
+		s, _ := strconv.Atoi(m[2])
+		return p, s
+	}
+	if m := clickHouseDecimalW.FindStringSubmatch(t); m != nil {
+		s, _ := strconv.Atoi(m[2])
+		switch m[1] {
+		case "32":
+			return 9, s
+		case "64":
+			return 18, s
+		case "128":
+			return 38, s
+		case "256":
+			return 76, s
+		}
+	}
+	return 0, 0
 }
 
 func mapClickHouseTypeToSchema(colType string) schema.DataType {

--- a/pkg/destination/clickhouse/clickhouse_test.go
+++ b/pkg/destination/clickhouse/clickhouse_test.go
@@ -406,3 +406,58 @@ func TestBeginTransactionUnsupported(t *testing.T) {
 		t.Fatalf("BeginTransaction() error = %v, want transaction unsupported error", err)
 	}
 }
+
+func TestParseClickHouseDecimal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		colType   string
+		precision int
+		scale     int
+	}{
+		// DESCRIBE renders Decimal(P, S) WITH a space; a parser that assumes
+		// "Decimal(38,9)" silently returns 0,0 and reintroduces the bug below.
+		{"Decimal(38, 9)", 38, 9},
+		{"Decimal(38,9)", 38, 9},
+		{"Nullable(Decimal(38, 9))", 38, 9},
+		{"LowCardinality(Decimal(18, 4))", 18, 4},
+		{"Decimal(30, 10)", 30, 10},
+		// Width-suffixed forms: precision is implied, and this is what ingestr's
+		// own mapper emits (Decimal128(9) by default).
+		{"Decimal32(2)", 9, 2},
+		{"Decimal64(4)", 18, 4},
+		{"Decimal128(9)", 38, 9},
+		{"Nullable(Decimal128(9))", 38, 9},
+		{"Decimal256(20)", 76, 20},
+		// Non-decimals must not report a precision.
+		{"String", 0, 0},
+		{"Nullable(DateTime64(6, 'UTC'))", 0, 0},
+	}
+
+	for _, tt := range tests {
+		p, s := parseClickHouseDecimal(tt.colType)
+		if p != tt.precision || s != tt.scale {
+			t.Errorf("parseClickHouseDecimal(%q) = (%d, %d), want (%d, %d)",
+				tt.colType, p, s, tt.precision, tt.scale)
+		}
+	}
+}
+
+// Regression: the destination column must report its scale. Read back as
+// Decimal(38, 0) the widener computes 38 integer digits and then requires
+// precision 38+9=47, failing every sync after the first.
+func TestParseClickHouseDecimalPreservesScaleForWidening(t *testing.T) {
+	t.Parallel()
+
+	const sourceScale = 9
+
+	p, s := parseClickHouseDecimal("Nullable(Decimal(38, 9))")
+	if p != 38 || s != sourceScale {
+		t.Fatalf("got (%d, %d), want (38, %d)", p, s, sourceScale)
+	}
+
+	intDigits := p - s
+	if required := intDigits + sourceScale; required > 38 {
+		t.Fatalf("widening requires precision %d, exceeds the maximum of 38", required)
+	}
+}


### PR DESCRIPTION
## What

The ClickHouse destination never reads a decimal column's precision and scale back from the
server, so schema evolution compares against a phantom type and **every sync after the first
fails** for any table containing a decimal column.

`ClickHouseDestination.GetTableSchema` builds each column as `{Name, DataType, Nullable}` and
leaves `Precision`/`Scale` at zero. `schemaevolution.normalizedDecimal` then fills
`Precision = 38` but leaves `Scale = 0`, producing a phantom `Decimal(38, 0)`. Widening a real
`Decimal(38, 9)` source column against that phantom computes integer digits `38 - 0 = 38`,
scale `max(9, 0) = 9`, and asks for precision `38 + 9 = 47`:

```
schema evolution failed: failed to compare schemas: column <c>:
decimal widening requires precision 47 (integer digits 38 + scale 9),
maximum supported precision is 38
```

The failure cannot occur on a first load — there is no destination table to compare against —
so initial testing always passes and the error only appears on the next run. Neither
`--schema-contract` (`freeze`, `discard_value`, `discard_row`) nor casting the source column
avoids it: the schema comparison runs before the contract is consulted, and the source side was
never the broken one.

## Changes

- **`pkg/destination/clickhouse/clickhouse.go`**
  - `GetTableSchema` now populates `Precision`/`Scale` for `schema.TypeDecimal` columns.
  - New `parseClickHouseDecimal` handles both renderings plus wrappers:
    - `Decimal(P, S)` — `DESCRIBE` emits a **space** after the comma;
    - `Decimal32|64|128|256(S)` — precision implied by width (9 / 18 / 38 / 76), which is what
      ingestr's own type mapper emits (`Decimal128(9)` by default);
    - `Nullable(...)` and `LowCardinality(...)`, unwrapped recursively.
  - Non-decimal types return `0, 0` — exactly what they returned before.

- **`pkg/destination/clickhouse/clickhouse_test.go`**
  - Table test covering both renderings, both wrappers and non-decimal types.
  - `TestParseClickHouseDecimalPreservesScaleForWidening` — named regression test pinning the
    precision-47 failure.

No docs change: the ClickHouse **destination** has no docs page (only
`docs/supported-sources/clickhouse.md`), and this fixes existing behaviour rather than adding an
option. No `go.mod`/`go.sum` change, so the license audit lock is untouched.

## How to test

1. `go test ./pkg/destination/clickhouse/`
2. End to end: ingest a source table with a `Decimal(38, 9)` column into ClickHouse **twice**.
   Before this change the second run fails with the error above. After it, the destination reads
   back as `(38, 9)`, the comparison short-circuits, and no `ALTER` is emitted at all.

Verified end to end against a live multi-replica ClickHouse over 60+ tables and several million
rows: tables that previously failed on their second pass now complete, with
`count() FINAL == count()` on every table, so the merge path introduces no duplication.

## Risk & rollback

- **Risk:** low. The two fields being populated were previously always zero, and that zero is
  precisely what produced the failure — no correct behaviour can depend on it. Non-decimal
  columns are untouched, and there are no API or signature changes.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`, `make test-full`)
- [x] Format and lint pass (`make format-ci` clean; `make lint` reports 0 issues on the
      changed package)
- [x] Integration tests pass if affected — ran the destination conformance suites that
      exercise this path (`TestDestinations_SchemaEvolution`, `TestDestinations_Merge`)
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable) — none; the change is type-metadata
      parsing of a `DESCRIBE` result.

> Note for reviewers: `make lint-full` currently reports 3 pre-existing `staticcheck`
> SA1019 deprecation findings on `main` — `pkg/destination/snowflake/snowflake.go:300`,
> `pkg/source/googleads/googleads.go:63` and `pkg/source/sqs/sqs.go:384`. None are touched
> by this PR; `golangci-lint run ./pkg/destination/clickhouse/...` is clean.

## Related issues

None found. Searched the repository for decimal/precision and ClickHouse schema-evolution
issues; #806 (MSSQL custom query drops decimal scale), #940 (preserve Snowflake decimal
metadata) and #641 (Snowflake decimal handling) are adjacent but none covers the ClickHouse
read-back path.
