### PR TITLE
Speed up SQL Server to Snowflake bulk loads

### DIFF
--- a/docs/supported-sources/snowflake.md
+++ b/docs/supported-sources/snowflake.md
@@ -86,3 +86,14 @@ When Snowflake is used as a Postgres CDC destination (`postgres+cdc://` → `sno
 - `_BRUIN_STAGING.CDC_TARGETS` — ownership claims for destination tables
 
 These tables live in the connected Snowflake database (the catalog from the URI). Snowflake also supports CDC merge with unchanged-TOAST / `_cdc_unchanged_cols` preservation for Postgres `JSONB` and other TOASTed columns under `REPLICA IDENTITY DEFAULT`.
+
+## Tuning the write path
+
+When Snowflake is the destination, ingestr coalesces record batches into larger Parquet files, uploads them to the table's implicit stage, and loads them with `COPY INTO`. Two environment variables tune that path; neither is normally needed.
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `INGESTR_SNOWFLAKE_FILE_SIZE_MB` | `32` | Compressed size at which a worker closes the current file and uploads it. Larger files amortize the per-upload overhead; smaller ones lower memory use. `0` uploads one file per record batch. Values above `1024` are clamped. |
+| `INGESTR_SNOWFLAKE_PARQUET_CODEC` | `zstd` | Parquet compression codec. `snappy` and `gzip` are also accepted; anything else falls back to `zstd`. |
+
+Each worker buffers up to one file in memory, so peak usage scales with `--extract-parallelism` and, for multi-table ingestions, with the number of tables. ingestr tracks the combined buffer across all concurrent workers and closes files early once it exceeds roughly 256 MiB. That is a soft limit checked between record batches, not a hard cap, and it does not cover the extra copy the Snowflake driver makes while a file is uploading, so plan for roughly twice that figure. Lower `INGESTR_SNOWFLAKE_FILE_SIZE_MB` if memory is tight.

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -248,7 +248,7 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 
 	uploaded := make(chan string, parallelism*4)
 	var totalRows atomic.Int64
-	var totalFiles atomic.Int64
+	writerProps, arrowProps := snowflakeParquetWriterProperties()
 
 	var uploadWg sync.WaitGroup
 	for i := 0; i < parallelism; i++ {
@@ -258,11 +258,14 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 
 			w := &snowflakeFileUploader{
 				dest:        d,
+				rowsLoaded:  &totalRows,
 				ctx:         writeCtx,
 				stageName:   stageName,
 				loadID:      loadID,
 				workerID:    workerID,
 				targetBytes: targetFileBytes,
+				writerProps: writerProps,
+				arrowProps:  arrowProps,
 			}
 
 			flush := func() bool {
@@ -272,7 +275,6 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 					return false
 				}
 				if fileName != "" {
-					totalFiles.Add(1)
 					uploaded <- fileName
 				}
 				return true
@@ -286,7 +288,7 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 				select {
 				case result, ok = <-records:
 				default:
-					if w.pendingBytes() >= minAdaptiveFlushBytes && !flush() {
+					if !failed.Load() && w.pendingBytes() >= minAdaptiveFlushBytes && !flush() {
 						continue
 					}
 					result, ok = <-records
@@ -296,6 +298,9 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 				}
 
 				if result.Err != nil {
+					if result.Batch != nil {
+						result.Batch.Release()
+					}
 					fail(result.Err)
 					continue
 				}
@@ -309,6 +314,14 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 					continue
 				}
 
+				// A mid-stream schema change (e.g. a retargeting schema
+				// aligner) ends the current file rather than the whole write;
+				// COPY matches columns by name across files.
+				if w.schemaChanged(record.Schema()) && !flush() {
+					record.Release()
+					continue
+				}
+
 				rows := record.NumRows()
 				err := w.append(record)
 				record.Release()
@@ -316,14 +329,20 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 					fail(err)
 					continue
 				}
-				totalRows.Add(rows)
+				w.pendingRows += rows
 
-				if w.pendingBytes() >= w.targetBytes {
+				if w.shouldFlush() {
 					flush()
 				}
 			}
 
-			flush()
+			if !failed.Load() {
+				flush()
+			}
+			// Unconditional: a no-op after a clean flush, but the only thing
+			// that gives back the buffer this worker still holds if that final
+			// flush failed.
+			w.discard()
 		}(i)
 	}
 
@@ -334,12 +353,11 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 
 	// With overlapCopy each iteration loads whatever accumulated while the
 	// previous COPY ran; otherwise files collect for one final COPY.
-	var copyErr error
 	var copiedFiles int
 	var pending []string
 	for fileName := range uploaded {
 		pending = append(pending, fileName)
-		if !overlapCopy || copyErr != nil || failed.Load() {
+		if !overlapCopy || failed.Load() {
 			continue
 		}
 		// Drain whatever else is already uploaded before starting a COPY.
@@ -355,24 +373,40 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 				break drain
 			}
 		}
-		if err := d.copyFiles(ctx, fullTable, stageName, loadID, pending); err != nil {
-			copyErr = err
+		copied, err := d.copyFilesInBatches(writeCtx, fullTable, stageName, loadID, pending)
+		if err != nil {
 			fail(err)
 			continue
 		}
-		copiedFiles += len(pending)
-		pending = pending[:0]
+		copiedFiles += copied
+		pending = pending[copied:]
 	}
 
+	// firstErr is the earliest failure from either an uploader or a COPY, since
+	// the COPY loop reports through fail() too.
 	if firstErr != nil {
-		return fmt.Errorf("parallel upload failed: %w", firstErr)
+		return fmt.Errorf("snowflake parallel write failed: %w", firstErr)
 	}
 
 	if len(pending) > 0 {
-		if err := d.copyFiles(ctx, fullTable, stageName, loadID, pending); err != nil {
-			return fmt.Errorf("failed to COPY INTO: %w", err)
+		if overlapCopy {
+			// Unreachable today: the loop above truncates pending after every
+			// COPY and returns on error. Kept so a future change to that loop
+			// cannot silently drop files.
+			copied, err := d.copyFilesInBatches(writeCtx, fullTable, stageName, loadID, pending)
+			if err != nil {
+				return fmt.Errorf("snowflake parallel write failed: %w", err)
+			}
+			copiedFiles += copied
+		} else {
+			// A FILES clause accepts at most 1,000 names. Once every upload is
+			// complete, the unique load prefix selects the same files without
+			// that limit and keeps direct writes in a single COPY statement.
+			if err := d.copyFiles(ctx, fullTable, stageName, loadID, nil); err != nil {
+				return fmt.Errorf("snowflake parallel write failed: %w", err)
+			}
+			copiedFiles += len(pending)
 		}
-		copiedFiles += len(pending)
 	}
 
 	if copiedFiles == 0 {
@@ -381,7 +415,7 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 	}
 
 	elapsed := time.Since(startTotal)
-	config.Debug("[DEST] Total: %d rows in %d files written in %v (%.0f rows/sec)", totalRows.Load(), copiedFiles, elapsed, float64(totalRows.Load())/elapsed.Seconds())
+	config.Debug("[DEST] Total: %d rows in %d files staged and loaded in %v (%.0f rows/sec)", totalRows.Load(), copiedFiles, elapsed, float64(totalRows.Load())/elapsed.Seconds())
 	return nil
 }
 
@@ -395,26 +429,97 @@ type snowflakeFileUploader struct {
 	loadID      string
 	workerID    int
 	targetBytes int64
+	writerProps *parquet.WriterProperties
+	arrowProps  pqarrow.ArrowWriterProperties
+	rowsLoaded  *atomic.Int64
 
-	buf     *bytes.Buffer
-	writer  *pqarrow.FileWriter
-	fileNum int
+	buf            *bytes.Buffer
+	writer         *pqarrow.FileWriter
+	schema         *arrow.Schema
+	fileNum        int
+	pendingRows    int64
+	accountedBytes int64
+	lastFileBytes  int64
+}
+
+// bufferedBytes is the compressed parquet held across every uploader in the
+// process, kept current by account(). A multi-table write starts one
+// WriteParallel per table concurrently, so without a shared figure the size
+// target would apply tables * parallelism times over.
+var bufferedBytes atomic.Int64
+
+// uploaderBudgetBytes is the buffered total above which uploaders close their
+// files early. It only binds on wide multi-table loads: a single-table write
+// at the default 4-way parallelism stays well under it and keeps the full
+// size target.
+const uploaderBudgetBytes = 256 << 20
+
+// account brings bufferedBytes in step with this uploader's buffer. It has to
+// run after anything that changes the buffer, including dropping it.
+func (w *snowflakeFileUploader) account() {
+	pending := w.pendingBytes()
+	bufferedBytes.Add(pending - w.accountedBytes)
+	w.accountedBytes = pending
+}
+
+// shouldFlush reports whether the open file has served its purpose: it reached
+// the size target, or uploaders elsewhere in the process are collectively over
+// the budget and this one is holding enough to be worth closing. The budget
+// check is a soft ceiling — it can only act between record batches.
+func (w *snowflakeFileUploader) shouldFlush() bool {
+	pending := w.pendingBytes()
+	if pending >= w.targetBytes {
+		return true
+	}
+	return pending >= minAdaptiveFlushBytes && bufferedBytes.Load() >= uploaderBudgetBytes
+}
+
+// schemaChanged reports whether record can still go into the open file. A
+// pqarrow writer rejects records whose schema differs from the one it was
+// created with, so the caller has to close the file first and start a new one.
+func (w *snowflakeFileUploader) schemaChanged(schema *arrow.Schema) bool {
+	return w.writer != nil && !w.schema.Equal(schema)
 }
 
 func (w *snowflakeFileUploader) append(record arrow.RecordBatch) error {
 	if w.writer == nil {
-		w.buf = new(bytes.Buffer)
-		writerProps, arrowProps := snowflakeParquetWriterProperties()
-		writer, err := pqarrow.NewFileWriter(record.Schema(), w.buf, writerProps, arrowProps)
+		w.buf = bytes.NewBuffer(make([]byte, 0, w.initialBufBytes()))
+		writer, err := pqarrow.NewFileWriter(record.Schema(), w.buf, w.writerProps, w.arrowProps)
 		if err != nil {
 			return fmt.Errorf("failed to create parquet writer: %w", err)
 		}
 		w.writer = writer
+		w.schema = record.Schema()
 	}
 	if err := w.writer.Write(record); err != nil {
 		return fmt.Errorf("failed to write record to parquet: %w", err)
 	}
+	w.account()
 	return nil
+}
+
+// initialBufBytes sizes the new file's buffer from the previous file this
+// uploader produced, which is the only evidence available that the bytes will
+// actually be used. The first file preallocates nothing: most writes are far
+// smaller than the size target, and guessing from the target instead would
+// commit megabytes per uploader (times parallelism, times tables) before a
+// single row is known to exist.
+func (w *snowflakeFileUploader) initialBufBytes() int64 {
+	const maxPrealloc = 8 << 20
+	return min(w.lastFileBytes, maxPrealloc)
+}
+
+// discard throws away the open file without uploading it, for when the write
+// has already failed and nothing more should reach the stage.
+func (w *snowflakeFileUploader) discard() {
+	if w.writer != nil {
+		_ = w.writer.Close()
+		w.writer = nil
+	}
+	w.buf = nil
+	w.schema = nil
+	w.pendingRows = 0
+	w.account()
 }
 
 // pendingBytes is the compressed size written so far, excluding row-group
@@ -440,6 +545,7 @@ func (w *snowflakeFileUploader) flush() (string, error) {
 	fileName := fmt.Sprintf("batch_%d_%d.parquet", w.workerID, w.fileNum)
 	startPut := time.Now()
 	sizeBytes := w.buf.Len()
+	w.lastFileBytes = int64(sizeBytes)
 
 	// Acquire a connection from the shared pool for just this PUT, so it's
 	// released back to the pool immediately afterward instead of being held
@@ -459,6 +565,11 @@ func (w *snowflakeFileUploader) flush() (string, error) {
 		return "", fmt.Errorf("failed to PUT file to stage: %w", err)
 	}
 	w.buf = nil
+	w.account()
+	// Count rows only once they are on the stage, so the totals reported after
+	// a partial failure describe what actually got there.
+	w.rowsLoaded.Add(w.pendingRows)
+	w.pendingRows = 0
 
 	config.Debug("[DEST] Uploaded %s: %.1f MiB in %v", fileName, float64(sizeBytes)/(1<<20), time.Since(startPut))
 	return fileName, nil
@@ -471,8 +582,27 @@ func (d *SnowflakeDestination) copyFiles(ctx context.Context, fullTable, stageNa
 		config.LogFailedQuery(copySQL, err)
 		return fmt.Errorf("failed to COPY INTO: %w", err)
 	}
-	config.Debug("[DEST] COPY INTO of %d files completed in %v", len(files), time.Since(startCopy))
+	if len(files) == 0 {
+		config.Debug("[DEST] COPY INTO of the whole load prefix completed in %v", time.Since(startCopy))
+	} else {
+		config.Debug("[DEST] COPY INTO of %d files completed in %v", len(files), time.Since(startCopy))
+	}
 	return nil
+}
+
+const maxFilesPerCopy = 1000
+
+func (d *SnowflakeDestination) copyFilesInBatches(ctx context.Context, fullTable, stageName, loadID string, files []string) (int, error) {
+	copied := 0
+	for len(files) > 0 {
+		batchSize := min(len(files), maxFilesPerCopy)
+		if err := d.copyFiles(ctx, fullTable, stageName, loadID, files[:batchSize]); err != nil {
+			return copied, err
+		}
+		copied += batchSize
+		files = files[batchSize:]
+	}
+	return copied, nil
 }
 
 // minAdaptiveFlushBytes stops the adaptive flush from sharding the load into
@@ -483,12 +613,18 @@ const minAdaptiveFlushBytes = 1 << 20
 // the current file and PUTs it, amortizing the ~1s per-PUT overhead.
 // INGESTR_SNOWFLAKE_FILE_SIZE_MB overrides; 0 flushes one file per batch.
 func snowflakeTargetFileBytes() int64 {
-	if v := os.Getenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB"); v != "" {
-		if mb, err := strconv.Atoi(v); err == nil && mb >= 0 {
-			return int64(mb) << 20
-		}
+	const defaultMB, maxMB = 32, 1024
+	v := os.Getenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB")
+	if v == "" {
+		return defaultMB << 20
 	}
-	return 32 << 20
+	mb, err := strconv.Atoi(v)
+	if err != nil || mb < 0 {
+		config.Debug("[DEST] Invalid INGESTR_SNOWFLAKE_FILE_SIZE_MB %q, using %d MiB", v, defaultMB)
+		return defaultMB << 20
+	}
+	// Clamped so the shift below cannot overflow into a negative size.
+	return int64(min(mb, maxMB)) << 20
 }
 
 // Zstd default: roughly a third fewer bytes than snappy, directly cutting
@@ -501,6 +637,8 @@ func snowflakeParquetWriterProperties() (*parquet.WriterProperties, pqarrow.Arro
 	case "gzip":
 		codec = compress.Codecs.Gzip
 	case "zstd", "":
+	default:
+		config.Debug("[DEST] Unrecognized INGESTR_SNOWFLAKE_PARQUET_CODEC %q, using zstd", os.Getenv("INGESTR_SNOWFLAKE_PARQUET_CODEC"))
 	}
 	writerProps := parquet.NewWriterProperties(
 		parquet.WithCompression(codec),

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -212,9 +212,8 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 	}
 
 	targetFileBytes := snowflakeTargetFileBytes()
-	// Overlapping COPY INTO with uploads makes rows visible incrementally, so
-	// it is only safe when writing to a staging table that a later swap/merge
-	// publishes atomically. Direct writes keep the single all-or-nothing COPY.
+	// Incremental COPY makes rows visible before the write finishes, so it is
+	// only safe for staging tables published atomically by a later swap/merge.
 	overlapCopy := opts.StagingTable
 
 	config.Debug("[DEST] Starting parallel write with %d workers, target file size %d MiB, overlapped COPY=%v", parallelism, targetFileBytes>>20, overlapCopy)
@@ -282,10 +281,8 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 			for {
 				var result source.RecordBatchResult
 				var ok bool
-				// Adaptive flush: when the source has nothing ready right now,
-				// upload what's buffered instead of idling. On a fast source
-				// files grow to the size target; on a slow source or at the
-				// stream tail the pipeline keeps moving with smaller files.
+				// Adaptive flush: upload what's buffered instead of idling
+				// when the source has nothing ready.
 				select {
 				case result, ok = <-records:
 				default:
@@ -335,9 +332,8 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 		close(uploaded)
 	}()
 
-	// The copier drains uploaded file names. With overlapped COPY it issues
-	// COPY INTO for whatever accumulated while the previous COPY ran; otherwise
-	// it collects names for one final COPY after all uploads finish.
+	// With overlapCopy each iteration loads whatever accumulated while the
+	// previous COPY ran; otherwise files collect for one final COPY.
 	var copyErr error
 	var copiedFiles int
 	var pending []string
@@ -421,9 +417,8 @@ func (w *snowflakeFileUploader) append(record arrow.RecordBatch) error {
 	return nil
 }
 
-// pendingBytes is the compressed size written so far; row-group buffers not yet
-// flushed by the parquet writer are not counted, which is fine for a soft
-// file-size target.
+// pendingBytes is the compressed size written so far, excluding row-group
+// buffers the parquet writer has not flushed yet.
 func (w *snowflakeFileUploader) pendingBytes() int64 {
 	if w.buf == nil {
 		return 0
@@ -456,9 +451,8 @@ func (w *snowflakeFileUploader) flush() (string, error) {
 		RaisePutGetError: true,
 	})
 
-	// The local file name (not the stage path, which is a directory prefix)
-	// determines the staged object's name, so COPY's FILES list can reference
-	// it as <loadID>/<fileName>.
+	// The stage path is a directory prefix; the local file name names the
+	// staged object, which COPY's FILES list references as <loadID>/<fileName>.
 	putSQL := fmt.Sprintf("PUT file://%s @%s/%s AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=NONE OVERWRITE=TRUE", fileName, w.stageName, w.loadID)
 	if _, err := w.dest.db.ExecContext(uploadCtx, putSQL); err != nil {
 		config.LogFailedQuery(putSQL, err)
@@ -485,12 +479,9 @@ func (d *SnowflakeDestination) copyFiles(ctx context.Context, fullTable, stageNa
 // sub-megabyte files when the uploaders keep pace with the source.
 const minAdaptiveFlushBytes = 1 << 20
 
-// snowflakeTargetFileBytes is the compressed parquet size at which an uploader
-// closes the current file and PUTs it. Larger files amortize the per-PUT
-// overhead (about a second each); smaller files pipeline better on slow
-// uplinks. The adaptive flush already flushes early whenever the source runs
-// dry, so this is only the cap reached on fast sources. Tunable via
-// INGESTR_SNOWFLAKE_FILE_SIZE_MB; 0 flushes one file per record batch.
+// snowflakeTargetFileBytes is the compressed size at which an uploader closes
+// the current file and PUTs it, amortizing the ~1s per-PUT overhead.
+// INGESTR_SNOWFLAKE_FILE_SIZE_MB overrides; 0 flushes one file per batch.
 func snowflakeTargetFileBytes() int64 {
 	if v := os.Getenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB"); v != "" {
 		if mb, err := strconv.Atoi(v); err == nil && mb >= 0 {
@@ -500,9 +491,8 @@ func snowflakeTargetFileBytes() int64 {
 	return 32 << 20
 }
 
-// Zstd is the default codec: it produces roughly a third fewer bytes than
-// snappy on typical row data, which directly cuts PUT upload time, at an
-// encode cost that stays far from the bottleneck on the parallel write path.
+// Zstd default: roughly a third fewer bytes than snappy, directly cutting
+// upload time.
 func snowflakeParquetWriterProperties() (*parquet.WriterProperties, pqarrow.ArrowWriterProperties) {
 	codec := compress.Codecs.Zstd
 	switch strings.ToLower(os.Getenv("INGESTR_SNOWFLAKE_PARQUET_CODEC")) {
@@ -532,9 +522,8 @@ func buildCopyIntoSQL(fullTable, stageName, loadID string, files []string) strin
 		}
 		filesClause = fmt.Sprintf(" FILES = (%s)", strings.Join(quoted, ", "))
 	}
-	// The FROM location must end with '/': Snowflake appends FILES entries to
-	// the location verbatim, so without it the prefix and file name concatenate
-	// into a nonexistent path.
+	// The FROM location must end with '/': FILES entries are appended to it
+	// verbatim.
 	return fmt.Sprintf("COPY INTO %s FROM @%s/%s/%s FILE_FORMAT = (TYPE = PARQUET USE_LOGICAL_TYPE = TRUE) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE",
 		fullTable, stageName, loadID, filesClause)
 }

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/compress"
@@ -209,7 +211,13 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 		parallelism = 4
 	}
 
-	config.Debug("[DEST] Starting parallel write with %d workers using stage-based loading", parallelism)
+	targetFileBytes := snowflakeTargetFileBytes()
+	// Overlapping COPY INTO with uploads makes rows visible incrementally, so
+	// it is only safe when writing to a staging table that a later swap/merge
+	// publishes atomically. Direct writes keep the single all-or-nothing COPY.
+	overlapCopy := opts.StagingTable
+
+	config.Debug("[DEST] Starting parallel write with %d workers, target file size %d MiB, overlapped COPY=%v", parallelism, targetFileBytes>>20, overlapCopy)
 	startTotal := time.Now()
 
 	tn := sfTable(opts.Table)
@@ -225,147 +233,287 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 	stageName := fmt.Sprintf(`%s.%%%s`, stagePrefix, quoteIdentifier(tn.Table))
 	loadID := fmt.Sprintf("%d", time.Now().UnixNano())
 
-	type uploadResult struct {
-		batchNum int
-		rows     int64
-		fileName string
-		duration time.Duration
-		err      error
+	writeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var firstErr error
+	var errOnce sync.Once
+	var failed atomic.Bool
+	fail := func(err error) {
+		errOnce.Do(func() {
+			firstErr = err
+			failed.Store(true)
+			cancel()
+		})
 	}
 
-	// Phase 1: Upload all parquet files to stage in parallel
-	uploadResults := make(chan uploadResult, parallelism*2)
-	var uploadWg sync.WaitGroup
-	batchNum := int64(0)
+	uploaded := make(chan string, parallelism*4)
+	var totalRows atomic.Int64
+	var totalFiles atomic.Int64
 
+	var uploadWg sync.WaitGroup
 	for i := 0; i < parallelism; i++ {
 		uploadWg.Add(1)
 		go func(workerID int) {
 			defer uploadWg.Done()
 
-			for result := range records {
-				myBatch := int(atomic.AddInt64(&batchNum, 1))
+			w := &snowflakeFileUploader{
+				dest:        d,
+				ctx:         writeCtx,
+				stageName:   stageName,
+				loadID:      loadID,
+				workerID:    workerID,
+				targetBytes: targetFileBytes,
+			}
+
+			flush := func() bool {
+				fileName, err := w.flush()
+				if err != nil {
+					fail(err)
+					return false
+				}
+				if fileName != "" {
+					totalFiles.Add(1)
+					uploaded <- fileName
+				}
+				return true
+			}
+
+			for {
+				var result source.RecordBatchResult
+				var ok bool
+				// Adaptive flush: when the source has nothing ready right now,
+				// upload what's buffered instead of idling. On a fast source
+				// files grow to the size target; on a slow source or at the
+				// stream tail the pipeline keeps moving with smaller files.
+				select {
+				case result, ok = <-records:
+				default:
+					if w.pendingBytes() >= minAdaptiveFlushBytes && !flush() {
+						continue
+					}
+					result, ok = <-records
+				}
+				if !ok {
+					break
+				}
 
 				if result.Err != nil {
-					uploadResults <- uploadResult{batchNum: myBatch, err: result.Err}
-					return
+					fail(result.Err)
+					continue
 				}
 
 				record := result.Batch
 				if record == nil {
 					continue
 				}
-
-				numRows := record.NumRows()
-				if numRows == 0 {
+				if record.NumRows() == 0 || failed.Load() {
 					record.Release()
 					continue
 				}
 
-				startBatch := time.Now()
-
-				buf := new(bytes.Buffer)
-				writerProps, arrowProps := snowflakeParquetWriterProperties()
-				writer, err := pqarrow.NewFileWriter(record.Schema(), buf, writerProps, arrowProps)
-				if err != nil {
-					record.Release()
-					uploadResults <- uploadResult{batchNum: myBatch, err: fmt.Errorf("failed to create parquet writer: %w", err)}
-					return
-				}
-
-				if err := writer.Write(record); err != nil {
-					_ = writer.Close()
-					record.Release()
-					uploadResults <- uploadResult{batchNum: myBatch, err: fmt.Errorf("failed to write record to parquet: %w", err)}
-					return
-				}
-
-				if err := writer.Close(); err != nil {
-					record.Release()
-					uploadResults <- uploadResult{batchNum: myBatch, err: fmt.Errorf("failed to close parquet writer: %w", err)}
-					return
-				}
-
+				rows := record.NumRows()
+				err := w.append(record)
 				record.Release()
-
-				fileName := fmt.Sprintf("batch_%d_%d.parquet", workerID, myBatch)
-
-				// Acquire a connection from the shared pool for just this PUT, so
-				// it's released back to the pool immediately afterward instead of
-				// being held for the worker's entire lifetime. This lets the pool
-				// (bounded by SetMaxOpenConns) be shared safely across all tables
-				// in a multi-table write, regardless of numTables * parallelism.
-				uploadCtx := sf.WithFileStream(ctx, buf)
-				uploadCtx = sf.WithFileTransferOptions(uploadCtx, &sf.SnowflakeFileTransferOptions{
-					RaisePutGetError: true,
-				})
-
-				putSQL := fmt.Sprintf("PUT file://data.parquet @%s/%s/%s AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=NONE OVERWRITE=TRUE", stageName, loadID, fileName)
-				_, err = d.db.ExecContext(uploadCtx, putSQL)
 				if err != nil {
-					config.LogFailedQuery(putSQL, err)
-					uploadResults <- uploadResult{batchNum: myBatch, err: fmt.Errorf("failed to PUT file to stage: %w", err)}
-					return
+					fail(err)
+					continue
 				}
+				totalRows.Add(rows)
 
-				uploadResults <- uploadResult{
-					batchNum: myBatch,
-					rows:     numRows,
-					fileName: fileName,
-					duration: time.Since(startBatch),
+				if w.pendingBytes() >= w.targetBytes {
+					flush()
 				}
 			}
+
+			flush()
 		}(i)
 	}
 
 	go func() {
 		uploadWg.Wait()
-		close(uploadResults)
+		close(uploaded)
 	}()
 
-	// Collect upload results
-	var totalRows int64
-	var firstErr error
-	var uploadedFiles []string
-	for res := range uploadResults {
-		if res.err != nil && firstErr == nil {
-			firstErr = res.err
-			config.Debug("[DEST] Worker error on batch %d: %v", res.batchNum, res.err)
-		} else if res.err == nil && res.rows > 0 {
-			totalRows += res.rows
-			uploadedFiles = append(uploadedFiles, res.fileName)
-			config.Debug("[DEST] Batch %d uploaded: %d rows in %v (%.0f rows/sec)", res.batchNum, res.rows, res.duration, float64(res.rows)/res.duration.Seconds())
+	// The copier drains uploaded file names. With overlapped COPY it issues
+	// COPY INTO for whatever accumulated while the previous COPY ran; otherwise
+	// it collects names for one final COPY after all uploads finish.
+	var copyErr error
+	var copiedFiles int
+	var pending []string
+	for fileName := range uploaded {
+		pending = append(pending, fileName)
+		if !overlapCopy || copyErr != nil || failed.Load() {
+			continue
 		}
+		// Drain whatever else is already uploaded before starting a COPY.
+	drain:
+		for {
+			select {
+			case name, ok := <-uploaded:
+				if !ok {
+					break drain
+				}
+				pending = append(pending, name)
+			default:
+				break drain
+			}
+		}
+		if err := d.copyFiles(ctx, fullTable, stageName, loadID, pending); err != nil {
+			copyErr = err
+			fail(err)
+			continue
+		}
+		copiedFiles += len(pending)
+		pending = pending[:0]
 	}
 
 	if firstErr != nil {
 		return fmt.Errorf("parallel upload failed: %w", firstErr)
 	}
 
-	if len(uploadedFiles) == 0 {
+	if len(pending) > 0 {
+		if err := d.copyFiles(ctx, fullTable, stageName, loadID, pending); err != nil {
+			return fmt.Errorf("failed to COPY INTO: %w", err)
+		}
+		copiedFiles += len(pending)
+	}
+
+	if copiedFiles == 0 {
 		config.Debug("[DEST] No files to load")
 		return nil
 	}
 
-	// Phase 2: Single COPY INTO to load ALL files at once
-	config.Debug("[DEST] Loading %d files with single COPY INTO...", len(uploadedFiles))
+	elapsed := time.Since(startTotal)
+	config.Debug("[DEST] Total: %d rows in %d files written in %v (%.0f rows/sec)", totalRows.Load(), copiedFiles, elapsed, float64(totalRows.Load())/elapsed.Seconds())
+	return nil
+}
+
+// snowflakeFileUploader accumulates record batches into a single parquet file
+// until it crosses the compressed size target, then PUTs it to the stage. One
+// uploader is owned by one worker goroutine.
+type snowflakeFileUploader struct {
+	dest        *SnowflakeDestination
+	ctx         context.Context
+	stageName   string
+	loadID      string
+	workerID    int
+	targetBytes int64
+
+	buf     *bytes.Buffer
+	writer  *pqarrow.FileWriter
+	fileNum int
+}
+
+func (w *snowflakeFileUploader) append(record arrow.RecordBatch) error {
+	if w.writer == nil {
+		w.buf = new(bytes.Buffer)
+		writerProps, arrowProps := snowflakeParquetWriterProperties()
+		writer, err := pqarrow.NewFileWriter(record.Schema(), w.buf, writerProps, arrowProps)
+		if err != nil {
+			return fmt.Errorf("failed to create parquet writer: %w", err)
+		}
+		w.writer = writer
+	}
+	if err := w.writer.Write(record); err != nil {
+		return fmt.Errorf("failed to write record to parquet: %w", err)
+	}
+	return nil
+}
+
+// pendingBytes is the compressed size written so far; row-group buffers not yet
+// flushed by the parquet writer are not counted, which is fine for a soft
+// file-size target.
+func (w *snowflakeFileUploader) pendingBytes() int64 {
+	if w.buf == nil {
+		return 0
+	}
+	return int64(w.buf.Len())
+}
+
+func (w *snowflakeFileUploader) flush() (string, error) {
+	if w.writer == nil {
+		return "", nil
+	}
+	if err := w.writer.Close(); err != nil {
+		w.writer = nil
+		return "", fmt.Errorf("failed to close parquet writer: %w", err)
+	}
+	w.writer = nil
+
+	w.fileNum++
+	fileName := fmt.Sprintf("batch_%d_%d.parquet", w.workerID, w.fileNum)
+	startPut := time.Now()
+	sizeBytes := w.buf.Len()
+
+	// Acquire a connection from the shared pool for just this PUT, so it's
+	// released back to the pool immediately afterward instead of being held
+	// for the worker's entire lifetime. This lets the pool (bounded by
+	// SetMaxOpenConns) be shared safely across all tables in a multi-table
+	// write, regardless of numTables * parallelism.
+	uploadCtx := sf.WithFileStream(w.ctx, w.buf)
+	uploadCtx = sf.WithFileTransferOptions(uploadCtx, &sf.SnowflakeFileTransferOptions{
+		RaisePutGetError: true,
+	})
+
+	// The local file name (not the stage path, which is a directory prefix)
+	// determines the staged object's name, so COPY's FILES list can reference
+	// it as <loadID>/<fileName>.
+	putSQL := fmt.Sprintf("PUT file://%s @%s/%s AUTO_COMPRESS=FALSE SOURCE_COMPRESSION=NONE OVERWRITE=TRUE", fileName, w.stageName, w.loadID)
+	if _, err := w.dest.db.ExecContext(uploadCtx, putSQL); err != nil {
+		config.LogFailedQuery(putSQL, err)
+		return "", fmt.Errorf("failed to PUT file to stage: %w", err)
+	}
+	w.buf = nil
+
+	config.Debug("[DEST] Uploaded %s: %.1f MiB in %v", fileName, float64(sizeBytes)/(1<<20), time.Since(startPut))
+	return fileName, nil
+}
+
+func (d *SnowflakeDestination) copyFiles(ctx context.Context, fullTable, stageName, loadID string, files []string) error {
 	startCopy := time.Now()
-
-	copySQL := buildCopyIntoSQL(fullTable, stageName, loadID)
-
+	copySQL := buildCopyIntoSQL(fullTable, stageName, loadID, files)
 	if _, err := d.db.ExecContext(ctx, copySQL); err != nil {
 		config.LogFailedQuery(copySQL, err)
 		return fmt.Errorf("failed to COPY INTO: %w", err)
 	}
-
-	config.Debug("[DEST] COPY INTO completed in %v", time.Since(startCopy))
-	config.Debug("[DEST] Total: %d rows written in %v (%.0f rows/sec)", totalRows, time.Since(startTotal), float64(totalRows)/time.Since(startTotal).Seconds())
+	config.Debug("[DEST] COPY INTO of %d files completed in %v", len(files), time.Since(startCopy))
 	return nil
 }
 
+// minAdaptiveFlushBytes stops the adaptive flush from sharding the load into
+// sub-megabyte files when the uploaders keep pace with the source.
+const minAdaptiveFlushBytes = 1 << 20
+
+// snowflakeTargetFileBytes is the compressed parquet size at which an uploader
+// closes the current file and PUTs it. Larger files amortize the per-PUT
+// overhead (about a second each); smaller files pipeline better on slow
+// uplinks. The adaptive flush already flushes early whenever the source runs
+// dry, so this is only the cap reached on fast sources. Tunable via
+// INGESTR_SNOWFLAKE_FILE_SIZE_MB; 0 flushes one file per record batch.
+func snowflakeTargetFileBytes() int64 {
+	if v := os.Getenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB"); v != "" {
+		if mb, err := strconv.Atoi(v); err == nil && mb >= 0 {
+			return int64(mb) << 20
+		}
+	}
+	return 32 << 20
+}
+
+// Zstd is the default codec: it produces roughly a third fewer bytes than
+// snappy on typical row data, which directly cuts PUT upload time, at an
+// encode cost that stays far from the bottleneck on the parallel write path.
 func snowflakeParquetWriterProperties() (*parquet.WriterProperties, pqarrow.ArrowWriterProperties) {
+	codec := compress.Codecs.Zstd
+	switch strings.ToLower(os.Getenv("INGESTR_SNOWFLAKE_PARQUET_CODEC")) {
+	case "snappy":
+		codec = compress.Codecs.Snappy
+	case "gzip":
+		codec = compress.Codecs.Gzip
+	case "zstd", "":
+	}
 	writerProps := parquet.NewWriterProperties(
-		parquet.WithCompression(compress.Codecs.Snappy),
+		parquet.WithCompression(codec),
 		parquet.WithBatchSize(64*1024),
 	)
 	arrowProps := pqarrow.NewArrowWriterProperties(
@@ -375,9 +523,20 @@ func snowflakeParquetWriterProperties() (*parquet.WriterProperties, pqarrow.Arro
 	return writerProps, arrowProps
 }
 
-func buildCopyIntoSQL(fullTable, stageName, loadID string) string {
-	return fmt.Sprintf("COPY INTO %s FROM @%s/%s FILE_FORMAT = (TYPE = PARQUET USE_LOGICAL_TYPE = TRUE) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE",
-		fullTable, stageName, loadID)
+func buildCopyIntoSQL(fullTable, stageName, loadID string, files []string) string {
+	var filesClause string
+	if len(files) > 0 {
+		quoted := make([]string, len(files))
+		for i, f := range files {
+			quoted[i] = "'" + strings.ReplaceAll(f, "'", "''") + "'"
+		}
+		filesClause = fmt.Sprintf(" FILES = (%s)", strings.Join(quoted, ", "))
+	}
+	// The FROM location must end with '/': Snowflake appends FILES entries to
+	// the location verbatim, so without it the prefix and file name concatenate
+	// into a nonexistent path.
+	return fmt.Sprintf("COPY INTO %s FROM @%s/%s/%s FILE_FORMAT = (TYPE = PARQUET USE_LOGICAL_TYPE = TRUE) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE",
+		fullTable, stageName, loadID, filesClause)
 }
 
 func (d *SnowflakeDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {

--- a/pkg/destination/snowflake/snowflake.go
+++ b/pkg/destination/snowflake/snowflake.go
@@ -267,6 +267,7 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 				writerProps: writerProps,
 				arrowProps:  arrowProps,
 			}
+			defer w.discard()
 
 			flush := func() bool {
 				fileName, err := w.flush()
@@ -275,23 +276,36 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 					return false
 				}
 				if fileName != "" {
-					uploaded <- fileName
+					select {
+					case uploaded <- fileName:
+					case <-writeCtx.Done():
+						return false
+					}
 				}
 				return true
 			}
 
 			for {
+				if writeCtx.Err() != nil {
+					return
+				}
 				var result source.RecordBatchResult
 				var ok bool
 				// Adaptive flush: upload what's buffered instead of idling
 				// when the source has nothing ready.
 				select {
+				case <-writeCtx.Done():
+					return
 				case result, ok = <-records:
 				default:
-					if !failed.Load() && w.pendingBytes() >= minAdaptiveFlushBytes && !flush() {
-						continue
+					if w.pendingBytes() >= minAdaptiveFlushBytes && !flush() {
+						return
 					}
-					result, ok = <-records
+					select {
+					case <-writeCtx.Done():
+						return
+					case result, ok = <-records:
+					}
 				}
 				if !ok {
 					break
@@ -302,14 +316,14 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 						result.Batch.Release()
 					}
 					fail(result.Err)
-					continue
+					return
 				}
 
 				record := result.Batch
 				if record == nil {
 					continue
 				}
-				if record.NumRows() == 0 || failed.Load() {
+				if record.NumRows() == 0 || writeCtx.Err() != nil {
 					record.Release()
 					continue
 				}
@@ -319,7 +333,7 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 				// COPY matches columns by name across files.
 				if w.schemaChanged(record.Schema()) && !flush() {
 					record.Release()
-					continue
+					return
 				}
 
 				rows := record.NumRows()
@@ -327,22 +341,18 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 				record.Release()
 				if err != nil {
 					fail(err)
-					continue
+					return
 				}
 				w.pendingRows += rows
 
-				if w.shouldFlush() {
-					flush()
+				if w.shouldFlush() && !flush() {
+					return
 				}
 			}
 
-			if !failed.Load() {
+			if writeCtx.Err() == nil {
 				flush()
 			}
-			// Unconditional: a no-op after a clean flush, but the only thing
-			// that gives back the buffer this worker still holds if that final
-			// flush failed.
-			w.discard()
 		}(i)
 	}
 
@@ -386,6 +396,9 @@ func (d *SnowflakeDestination) WriteParallel(ctx context.Context, records <-chan
 	// the COPY loop reports through fail() too.
 	if firstErr != nil {
 		return fmt.Errorf("snowflake parallel write failed: %w", firstErr)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("snowflake parallel write failed: %w", err)
 	}
 
 	if len(pending) > 0 {

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"regexp"
 	"strings"
 	"sync"
@@ -700,6 +701,69 @@ func TestWriteParallelRollsOverFileOnSchemaChange(t *testing.T) {
 	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatchWithColumns(mem, "id")}
 	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatchWithColumns(mem, "id", "extra")}
 	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	require.NoError(t, dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:       "public.events",
+		Parallelism: 1,
+	}))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func newIncompressibleRecordBatch(mem memory.Allocator, totalBytes int) arrow.RecordBatch {
+	arrowSchema := arrow.NewSchema([]arrow.Field{
+		{Name: "payload", Type: arrow.BinaryTypes.Binary},
+	}, nil)
+	builder := array.NewRecordBuilder(mem, arrowSchema)
+	defer builder.Release()
+	rng := rand.New(rand.NewPCG(1, 2))
+	const rowBytes = 64 << 10
+	for written := 0; written < totalBytes; written += rowBytes {
+		payload := make([]byte, rowBytes)
+		for i := range payload {
+			payload[i] = byte(rng.Uint32())
+		}
+		builder.Field(0).(*array.BinaryBuilder).Append(payload)
+	}
+	return builder.NewRecordBatch()
+}
+
+// When the source stalls, an uploader holding at least minAdaptiveFlushBytes
+// uploads what it has instead of idling until the size target is reached. The
+// second batch is only sent after the first PUT is observed, so the test
+// deadlocks (and times out) if the adaptive flush does not fire.
+func TestWriteParallelAdaptiveFlushUploadsWhileSourceIsIdle(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	firstPut := make(chan struct{})
+	var signalOnce sync.Once
+	capture := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		if strings.HasPrefix(actualSQL, "PUT ") {
+			signalOnce.Do(func() { close(firstPut) })
+		}
+		return sqlmock.QueryMatcherRegexp.Match(expectedSQL, actualSQL)
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(capture))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("PUT file://batch_0_1.parquet").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("PUT file://batch_0_2.parquet").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("COPY INTO").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	records := make(chan source.RecordBatchResult)
+	go func() {
+		defer close(records)
+		records <- source.RecordBatchResult{Batch: newIncompressibleRecordBatch(mem, 2*minAdaptiveFlushBytes)}
+		select {
+		case <-firstPut:
+		case <-time.After(10 * time.Second):
+			t.Error("uploader did not flush while the source was idle")
+			return
+		}
+		records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	}()
 
 	dest := &SnowflakeDestination{db: db}
 	require.NoError(t, dest.WriteParallel(t.Context(), records, destination.WriteOptions{

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -773,11 +773,8 @@ func TestWriteParallelAdaptiveFlushUploadsWhileSourceIsIdle(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-// A failed PUT has to abort the whole write: the error is returned, the
-// batches still queued behind it are drained and released rather than leaked,
-// and nothing further reaches Snowflake -- in particular no COPY, which would
-// publish a partial load. The write context is cancelled on failure, so later
-// statements are rejected before they get as far as the driver.
+// A failed PUT aborts the write and leaves queued batches for the caller's
+// cancellation and drain path. No COPY may publish the partial load.
 func TestWriteParallelAbortsOnUploadFailure(t *testing.T) {
 	t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", "0") // one PUT per batch
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
@@ -808,6 +805,11 @@ func TestWriteParallelAbortsOnUploadFailure(t *testing.T) {
 
 	const batches = 8
 	records := make(chan source.RecordBatchResult, batches)
+	defer func() {
+		for result := range records {
+			result.Batch.Release()
+		}
+	}()
 	for i := 0; i < batches; i++ {
 		records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
 	}
@@ -821,6 +823,7 @@ func TestWriteParallelAbortsOnUploadFailure(t *testing.T) {
 	})
 	require.ErrorIs(t, err, putErr)
 	assert.Contains(t, err.Error(), "snowflake parallel write failed")
+	assert.Len(t, records, batches-1, "failed workers must leave remaining records for the caller")
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -829,6 +832,118 @@ func TestWriteParallelAbortsOnUploadFailure(t *testing.T) {
 	}
 	assert.Len(t, statements, 1, "no further statements after the failing PUT: %v", statements)
 	assert.Zero(t, bufferedBytes.Load(), "a failed write must give back its buffer budget")
+}
+
+func TestWriteParallelReturnsOnFailureWhileSourceIsOpen(t *testing.T) {
+	for _, parallelism := range []int{1, 4} {
+		for _, tc := range []struct {
+			name       string
+			query      string
+			fileSizeMB string
+			batchBytes int
+		}{
+			{name: "PUT", query: "PUT", fileSizeMB: "0"},
+			{name: "adaptive PUT", query: "PUT", fileSizeMB: "32", batchBytes: 2 * minAdaptiveFlushBytes},
+			{name: "COPY", query: "COPY INTO", fileSizeMB: "0"},
+			{name: "source", fileSizeMB: "0"},
+		} {
+			t.Run(fmt.Sprintf("%s/workers=%d", tc.name, parallelism), func(t *testing.T) {
+				t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", tc.fileSizeMB)
+				mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+				defer mem.AssertSize(t, 0)
+
+				db, mock, err := sqlmock.New()
+				require.NoError(t, err)
+				defer func() { _ = db.Close() }()
+
+				wantErr := errors.New("write failed")
+				if tc.query == "COPY INTO" {
+					mock.ExpectExec("PUT").WillReturnResult(sqlmock.NewResult(0, 0))
+				}
+				if tc.query != "" {
+					mock.ExpectExec(tc.query).WillReturnError(wantErr)
+				}
+
+				var batch arrow.RecordBatch
+				if tc.batchBytes > 0 {
+					batch = newIncompressibleRecordBatch(mem, tc.batchBytes)
+				} else {
+					batch = newSingleRowRecordBatch(mem)
+				}
+				result := source.RecordBatchResult{Batch: batch}
+				if tc.query == "" {
+					result.Err = wantErr
+				}
+				records := make(chan source.RecordBatchResult, 1)
+				records <- result
+
+				done := make(chan struct{})
+				var writeErr error
+				go func() {
+					dest := &SnowflakeDestination{db: db}
+					writeErr = dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+						Table:        "public.events",
+						Parallelism:  parallelism,
+						StagingTable: true,
+					})
+					close(done)
+				}()
+				defer func() {
+					close(records)
+					<-done
+					for result := range records {
+						if result.Batch != nil {
+							result.Batch.Release()
+						}
+					}
+				}()
+
+				select {
+				case <-done:
+					require.ErrorIs(t, writeErr, wantErr)
+				case <-time.After(5 * time.Second):
+					t.Fatal("WriteParallel waited for source EOF after a failure")
+				}
+				assert.Zero(t, bufferedBytes.Load(), "failed workers must release their buffer budget")
+				require.NoError(t, mock.ExpectationsWereMet())
+			})
+		}
+	}
+}
+
+func TestWriteParallelReturnsOnCancellationWhileSourceIsOpen(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	records := make(chan source.RecordBatchResult)
+	done := make(chan struct{})
+	var writeErr error
+	go func() {
+		dest := &SnowflakeDestination{}
+		writeErr = dest.WriteParallel(ctx, records, destination.WriteOptions{
+			Table:       "public.events",
+			Parallelism: 4,
+		})
+		close(done)
+	}()
+	defer func() {
+		close(records)
+		<-done
+	}()
+
+	select {
+	case records <- source.RecordBatchResult{}:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WriteParallel did not start consuming records")
+	}
+	cancel()
+
+	select {
+	case <-done:
+		require.ErrorIs(t, writeErr, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WriteParallel waited for source EOF after cancellation")
+	}
 }
 
 func TestWriteParallelCancelsOverlappedCopyOnUploadFailure(t *testing.T) {
@@ -1040,6 +1155,11 @@ func TestWriteParallelReturnsSourceError(t *testing.T) {
 
 	sourceErr := errors.New("source read failed")
 	records := make(chan source.RecordBatchResult, 3)
+	defer func() {
+		for result := range records {
+			result.Batch.Release()
+		}
+	}()
 	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem), Err: sourceErr}
 	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
 	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
@@ -1052,6 +1172,7 @@ func TestWriteParallelReturnsSourceError(t *testing.T) {
 		StagingTable: true,
 	})
 	require.ErrorIs(t, err, sourceErr)
+	assert.Len(t, records, 2, "failed workers must leave remaining records for the caller")
 }
 
 // With StagingTable set, COPY runs while uploads are still going, naming the

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,6 +17,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	pqgo "github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/compress"
 	pqfile "github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	pqschema "github.com/apache/arrow-go/v18/parquet/schema"
@@ -303,6 +308,36 @@ func TestBuildCopyIntoSQLWithFilesList(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestCopyFilesInBatchesCapsFilesClause(t *testing.T) {
+	var executed []string
+	capture := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		executed = append(executed, actualSQL)
+		return nil
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(capture))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("COPY INTO").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("COPY INTO").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	files := make([]string, maxFilesPerCopy+1)
+	for i := range files {
+		files[i] = fmt.Sprintf("batch_%d.parquet", i)
+	}
+
+	dest := &SnowflakeDestination{db: db}
+	copied, err := dest.copyFilesInBatches(t.Context(), `"PUBLIC"."EVENTS"`, `"PUBLIC".%"EVENTS"`, "123456789", files)
+	require.NoError(t, err)
+	assert.Equal(t, len(files), copied)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	// Snowflake rejects a FILES clause with more than maxFilesPerCopy names.
+	require.Len(t, executed, 2)
+	assert.Equal(t, maxFilesPerCopy, strings.Count(executed[0], ".parquet'"))
+	assert.Equal(t, 1, strings.Count(executed[1], ".parquet'"))
+}
+
 func TestSnowflakeParquetWriterTimestampLogicalTypes(t *testing.T) {
 	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
 	defer mem.AssertSize(t, 0)
@@ -343,6 +378,135 @@ func TestSnowflakeParquetWriterTimestampLogicalTypes(t *testing.T) {
 	require.True(t, ok, "synced_at logical type = %T", syncedAt.LogicalType())
 	assert.Equal(t, pqschema.TimeUnitMicros, syncedAtLogical.TimeUnit())
 	assert.True(t, syncedAtLogical.IsAdjustedToUTC())
+}
+
+// The staged files are only useful if Snowflake can decode them, so assert the
+// codec that actually lands in the footer and read a value back through it.
+func TestSnowflakeParquetWriterCodec(t *testing.T) {
+	roundTrip := func(t *testing.T) compress.Compression {
+		t.Helper()
+		mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+		defer mem.AssertSize(t, 0)
+
+		builder := array.NewRecordBuilder(mem, arrow.NewSchema([]arrow.Field{
+			{Name: "id", Type: arrow.PrimitiveTypes.Int64},
+		}, nil))
+		builder.Field(0).(*array.Int64Builder).Append(4242)
+		record := builder.NewRecordBatch()
+		builder.Release()
+		defer record.Release()
+
+		var buf bytes.Buffer
+		writerProps, arrowProps := snowflakeParquetWriterProperties()
+		writer, err := pqarrow.NewFileWriter(record.Schema(), &buf, writerProps, arrowProps)
+		require.NoError(t, err)
+		require.NoError(t, writer.Write(record))
+		require.NoError(t, writer.Close())
+
+		reader, err := pqfile.NewParquetReader(bytes.NewReader(buf.Bytes()))
+		require.NoError(t, err)
+		defer func() { _ = reader.Close() }()
+
+		chunk, err := reader.MetaData().RowGroup(0).ColumnChunk(0)
+		require.NoError(t, err)
+
+		col, err := reader.RowGroup(0).Column(0)
+		require.NoError(t, err)
+		values := make([]int64, 1)
+		read, _, err := col.(*pqfile.Int64ColumnChunkReader).ReadBatch(1, values, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), read)
+		assert.Equal(t, int64(4242), values[0], "value must survive the round trip")
+
+		return chunk.Compression()
+	}
+
+	t.Run("default is zstd", func(t *testing.T) {
+		assert.Equal(t, compress.Codecs.Zstd, roundTrip(t))
+	})
+
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("INGESTR_SNOWFLAKE_PARQUET_CODEC", "SNAPPY")
+		assert.Equal(t, compress.Codecs.Snappy, roundTrip(t))
+	})
+
+	t.Run("unrecognized override falls back to zstd", func(t *testing.T) {
+		t.Setenv("INGESTR_SNOWFLAKE_PARQUET_CODEC", "lz4")
+		assert.Equal(t, compress.Codecs.Zstd, roundTrip(t))
+	})
+}
+
+func TestSnowflakeTargetFileBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int64
+	}{
+		{name: "unset", env: "", want: 32 << 20},
+		{name: "override", env: "8", want: 8 << 20},
+		{name: "zero flushes per batch", env: "0", want: 0},
+		{name: "negative falls back", env: "-1", want: 32 << 20},
+		{name: "unparseable falls back", env: "big", want: 32 << 20},
+		// Without the clamp the shift overflows to a negative size, which
+		// panics the buffer preallocation.
+		{name: "absurd value is clamped", env: "999999999999999", want: 1024 << 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", tt.env)
+			assert.Equal(t, tt.want, snowflakeTargetFileBytes())
+		})
+	}
+}
+
+// A multi-table write runs one WriteParallel per table concurrently, so files
+// have to close early once those uploaders collectively hold more than the
+// shared budget -- but only for uploaders actually holding something, or the
+// wide loads the budget exists for would be pushed into tiny files.
+func TestUploaderShouldFlush(t *testing.T) {
+	withBufferedBytes := func(t *testing.T, n int64) {
+		t.Helper()
+		bufferedBytes.Store(n)
+		t.Cleanup(func() { bufferedBytes.Store(0) })
+	}
+	buffered := func(n int) *bytes.Buffer { return bytes.NewBuffer(make([]byte, n)) }
+
+	t.Run("under the target and under budget", func(t *testing.T) {
+		withBufferedBytes(t, 0)
+		w := &snowflakeFileUploader{targetBytes: 32 << 20, buf: buffered(4 << 20)}
+		assert.False(t, w.shouldFlush())
+	})
+
+	t.Run("at the target", func(t *testing.T) {
+		withBufferedBytes(t, 0)
+		w := &snowflakeFileUploader{targetBytes: 32 << 20, buf: buffered(32 << 20)}
+		assert.True(t, w.shouldFlush())
+	})
+
+	t.Run("over budget closes early", func(t *testing.T) {
+		withBufferedBytes(t, uploaderBudgetBytes)
+		w := &snowflakeFileUploader{targetBytes: 32 << 20, buf: buffered(4 << 20)}
+		assert.True(t, w.shouldFlush())
+	})
+
+	t.Run("over budget still respects the adaptive floor", func(t *testing.T) {
+		withBufferedBytes(t, uploaderBudgetBytes)
+		w := &snowflakeFileUploader{targetBytes: 32 << 20, buf: buffered(minAdaptiveFlushBytes - 1)}
+		assert.False(t, w.shouldFlush(), "an idle uploader must not be pushed into sub-MiB files")
+	})
+
+	t.Run("idle uploader holds nothing", func(t *testing.T) {
+		withBufferedBytes(t, uploaderBudgetBytes)
+		w := &snowflakeFileUploader{targetBytes: 32 << 20}
+		assert.False(t, w.shouldFlush())
+	})
+
+	t.Run("zero target flushes every batch", func(t *testing.T) {
+		withBufferedBytes(t, 0)
+		w := &snowflakeFileUploader{targetBytes: 0}
+		assert.True(t, w.shouldFlush())
+	})
 }
 
 func TestGetTableSchemaPreservesSnowflakeTypeMetadata(t *testing.T) {
@@ -471,14 +635,433 @@ func TestMapDataTypeToSnowflake(t *testing.T) {
 	}
 }
 
-func newSingleRowRecordBatch() arrow.RecordBatch {
+func newSingleRowRecordBatch(mem memory.Allocator) arrow.RecordBatch {
 	arrowSchema := arrow.NewSchema([]arrow.Field{
 		{Name: "id", Type: arrow.PrimitiveTypes.Int64},
 	}, nil)
-	builder := array.NewRecordBuilder(memory.DefaultAllocator, arrowSchema)
+	builder := array.NewRecordBuilder(mem, arrowSchema)
 	defer builder.Release()
 	builder.Field(0).(*array.Int64Builder).Append(1)
 	return builder.NewRecordBatch()
+}
+
+func TestWriteParallelNonStagingCopiesByPrefix(t *testing.T) {
+	t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", "0")
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("PUT file://batch_").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`COPY INTO .* FROM .*/ FILE_FORMAT =`).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	require.NoError(t, dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:       "public.events",
+		Parallelism: 1,
+	}))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func newSingleRowRecordBatchWithColumns(mem memory.Allocator, names ...string) arrow.RecordBatch {
+	fields := make([]arrow.Field, len(names))
+	for i, name := range names {
+		fields[i] = arrow.Field{Name: name, Type: arrow.PrimitiveTypes.Int64}
+	}
+	builder := array.NewRecordBuilder(mem, arrow.NewSchema(fields, nil))
+	defer builder.Release()
+	for i := range names {
+		builder.Field(i).(*array.Int64Builder).Append(int64(i))
+	}
+	return builder.NewRecordBatch()
+}
+
+// A retargeting schema aligner can change the Arrow schema mid-stream. The
+// parquet writer rejects a record whose schema differs from the one it was
+// created with, so the uploader has to roll over to a new file instead of
+// failing the whole write.
+func TestWriteParallelRollsOverFileOnSchemaChange(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectExec("PUT file://batch_").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("PUT file://batch_").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("COPY INTO").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatchWithColumns(mem, "id")}
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatchWithColumns(mem, "id", "extra")}
+	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	require.NoError(t, dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:       "public.events",
+		Parallelism: 1,
+	}))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A failed PUT has to abort the whole write: the error is returned, the
+// batches still queued behind it are drained and released rather than leaked,
+// and nothing further reaches Snowflake -- in particular no COPY, which would
+// publish a partial load. The write context is cancelled on failure, so later
+// statements are rejected before they get as far as the driver.
+func TestWriteParallelAbortsOnUploadFailure(t *testing.T) {
+	t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", "0") // one PUT per batch
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	var mu sync.Mutex
+	statements := map[string]bool{}
+	capture := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		statements[actualSQL] = true
+		return nil
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(capture))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	putErr := errors.New("stage is full")
+	mock.ExpectExec("PUT").WillReturnError(putErr)
+	// sqlmock stops consulting the matcher once every expectation is
+	// fulfilled, so leave surplus ones: without them a statement issued after
+	// the failure would never be recorded and the assertions below could not
+	// fail.
+	mock.MatchExpectationsInOrder(false)
+	for i := 0; i < 4; i++ {
+		mock.ExpectExec("").WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+
+	const batches = 8
+	records := make(chan source.RecordBatchResult, batches)
+	for i := 0; i < batches; i++ {
+		records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	}
+	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	err = dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:        "public.events",
+		Parallelism:  1,
+		StagingTable: true,
+	})
+	require.ErrorIs(t, err, putErr)
+	assert.Contains(t, err.Error(), "snowflake parallel write failed")
+
+	mu.Lock()
+	defer mu.Unlock()
+	for stmt := range statements {
+		assert.NotContains(t, stmt, "COPY INTO", "no COPY may run after the write failed")
+	}
+	assert.Len(t, statements, 1, "no further statements after the failing PUT: %v", statements)
+	assert.Zero(t, bufferedBytes.Load(), "a failed write must give back its buffer budget")
+}
+
+func TestWriteParallelCancelsOverlappedCopyOnUploadFailure(t *testing.T) {
+	t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", "0")
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	mock.MatchExpectationsInOrder(false)
+
+	putErr := errors.New("stage is full")
+	mock.ExpectExec("PUT").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("PUT").WillDelayFor(100 * time.Millisecond).WillReturnError(putErr)
+	mock.ExpectExec("COPY INTO").WillDelayFor(5 * time.Second).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	start := time.Now()
+	err = dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:        "public.events",
+		Parallelism:  2,
+		StagingTable: true,
+	})
+	require.ErrorIs(t, err, putErr)
+	assert.Less(t, time.Since(start), time.Second, "upload failure should cancel the in-flight COPY")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The schema-change roll-over flushes mid-stream, so a PUT can fail while the
+// triggering record is still held. It has to be released like every other
+// batch, and the write has to abort.
+func TestWriteParallelAbortsWhenSchemaChangeFlushFails(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	putErr := errors.New("stage is full")
+	mock.ExpectExec("PUT").WillReturnError(putErr)
+
+	// Left at the default file size target so the only flush is the one the
+	// schema change forces.
+	records := make(chan source.RecordBatchResult, 2)
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatchWithColumns(mem, "id")}
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatchWithColumns(mem, "id", "extra")}
+	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	err = dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:        "public.events",
+		Parallelism:  1,
+		StagingTable: true,
+	})
+	require.ErrorIs(t, err, putErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The shared budget is only meaningful if every uploader keeps bufferedBytes
+// in step with its own buffer, including when the buffer goes away.
+func TestUploaderAccountsBufferedBytes(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	require.Zero(t, bufferedBytes.Load(), "another test leaked buffered bytes")
+	t.Cleanup(func() { bufferedBytes.Store(0) })
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	mock.ExpectExec("PUT").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	var rows atomic.Int64
+	writerProps, arrowProps := snowflakeParquetWriterProperties()
+	newUploader := func() *snowflakeFileUploader {
+		return &snowflakeFileUploader{
+			dest:        &SnowflakeDestination{db: db},
+			ctx:         t.Context(),
+			stageName:   `"PUBLIC".%"EVENTS"`,
+			loadID:      "123456789",
+			targetBytes: 32 << 20,
+			writerProps: writerProps,
+			arrowProps:  arrowProps,
+			rowsLoaded:  &rows,
+		}
+	}
+
+	appendOne := func(w *snowflakeFileUploader) {
+		t.Helper()
+		record := newSingleRowRecordBatch(mem)
+		require.NoError(t, w.append(record))
+		record.Release()
+	}
+
+	uploaded := newUploader()
+	appendOne(uploaded)
+	require.Positive(t, bufferedBytes.Load())
+	assert.Equal(t, uploaded.pendingBytes(), bufferedBytes.Load())
+
+	// A second uploader's bytes add to the same total, the way concurrent
+	// per-table writes do.
+	discarded := newUploader()
+	appendOne(discarded)
+	assert.Equal(t, uploaded.pendingBytes()+discarded.pendingBytes(), bufferedBytes.Load())
+
+	_, err = uploaded.flush()
+	require.NoError(t, err)
+	assert.Equal(t, discarded.pendingBytes(), bufferedBytes.Load(), "a flushed file releases its share")
+
+	discarded.discard()
+	assert.Zero(t, bufferedBytes.Load(), "a discarded file releases its share")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// discard drops the open file instead of uploading it, so a worker that gives
+// up after a failure cannot leave a partial file on the stage.
+func TestUploaderDiscardDropsOpenFileWithoutUploading(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var rows atomic.Int64
+	writerProps, arrowProps := snowflakeParquetWriterProperties()
+	w := &snowflakeFileUploader{
+		dest:        &SnowflakeDestination{db: db},
+		ctx:         t.Context(),
+		stageName:   `"PUBLIC".%"EVENTS"`,
+		loadID:      "123456789",
+		targetBytes: 32 << 20,
+		writerProps: writerProps,
+		arrowProps:  arrowProps,
+		rowsLoaded:  &rows,
+	}
+
+	record := newSingleRowRecordBatch(mem)
+	require.NoError(t, w.append(record))
+	record.Release()
+	w.pendingRows = 1
+
+	w.discard()
+	assert.Zero(t, w.pendingBytes())
+	assert.Zero(t, w.pendingRows)
+
+	// No PUT expectation is registered, so any upload here fails the mock.
+	fileName, err := w.flush()
+	require.NoError(t, err)
+	assert.Empty(t, fileName)
+	assert.Zero(t, rows.Load(), "discarded rows must not be counted as loaded")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The final flush at end-of-stream is the one an uploader does not follow with
+// anything else, so a failure there is where buffered bytes are most likely to
+// stay counted against the shared budget forever.
+func TestWriteParallelReleasesBudgetWhenFinalFlushFails(t *testing.T) {
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	require.Zero(t, bufferedBytes.Load(), "another test leaked buffered bytes")
+	t.Cleanup(func() { bufferedBytes.Store(0) })
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	putErr := errors.New("stage is full")
+	mock.ExpectExec("PUT").WillReturnError(putErr)
+
+	// Left at the default size target, so the batch is still buffered when the
+	// records channel closes and the only PUT is the end-of-stream flush.
+	records := make(chan source.RecordBatchResult, 1)
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	err = dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:        "public.events",
+		Parallelism:  1,
+		StagingTable: true,
+	})
+	require.ErrorIs(t, err, putErr)
+	assert.Zero(t, bufferedBytes.Load())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A source error must surface from WriteParallel rather than being swallowed
+// into a silently short write, and a batch attached to that error result has
+// to be released like any other -- see
+// pkg/destination/error_batch_release_test.go for the same contract across the
+// other destinations.
+func TestWriteParallelReturnsSourceError(t *testing.T) {
+	t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", "0")
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	mock.MatchExpectationsInOrder(false)
+	mock.ExpectExec("PUT").WillReturnResult(sqlmock.NewResult(0, 0))
+
+	sourceErr := errors.New("source read failed")
+	records := make(chan source.RecordBatchResult, 3)
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem), Err: sourceErr}
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	err = dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:        "public.events",
+		Parallelism:  1,
+		StagingTable: true,
+	})
+	require.ErrorIs(t, err, sourceErr)
+}
+
+// With StagingTable set, COPY runs while uploads are still going, naming the
+// files that finished since the previous statement. How many files each COPY
+// picks up is a race, so this asserts only the invariant: every uploaded file
+// is named by exactly one COPY.
+func TestWriteParallelStagingLoadsEveryFileExactlyOnce(t *testing.T) {
+	t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", "0") // one file per batch
+	mem := memory.NewCheckedAllocator(memory.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	// sqlmock invokes the matcher once per candidate expectation, so the same
+	// statement can be offered several times; collect them as a set.
+	var mu sync.Mutex
+	puts := map[string]bool{}
+	copies := map[string]bool{}
+	capture := sqlmock.QueryMatcherFunc(func(expectedSQL, actualSQL string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		switch {
+		case strings.HasPrefix(actualSQL, "PUT "):
+			puts[actualSQL] = true
+		case strings.HasPrefix(actualSQL, "COPY INTO"):
+			copies[actualSQL] = true
+		}
+		return nil
+	})
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(capture))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	mock.MatchExpectationsInOrder(false)
+
+	// One PUT per batch and at most one COPY per PUT, plus headroom so an
+	// unexpected extra statement fails on its own assertion rather than on a
+	// confusing "all expectations were already fulfilled".
+	const batches = 60
+	for i := 0; i < batches+8; i++ {
+		mock.ExpectExec("PUT").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("COPY INTO").WillReturnResult(sqlmock.NewResult(0, 0))
+	}
+
+	records := make(chan source.RecordBatchResult, batches)
+	for i := 0; i < batches; i++ {
+		records <- source.RecordBatchResult{Batch: newSingleRowRecordBatch(mem)}
+	}
+	close(records)
+
+	dest := &SnowflakeDestination{db: db}
+	require.NoError(t, dest.WriteParallel(t.Context(), records, destination.WriteOptions{
+		Table:        "public.events",
+		Parallelism:  4,
+		StagingTable: true,
+	}))
+
+	fileRE := regexp.MustCompile(`batch_\d+_\d+\.parquet`)
+	uploaded := map[string]bool{}
+	for put := range puts {
+		name := fileRE.FindString(put)
+		require.NotEmpty(t, name)
+		uploaded[name] = true
+	}
+	require.Len(t, uploaded, batches)
+
+	loaded := map[string]int{}
+	for c := range copies {
+		require.Contains(t, c, "FILES = (", "overlapped COPY must name its files")
+		for _, name := range fileRE.FindAllString(c, -1) {
+			loaded[name]++
+		}
+	}
+	for name := range uploaded {
+		assert.Equal(t, 1, loaded[name], "file %s loaded %d times", name, loaded[name])
+	}
+	assert.Len(t, loaded, batches, "COPY named a file that was never uploaded")
 }
 
 // TestMultiTableWriteDoesNotDeadlockUnderConnectionPressure reproduces the
@@ -534,7 +1117,7 @@ func TestMultiTableWriteDoesNotDeadlockUnderConnectionPressure(t *testing.T) {
 		defer close(records)
 		for j := 0; j < batchesPerTable; j++ {
 			for _, name := range tableNames {
-				records <- source.RecordBatchResult{TableName: name, Batch: newSingleRowRecordBatch()}
+				records <- source.RecordBatchResult{TableName: name, Batch: newSingleRowRecordBatch(memory.DefaultAllocator)}
 			}
 		}
 	}()

--- a/pkg/destination/snowflake/snowflake_test.go
+++ b/pkg/destination/snowflake/snowflake_test.go
@@ -292,8 +292,14 @@ func TestImplicitTableStageName(t *testing.T) {
 }
 
 func TestBuildCopyIntoSQLUsesParquetLogicalTypes(t *testing.T) {
-	got := buildCopyIntoSQL(`"PUBLIC"."EVENTS"`, `"PUBLIC".%"EVENTS"`, "123456789")
-	want := `COPY INTO "PUBLIC"."EVENTS" FROM @"PUBLIC".%"EVENTS"/123456789 FILE_FORMAT = (TYPE = PARQUET USE_LOGICAL_TYPE = TRUE) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE`
+	got := buildCopyIntoSQL(`"PUBLIC"."EVENTS"`, `"PUBLIC".%"EVENTS"`, "123456789", nil)
+	want := `COPY INTO "PUBLIC"."EVENTS" FROM @"PUBLIC".%"EVENTS"/123456789/ FILE_FORMAT = (TYPE = PARQUET USE_LOGICAL_TYPE = TRUE) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE`
+	assert.Equal(t, want, got)
+}
+
+func TestBuildCopyIntoSQLWithFilesList(t *testing.T) {
+	got := buildCopyIntoSQL(`"PUBLIC"."EVENTS"`, `"PUBLIC".%"EVENTS"`, "123456789", []string{"batch_0_1.parquet", "batch_1_1.parquet"})
+	want := `COPY INTO "PUBLIC"."EVENTS" FROM @"PUBLIC".%"EVENTS"/123456789/ FILES = ('batch_0_1.parquet', 'batch_1_1.parquet') FILE_FORMAT = (TYPE = PARQUET USE_LOGICAL_TYPE = TRUE) MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE PURGE = TRUE`
 	assert.Equal(t, want, got)
 }
 
@@ -492,6 +498,7 @@ func newSingleRowRecordBatch() arrow.RecordBatch {
 // fix) lets the shared pool be time-shared safely regardless of numTables *
 // Parallelism, so the write completes instead of hanging.
 func TestMultiTableWriteDoesNotDeadlockUnderConnectionPressure(t *testing.T) {
+	t.Setenv("INGESTR_SNOWFLAKE_FILE_SIZE_MB", "0") // one PUT per batch so expectations are deterministic
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
@@ -512,7 +519,7 @@ func TestMultiTableWriteDoesNotDeadlockUnderConnectionPressure(t *testing.T) {
 		tableConfigs[name] = destination.TableWriteConfig{DestTable: fmt.Sprintf("public.%s", name)}
 
 		for j := 0; j < batchesPerTable; j++ {
-			mock.ExpectExec("PUT file://data.parquet").WillReturnResult(sqlmock.NewResult(0, 0))
+			mock.ExpectExec("PUT file://batch_").WillReturnResult(sqlmock.NewResult(0, 0))
 		}
 		mock.ExpectExec("COPY INTO").WillReturnResult(sqlmock.NewResult(0, 0))
 	}

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -24,6 +24,12 @@ import (
 const (
 	sqlServerDriverName = "sqlserver"
 	azureSQLDriverName  = "azuresql"
+
+	// go-mssqldb defaults to 4096-byte TDS packets, which bottlenecks bulk
+	// extraction on packet-processing overhead. Use the protocol maximum like
+	// the MSSQL destination does; the server negotiates down (e.g. to 16383
+	// on encrypted connections) when needed.
+	defaultPacketSize = "32767"
 )
 
 type MSSQLSource struct {
@@ -98,6 +104,10 @@ func URIToConnString(uri string) (string, string, error) {
 	database := strings.TrimPrefix(u.Path, "/")
 	query := u.Query()
 	deleteQueryParamCI(query, "driver")
+
+	if _, hasPacketSize := normalizeQueryParamCI(query, "packet size"); !hasPacketSize {
+		query.Set("packet size", defaultPacketSize)
+	}
 
 	auth, hasAuthentication := normalizeQueryParamCI(query, "authentication")
 	if hasAuthentication {

--- a/pkg/source/mssql/mssql_test.go
+++ b/pkg/source/mssql/mssql_test.go
@@ -122,6 +122,31 @@ func TestURIToConnString(t *testing.T) {
 			absentQuery: []string{"Authentication"},
 		},
 		{
+			name:         "packet size defaults to the protocol maximum",
+			uri:          "mssql://sa:pass@localhost/testdb",
+			wantDriver:   sqlServerDriverName,
+			wantHost:     "localhost:1433",
+			wantUser:     "sa",
+			wantPassword: "pass",
+			wantQuery: map[string]string{
+				"database":    "testdb",
+				"packet size": defaultPacketSize,
+			},
+		},
+		{
+			name:         "explicit packet size is preserved regardless of case",
+			uri:          "mssql://sa:pass@localhost/testdb?Packet%20Size=8000",
+			wantDriver:   sqlServerDriverName,
+			wantHost:     "localhost:1433",
+			wantUser:     "sa",
+			wantPassword: "pass",
+			wantQuery: map[string]string{
+				"database":    "testdb",
+				"packet size": "8000",
+			},
+			absentQuery: []string{"Packet Size"},
+		},
+		{
 			name:    "wrong scheme errors",
 			uri:     "postgres://user:pass@localhost/db",
 			wantErr: true,


### PR DESCRIPTION
## What
Bulk loads from SQL Server to Snowflake were spending most of their time on per-batch PUT overhead and only starting COPY INTO after every upload finished. This reworks the Snowflake write path and fixes the MSSQL source's TDS packet size, making 10M-row loads 2.9-3.6x faster in benchmarks — all client-side, with no extra load on the source database.

## Changes
- `pkg/destination/snowflake/snowflake.go`: coalesce record batches into larger parquet files (32MiB compressed target, adaptive flush that uploads early when the source runs dry), default to zstd compression, and overlap incremental COPY INTO with uploads on staging-table loads (direct/append writes keep the single atomic COPY). Also fixes COPY `FILES=(...)` path concatenation (needs trailing `/` on the FROM location) and names staged objects via the PUT local file name instead of nesting `<name>.parquet/data.parquet`. Tunable via `INGESTR_SNOWFLAKE_FILE_SIZE_MB` and `INGESTR_SNOWFLAKE_PARQUET_CODEC`.
- `pkg/source/mssql/mssql.go`: default `packet size=32767` on source connections, matching the MSSQL destination (go-mssqldb defaults to 4096).
- `pkg/destination/snowflake/snowflake_test.go`: cover the FILES clause and updated PUT/COPY expectations.

## How to test
1. `make test` (snowflake destination and mssql source packages cover the new SQL shapes)
2. Run a replace load: `ingestr ingest --source-uri 'mssql://...' --source-table dbo.some_table --dest-uri 'snowflake://...' --dest-table schema.table` and verify row counts/checksums match the source; merge and append strategies verified the same way against a live account.

## Risk & rollback
- **Risk:** medium — the Snowflake write path is restructured; correctness was verified against a live account (replace, merge idempotency, append) with exact row counts and checksums, and overlapped COPY is gated to staging-table loads so atomicity semantics are unchanged.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues