### PR TITLE
feat: add RIPEstat source

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -6,6 +6,7 @@ local_bin="$HOME/.local/bin"
 go_version="$(awk '/^go / { print $2; exit }' "$repo_root/go.mod")"
 node_version="22.14.0"
 npm_version="11.10.0"
+duckdb_version="1.5.5"
 
 mkdir -p "$local_bin" "$HOME/.local/share"
 export PATH="$local_bin:$HOME/go/bin:$PATH"
@@ -73,8 +74,29 @@ install_uv() {
     sh -c 'curl -LsSf https://astral.sh/uv/install.sh | sh'
 }
 
+install_duckdb() {
+  if [[ -x "$local_bin/duckdb" ]] && [[ "$($local_bin/duckdb --version)" == "v${duckdb_version} "* ]]; then
+    return
+  fi
+
+  local arch
+  case "$(uname -m)" in
+    x86_64) arch=amd64 ;;
+    aarch64 | arm64) arch=arm64 ;;
+    *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+  esac
+
+  local tmp_file
+  tmp_file="$(mktemp)"
+  curl -fsSL "https://github.com/duckdb/duckdb/releases/download/v${duckdb_version}/duckdb_cli-linux-${arch}.gz" -o "$tmp_file"
+  gzip -dc "$tmp_file" > "$local_bin/duckdb"
+  chmod +x "$local_bin/duckdb"
+  rm "$tmp_file"
+}
+
 step "Installing Go $go_version" install_go
 step "Installing Node.js $node_version and npm $npm_version" install_node
+step "Installing DuckDB CLI $duckdb_version" install_duckdb
 
 go_root="$HOME/.local/share/go/$go_version"
 node_root="$HOME/.local/share/node/$node_version"

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -112,3 +112,4 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Internet Society Pulse](/supported-sources/isoc-pulse.md)
 - [Kalshi](/supported-sources/kalshi.md)
 - [Polymarket](/supported-sources/polymarket.md)
+- [RIPEstat](/supported-sources/ripestat.md)

--- a/docs/supported-sources/ripestat.md
+++ b/docs/supported-sources/ripestat.md
@@ -1,0 +1,45 @@
+# RIPEstat
+
+[RIPEstat](https://stat.ripe.net/) provides Internet routing, registration, geography, DNS, and RPKI data from the RIPE NCC. Its Data API is public and does not require authentication.
+
+## URI format
+
+The source URI has no parameters because the API is public:
+
+```plaintext
+ripestat://
+```
+
+Use the RIPEstat endpoint name as the source table and append the endpoint's [request parameters](https://stat.ripe.net/docs/data-api/ripestat-data-api) in URL query format. For example, this command loads an overview of AS3333 into DuckDB:
+
+```sh
+ingestr ingest \
+  --source-uri 'ripestat://' \
+  --source-table 'as-overview?resource=AS3333' \
+  --dest-uri 'duckdb:///ripestat.duckdb' \
+  --dest-table 'main.as_overview'
+```
+
+Other source table examples include `announced-prefixes?resource=AS3333`, `prefix-overview?resource=193.0.20.0%2F24`, and `routing-history?resource=AS3333`. Endpoints that take no parameters, such as `example-resources`, use only the endpoint name.
+
+## Time intervals
+
+For endpoints that support a bounded time range, use ingestr's interval flags. They are sent to RIPEstat as `starttime` and `endtime` in UTC:
+
+```sh
+ingestr ingest \
+  --source-uri 'ripestat://' \
+  --source-table 'announced-prefixes?resource=AS3333' \
+  --interval-start '2026-01-01' \
+  --interval-end '2026-02-01' \
+  --dest-uri 'duckdb:///ripestat.duckdb' \
+  --dest-table 'main.announced_prefixes'
+```
+
+The interval flags are supported by `allocation-history`, `announced-prefixes`, `asn-neighbours-history`, `atlas-probe-deployment`, `bgp-update-activity`, `bgp-updates`, `bgplay`, `country-resource-stats`, `prefix-count`, `rir`, `ris-peer-count`, and `routing-history`. Supplying them for another endpoint returns an error instead of silently ignoring the interval. If `starttime` or `endtime` are also present in the source table, the interval flags take precedence.
+
+Loads default to the `replace` strategy. `--incremental-strategy` and `--primary-key` can be used when snapshots should instead be appended or merged. RIPEstat has no common incremental key across endpoints, so `--incremental-key` is not used for API filtering.
+
+Each request produces one snapshot row from the endpoint's `data` object. Scalar properties become columns, while nested objects and arrays are stored as JSON.
+
+RIPEstat limits callers to eight concurrent requests per IP address. A source read makes one request at a time and does not paginate or parallelize requests.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -386,6 +386,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("redis", "Redis Streams", []string{"redis", "rediss"}, true, false),
 		genericURIConnector("recurly", "Recurly", []string{"recurly"}, true, false),
 		genericURIConnector("redshift", "Redshift", []string{"redshift", "redshift+psycopg2"}, true, true),
+		genericURIConnector("ripestat", "RIPEstat", []string{"ripestat"}, true, false),
 		genericURIConnector("revenuecat", "RevenueCat", []string{"revenuecat"}, true, false),
 		genericURIConnector("salesforce", "Salesforce", []string{"salesforce"}, true, false),
 		genericURIConnector("sendgrid", "SendGrid", []string{"sendgrid"}, true, false),

--- a/pkg/source/ripestat/register.go
+++ b/pkg/source/ripestat/register.go
@@ -1,0 +1,10 @@
+package ripestat
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"ripestat"},
+		func() interface{} { return NewRIPEstatSource() },
+	)
+}

--- a/pkg/source/ripestat/ripestat.go
+++ b/pkg/source/ripestat/ripestat.go
@@ -1,0 +1,231 @@
+package ripestat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablespec"
+)
+
+const baseURL = "https://stat.ripe.net"
+
+var endpointPattern = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+var intervalEndpoints = map[string]struct{}{
+	"allocation-history":     {},
+	"announced-prefixes":     {},
+	"asn-neighbours-history": {},
+	"atlas-probe-deployment": {},
+	"bgp-update-activity":    {},
+	"bgp-updates":            {},
+	"bgplay":                 {},
+	"country-resource-stats": {},
+	"prefix-count":           {},
+	"rir":                    {},
+	"ris-peer-count":         {},
+	"routing-history":        {},
+}
+
+type RIPEstatSource struct {
+	client *httpclient.Client
+}
+
+func NewRIPEstatSource() *RIPEstatSource {
+	return &RIPEstatSource{}
+}
+
+func (s *RIPEstatSource) Schemes() []string {
+	return []string{"ripestat"}
+}
+
+func (s *RIPEstatSource) Connect(ctx context.Context, uri string) error {
+	if err := parseURI(uri); err != nil {
+		return err
+	}
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(baseURL),
+		httpclient.WithTimeout(120*time.Second),
+		httpclient.WithDebug(config.DebugMode),
+	)
+
+	config.Debug("[RIPESTAT] Connected successfully")
+	return nil
+}
+
+func parseURI(uri string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("failed to parse RIPEstat URI: %w", err)
+	}
+	if parsed.Scheme != "ripestat" {
+		return fmt.Errorf("invalid RIPEstat URI: must be ripestat://")
+	}
+	if parsed.Host != "" || parsed.Path != "" || parsed.User != nil || parsed.Fragment != "" || parsed.RawQuery != "" {
+		return fmt.Errorf("invalid RIPEstat URI: use ripestat:// and supply API parameters on the source table")
+	}
+	return nil
+}
+
+func (s *RIPEstatSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func (s *RIPEstatSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *RIPEstatSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	endpoint, params, err := parseTable(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	strategy := req.Strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           endpoint,
+		TablePrimaryKeys:    req.PrimaryKeys,
+		TableIncrementalKey: "",
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("RIPEstat source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			query, err := applyIntervalParams(endpoint, params, opts)
+			if err != nil {
+				return nil, err
+			}
+			return s.read(ctx, endpoint, query, opts), nil
+		},
+	}, nil
+}
+
+func parseTable(raw string) (string, url.Values, error) {
+	endpoint, params, _, err := tablespec.Split(raw)
+	if err != nil {
+		return "", nil, err
+	}
+	endpoint = strings.TrimSpace(endpoint)
+	if !isValidEndpoint(endpoint) {
+		return "", nil, fmt.Errorf("invalid RIPEstat endpoint %q: use the lowercase endpoint name from the RIPEstat Data API documentation", endpoint)
+	}
+	if params.Has("callback") {
+		return "", nil, fmt.Errorf("callback is not supported because the source requires a JSON response")
+	}
+	if !params.Has("sourceapp") {
+		params.Set("sourceapp", "ingestr")
+	}
+	if !params.Has("data_overload_limit") {
+		params.Set("data_overload_limit", "ignore")
+	}
+	return endpoint, params, nil
+}
+
+func isValidEndpoint(endpoint string) bool {
+	return endpointPattern.MatchString(endpoint)
+}
+
+func applyIntervalParams(endpoint string, params url.Values, opts source.ReadOptions) (url.Values, error) {
+	if opts.IntervalStart == nil && opts.IntervalEnd == nil {
+		return params, nil
+	}
+	if opts.IntervalStart == nil || opts.IntervalEnd == nil {
+		return nil, fmt.Errorf("RIPEstat intervals require both --interval-start and --interval-end")
+	}
+	if _, ok := intervalEndpoints[endpoint]; !ok {
+		return nil, fmt.Errorf("RIPEstat endpoint %q does not support starttime/endtime; omit --interval-start and --interval-end", endpoint)
+	}
+
+	query := make(url.Values, len(params))
+	for key, values := range params {
+		query[key] = values
+	}
+	query.Set("starttime", opts.IntervalStart.UTC().Format(time.RFC3339))
+	query.Set("endtime", opts.IntervalEnd.UTC().Format(time.RFC3339))
+	return query, nil
+}
+
+func (s *RIPEstatSource) read(ctx context.Context, endpoint string, params url.Values, opts source.ReadOptions) <-chan source.RecordBatchResult {
+	results := make(chan source.RecordBatchResult, 1)
+
+	go func() {
+		defer close(results)
+
+		item, err := s.fetch(ctx, endpoint, params)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+			return
+		}
+		if len(item) == 0 {
+			return
+		}
+
+		record, err := arrowconv.ItemsToArrowRecordWithSchema([]map[string]interface{}{item}, nil, opts.ExcludeColumns)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to convert RIPEstat endpoint %q to Arrow: %w", endpoint, err)}
+			return
+		}
+		results <- source.RecordBatchResult{Batch: record}
+	}()
+
+	return results
+}
+
+func (s *RIPEstatSource) fetch(ctx context.Context, endpoint string, params url.Values) (map[string]interface{}, error) {
+	path := fmt.Sprintf("/data/%s/data.json", endpoint)
+	config.Debug("[RIPESTAT] Fetching endpoint: %s", endpoint)
+
+	resp, err := s.client.R(ctx).SetQueryParamValues(params).Get(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch RIPEstat endpoint %q: %w", endpoint, err)
+	}
+	if !resp.IsSuccess() {
+		return nil, fmt.Errorf("RIPEstat endpoint %q returned HTTP status %d: %s", endpoint, resp.StatusCode(), resp.String())
+	}
+
+	var envelope struct {
+		Status     string          `json:"status"`
+		StatusCode int             `json:"status_code"`
+		Data       json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body(), &envelope); err != nil {
+		return nil, fmt.Errorf("failed to parse RIPEstat endpoint %q response: %w", endpoint, err)
+	}
+	if envelope.Status != "ok" || envelope.StatusCode != 200 {
+		return nil, fmt.Errorf("RIPEstat endpoint %q returned API status %q (%d): %s", endpoint, envelope.Status, envelope.StatusCode, resp.String())
+	}
+
+	item, err := decodeData(envelope.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse data from RIPEstat endpoint %q: %w", endpoint, err)
+	}
+	return item, nil
+}
+
+func decodeData(data json.RawMessage) (map[string]interface{}, error) {
+	var item map[string]interface{}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&item); err != nil {
+		return nil, err
+	}
+	return item, nil
+}

--- a/pkg/source/ripestat/ripestat_test.go
+++ b/pkg/source/ripestat/ripestat_test.go
@@ -1,0 +1,195 @@
+package ripestat
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr string
+	}{
+		{name: "empty", uri: "ripestat://"},
+		{name: "wrong scheme", uri: "https://stat.ripe.net", wantErr: "must be ripestat://"},
+		{name: "host", uri: "ripestat://AS3333", wantErr: "parameters on the source table"},
+		{name: "path", uri: "ripestat:///AS3333", wantErr: "parameters on the source table"},
+		{name: "parameters", uri: "ripestat://?resource=AS3333", wantErr: "parameters on the source table"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := parseURI(tt.uri)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestParseTable(t *testing.T) {
+	endpoint, params, err := parseTable("announced-prefixes?resource=AS3333&sourceapp=my_app&data_overload_limit=custom&tag=one&tag=two")
+	require.NoError(t, err)
+
+	assert.Equal(t, "announced-prefixes", endpoint)
+	assert.Equal(t, "AS3333", params.Get("resource"))
+	assert.Equal(t, "my_app", params.Get("sourceapp"))
+	assert.Equal(t, "custom", params.Get("data_overload_limit"))
+	assert.Equal(t, []string{"one", "two"}, params["tag"])
+}
+
+func TestParseTableDefaults(t *testing.T) {
+	endpoint, params, err := parseTable("example-resources")
+	require.NoError(t, err)
+
+	assert.Equal(t, "example-resources", endpoint)
+	assert.Equal(t, "ingestr", params.Get("sourceapp"))
+	assert.Equal(t, "ignore", params.Get("data_overload_limit"))
+}
+
+func TestParseTableRejectsCallback(t *testing.T) {
+	_, _, err := parseTable("as-overview?resource=AS3333&callback=handle")
+	require.ErrorContains(t, err, "callback is not supported")
+}
+
+func TestGetTableUsesRequestedStrategyAndPrimaryKeys(t *testing.T) {
+	s := NewRIPEstatSource()
+	table, err := s.GetTable(context.Background(), source.TableRequest{
+		Name:        "announced-prefixes?resource=AS3333",
+		Strategy:    config.StrategyAppend,
+		PrimaryKeys: []string{"resource"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, config.StrategyAppend, table.Strategy())
+	assert.Equal(t, []string{"resource"}, table.PrimaryKeys())
+}
+
+func TestIsValidEndpoint(t *testing.T) {
+	assert.True(t, isValidEndpoint("announced-prefixes"))
+	assert.True(t, isValidEndpoint("as-overview"))
+	assert.False(t, isValidEndpoint(""))
+	assert.False(t, isValidEndpoint("AS-overview"))
+	assert.False(t, isValidEndpoint("../meta"))
+	assert.False(t, isValidEndpoint("as_overview"))
+}
+
+func TestApplyIntervalParams(t *testing.T) {
+	start := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.FixedZone("test", 2*60*60))
+	end := time.Date(2026, time.January, 3, 4, 5, 6, 0, time.FixedZone("test", 2*60*60))
+	original := map[string][]string{
+		"resource":  {"AS3333"},
+		"starttime": {"old-start"},
+		"endtime":   {"old-end"},
+	}
+
+	params, err := applyIntervalParams("announced-prefixes", original, source.ReadOptions{
+		IntervalStart: &start,
+		IntervalEnd:   &end,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "2026-01-02T01:04:05Z", params.Get("starttime"))
+	assert.Equal(t, "2026-01-03T02:05:06Z", params.Get("endtime"))
+	assert.Equal(t, []string{"old-start"}, original["starttime"])
+	assert.Equal(t, []string{"old-end"}, original["endtime"])
+}
+
+func TestApplyIntervalParamsUnsupportedEndpoint(t *testing.T) {
+	start := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+
+	_, err := applyIntervalParams("as-overview", make(map[string][]string), source.ReadOptions{
+		IntervalStart: &start,
+		IntervalEnd:   &end,
+	})
+	require.ErrorContains(t, err, "does not support starttime/endtime")
+}
+
+func TestApplyIntervalParamsRequiresBothBounds(t *testing.T) {
+	start := time.Date(2026, time.January, 2, 0, 0, 0, 0, time.UTC)
+
+	_, err := applyIntervalParams("announced-prefixes", make(map[string][]string), source.ReadOptions{IntervalStart: &start})
+	require.ErrorContains(t, err, "require both --interval-start and --interval-end")
+}
+
+func TestDecodeDataUsesNumber(t *testing.T) {
+	item, err := decodeData(json.RawMessage(`{"asn":9007199254740993}`))
+	require.NoError(t, err)
+
+	value, ok := item["asn"].(json.Number)
+	require.True(t, ok)
+	assert.Equal(t, "9007199254740993", value.String())
+}
+
+func TestRead(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/data/as-overview/data.json", r.URL.Path)
+		assert.Equal(t, "AS3333", r.URL.Query().Get("resource"))
+		assert.Equal(t, "ingestr", r.URL.Query().Get("sourceapp"))
+		assert.Equal(t, "ignore", r.URL.Query().Get("data_overload_limit"))
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":      "ok",
+			"status_code": 200,
+			"data": map[string]interface{}{
+				"resource":  "3333",
+				"announced": true,
+				"block": map[string]interface{}{
+					"name": "test block",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	s := NewRIPEstatSource()
+	require.NoError(t, s.Connect(context.Background(), "ripestat://"))
+	defer func() { require.NoError(t, s.Close(context.Background())) }()
+	require.NoError(t, s.client.Close())
+	s.client = httpclient.New(httpclient.WithBaseURL(server.URL), httpclient.WithDisableRetry())
+
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "as-overview?resource=AS3333"})
+	require.NoError(t, err)
+	assert.Equal(t, "as-overview", table.Name())
+	assert.False(t, table.HasKnownSchema())
+
+	results, err := table.Read(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	result := <-results
+	require.NoError(t, result.Err)
+	require.NotNil(t, result.Batch)
+	defer result.Batch.Release()
+	assert.Equal(t, int64(1), result.Batch.NumRows())
+	assert.Equal(t, int64(3), result.Batch.NumCols())
+}
+
+func TestFetchAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":      "error",
+			"status_code": 400,
+			"messages":    [][]string{{"error", "resource is required"}},
+			"data":        map[string]interface{}{},
+		})
+	}))
+	defer server.Close()
+
+	s := NewRIPEstatSource()
+	s.client = httpclient.New(httpclient.WithBaseURL(server.URL), httpclient.WithDisableRetry())
+	defer func() { require.NoError(t, s.client.Close()) }()
+
+	_, err := s.fetch(context.Background(), "as-overview", make(map[string][]string))
+	require.ErrorContains(t, err, "returned API status \"error\" (400)")
+}


### PR DESCRIPTION
## Summary
- add a public RIPEstat Data API source with endpoint parameters on `--source-table`
- map ingestr interval flags to supported RIPEstat `starttime`/`endtime` parameters
- preserve endpoint-specific nested data as JSON with inferred schemas
- document usage and install the DuckDB CLI in Amp orb setup for local inspection

## Verification
- `make format`
- `make lint`
- `TEST_CONCURRENCY=1 make test`
- `make build`
- live RIPEstat to DuckDB ingestion for `as-overview` and `announced-prefixes`
- live API validation of all 12 interval-capable endpoints