### PR TITLE
feat(source): add Sklik source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -267,6 +267,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "SFTP", link: "/supported-sources/sftp.md"},
               { text: "SharePoint", link: "/supported-sources/sharepoint.md" },
               { text: "Shopify", link: "/supported-sources/shopify.md" },
+              { text: "Sklik", link: "/supported-sources/sklik.md" },
               { text: "Slack", link: "/supported-sources/slack.md" },
               { text: "Smartsheet", link: "/supported-sources/smartsheets.md" },
               { text: "Snapchat Ads", link: "/supported-sources/snapchat-ads.md" },

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -19,6 +19,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Mailchimp](/supported-sources/mailchimp.md)
 - [Pinterest](/supported-sources/pinterest.md)
 - [Reddit Ads](/supported-sources/reddit_ads.md)
+- [Sklik](/supported-sources/sklik.md)
 - [Snapchat Ads](/supported-sources/snapchat-ads.md)
 - [TikTok Ads](/supported-sources/tiktok-ads.md)
 

--- a/docs/supported-sources/sklik.md
+++ b/docs/supported-sources/sklik.md
@@ -1,0 +1,109 @@
+# Sklik
+
+[Sklik](https://www.sklik.cz/) is the paid-search advertising platform of Seznam.cz, the dominant Czech search engine.
+
+ingestr supports Sklik as a source through the [Sklik API](https://api.sklik.cz/drak/), a JSON-RPC interface.
+
+## URI format
+
+```plaintext
+sklik://?token=<api_token>
+```
+
+URI parameters:
+
+- `token`: Required. The permanent API token generated in the Sklik UI.
+
+The token belongs to a single Sklik account. To load several accounts into one destination table, run ingestr once per token; every row carries a `_user_id` column identifying the account it came from (see [Account column](#account-column)).
+
+Sklik's API is session-based: `client.loginByToken` exchanges the permanent token for a rolling session that changes on every response. The connector handles this, including re-login when a session expires mid-run.
+
+## Example usage
+
+```bash
+ingestr ingest \
+  --source-uri 'sklik://?token=<api_token>' \
+  --source-table campaigns \
+  --dest-uri duckdb:///sklik.duckdb \
+  --dest-table main.campaigns
+```
+
+Report tables accept `--interval-start` / `--interval-end` to bound the date window:
+
+```bash
+ingestr ingest \
+  --source-uri 'sklik://?token=<api_token>' \
+  --source-table campaign_stats_daily \
+  --interval-start 2026-01-01 \
+  --dest-uri duckdb:///sklik.duckdb \
+  --dest-table main.campaign_stats_daily
+```
+
+## Entity tables
+
+Snapshots of current state. They have no date dimension — each run returns the account as it stands now.
+
+| Table | Primary key | Strategy | Data |
+|---|---|---|---|
+| `campaigns` | `id` | merge | Campaigns with budget, status and settings |
+| `groups` | `id` | merge | Ad groups |
+| `ads` | `id` | merge | Ads |
+| `keywords` | `id` | merge | Keywords, including match type and bids |
+| `conversions` | `id` | merge | Conversion definitions |
+
+## Report tables
+
+One row per entity per day, built through Sklik's asynchronous `createReport` / `readReport` pair.
+
+| Table | Primary key | Incremental key | Strategy | Data |
+|---|---|---|---|---|
+| `campaign_stats_daily` | `id`, `date` | `date` | merge | Daily campaign performance |
+| `search_queries` | `query`, `keyword_id`, `date` | `date` | merge | Search terms that triggered ads |
+
+`campaign_stats_daily` exposes `impressions`, `clicks`, `ctr`, `avgCpc`, `conversions`, `conversionValue`, `transactions`, `clickMoney`, `impressionMoney`, `totalMoney`, `pno`, `ish`, `exhaustedBudget` and `stoppedBySchedule`.
+
+`search_queries` includes `keyword_id` in its primary key because Sklik reports the same search term once per matching keyword. Keying on `(query, date)` alone would keep one arbitrary keyword's row per query and silently drop the rest of the spend.
+
+## Account column
+
+Every row gets a `_user_id` column holding the Sklik account id. Sklik never returns it in a row payload — ingestr adds it, so the underscore prefix marks it as ingestr-owned, the same convention as `_ingestr_loaded_at`.
+
+It is deliberately **not** part of any primary key. If you load several accounts into one destination table and two of them ever share an entity id, the merge would keep only one of the rows. Loading each account into its own table avoids the question entirely.
+
+## Notes and limitations
+
+### An empty report usually means throttled, not "no data"
+
+This is the most important thing to know about the Sklik API.
+
+Sklik rate-limits per account per minute, and when you exceed the limit **the report comes back as a successful, empty response** rather than an error:
+
+```json
+{"status":200,"statusMessage":"OK","report":[]}
+```
+
+There is no `429` and no error message. A throttled report and a genuinely empty one are the same payload, so a job that quietly loads zero rows looks like a clean run.
+
+`createReport` returns a `totalCount` before you read the report — use it as the oracle. If `totalCount` is greater than zero but `readReport` yields no rows, you are throttled or the report has not finished materialising; that is not a successful empty run. ingestr does this for you: when a page comes back empty while `createReport` promised rows, it retries with a linear backoff of 15s, 30s, 45s … up to about seven minutes. A healthy report returns on the first read and never sleeps.
+
+Practical consequences:
+
+- Keep report calls to roughly one per account per minute. A per-day chunking strategy across a multi-year backfill will throttle everything after the first window.
+- Back off in minutes, not seconds.
+- Prefer wide windows (monthly or larger) over narrow ones, and accept the coarser request granularity.
+
+### Search-term reports must be scoped to campaigns
+
+`queries.createReport` returns an empty report — again with `status: 200` — unless the restriction filter scopes it to campaigns, groups or keywords. Measured against a live account: no restriction returned 0 rows; restricting to a campaign over the same window returned 165. ingestr always scopes the `search_queries` report to the account's campaigns.
+
+`campaigns.createReport` does not behave this way, so a working campaign report tells you nothing about the search-term one.
+
+### `displayColumns` enums are per-endpoint
+
+Each `*.readReport` method has its own enum of valid `displayColumns`, and they are asymmetric — a column name accepted by one endpoint can be rejected by another. Sklik answers with a bare `400 Bad arguments` for the whole report, with no indication of which column was at fault.
+
+The clearest example: `ctr` is valid in `campaigns.readReport` but rejected by `queries.readReport`, so `search_queries` does not request it. Compute CTR from `clicks` and `impressions` downstream instead. When adding a column, check it against that specific method's documentation page (for example [`queries.readReport`](https://api.sklik.cz/drak/queries.readReport.html)) rather than against another endpoint or the Sklik UI.
+
+### Request size
+
+Sklik rejects requests that ask for too much data at once with `406 You are requiring too much data in one request`. ingestr pages reports at 50 entities and caps the rows requested per call, sizing the window automatically from the interval you ask for.

--- a/docs/supported-sources/sklik.md
+++ b/docs/supported-sources/sklik.md
@@ -72,9 +72,7 @@ It is deliberately **not** part of any primary key. If you load several accounts
 
 ## Notes and limitations
 
-### An empty report usually means throttled, not "no data"
-
-This is the most important thing to know about the Sklik API.
+### Empty reports and throttling
 
 Sklik rate-limits per account per minute, and when you exceed the limit **the report comes back as a successful, empty response** rather than an error:
 
@@ -82,27 +80,15 @@ Sklik rate-limits per account per minute, and when you exceed the limit **the re
 {"status":200,"statusMessage":"OK","report":[]}
 ```
 
-There is no `429` and no error message. A throttled report and a genuinely empty one are the same payload, so a job that quietly loads zero rows looks like a clean run.
-
-`createReport` returns a `totalCount` before you read the report — use it as the oracle. If `totalCount` is greater than zero but `readReport` yields no rows, you are throttled or the report has not finished materialising; that is not a successful empty run. ingestr does this for you: when a page comes back empty while `createReport` promised rows, it retries with a linear backoff of 15s, 30s, 45s … up to about seven minutes. A healthy report returns on the first read and never sleeps.
-
-Practical consequences:
-
-- Keep report calls to roughly one per account per minute. A per-day chunking strategy across a multi-year backfill will throttle everything after the first window.
-- Back off in minutes, not seconds.
-- Prefer wide windows (monthly or larger) over narrow ones, and accept the coarser request granularity.
+There is no `429` or error message, so throttling and a genuinely empty report are indistinguishable. When `createReport` returns a positive `totalCount` but `readReport` has no rows, ingestr retries with linear backoff for about seven minutes before returning an error.
 
 ### Search-term reports must be scoped to campaigns
 
-`queries.createReport` returns an empty report — again with `status: 200` — unless the restriction filter scopes it to campaigns, groups or keywords. Measured against a live account: no restriction returned 0 rows; restricting to a campaign over the same window returned 165. ingestr always scopes the `search_queries` report to the account's campaigns.
-
-`campaigns.createReport` does not behave this way, so a working campaign report tells you nothing about the search-term one.
+`queries.createReport` returns an empty report with `status: 200` unless the restriction filter scopes it to campaigns, groups or keywords. ingestr scopes `search_queries` reports to the account's campaigns.
 
 ### `displayColumns` enums are per-endpoint
 
-Each `*.readReport` method has its own enum of valid `displayColumns`, and they are asymmetric — a column name accepted by one endpoint can be rejected by another. Sklik answers with a bare `400 Bad arguments` for the whole report, with no indication of which column was at fault.
-
-The clearest example: `ctr` is valid in `campaigns.readReport` but rejected by `queries.readReport`, so `search_queries` does not request it. Compute CTR from `clicks` and `impressions` downstream instead. When adding a column, check it against that specific method's documentation page (for example [`queries.readReport`](https://api.sklik.cz/drak/queries.readReport.html)) rather than against another endpoint or the Sklik UI.
+Each `*.readReport` method has its own enum of valid `displayColumns`. Sklik returns `400 Bad arguments` if any requested column is invalid. For example, `ctr` is valid for `campaigns.readReport` but not `queries.readReport`, so calculate search-query CTR from `clicks` and `impressions` instead.
 
 ### Request size
 

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -392,6 +392,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("sendgrid", "SendGrid", []string{"sendgrid"}, true, false),
 		genericURIConnector("sharepoint", "SharePoint", []string{"sharepoint"}, true, false),
 		genericURIConnector("shopify", "Shopify", []string{"shopify"}, true, false),
+		genericURIConnector("sklik", "Sklik", []string{"sklik"}, true, false),
 		genericURIConnector("slack", "Slack", []string{"slack"}, true, false),
 		genericURIConnector("smartsheet", "Smartsheet", []string{"smartsheet"}, true, false),
 		genericURIConnector("snapchatads", "Snapchat Ads", []string{"snapchatads"}, true, false),

--- a/pkg/source/sklik/register.go
+++ b/pkg/source/sklik/register.go
@@ -1,0 +1,10 @@
+package sklik
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"sklik"},
+		func() interface{} { return NewSklikSource() },
+	)
+}

--- a/pkg/source/sklik/sklik.go
+++ b/pkg/source/sklik/sklik.go
@@ -1,31 +1,4 @@
-// Package sklik implements an ingestr source for the Seznam Sklik "Drak"
-// JSON-RPC API (v5). Sklik is the dominant paid-search platform in Czechia and
-// has no upstream ingestr connector.
-//
-// Docs: https://api.sklik.cz/drak/
-//
-// AUTH MODEL — this is the part that trips people up:
-//   - Each account has one permanent API token, generated in the Sklik UI.
-//   - client.loginByToken(<token>) returns a ROLLING session string.
-//   - Every subsequent call's first positional parameter is {session, userId?}.
-//   - Every response carries a REFRESHED session which MUST replace the old one.
-//     A connector that logs in once and reuses the first session will start
-//     failing with status 401 partway through a long run.
-//   - status 401 mid-run means "session expired": re-login once and retry.
-//   - Managed accounts: pass the foreign account's userId. Omit it (0) to target
-//     the token owner's own account.
-//
-// Transport is JSON-over-HTTP: the method name is the URL path and the params
-// are a positional JSON array in the body, mirroring the XML-RPC semantics 1:1.
-//
-// REPORT TABLES are a two-step flow, not a single GET:
-//
-//	<entity>.createReport(restrictionFilter, displayOptions) -> {reportId, totalCount}
-//	<entity>.readReport(reportId, {offset, limit, displayColumns, ...}) -> rows
-//
-// The report is materialised server-side, then paged. Stats come back nested as
-// a per-period array on each row, so we flatten them into one row per
-// (entity, date) — otherwise the destination gets an unusable array column.
+// Package sklik implements a source for the Sklik JSON API.
 package sklik
 
 import (
@@ -50,71 +23,30 @@ const (
 	apiVersion = "v5"
 	baseURL    = "https://api.sklik.cz/drak/json/" + apiVersion
 	pageSize   = 500
-	// Report pages are far smaller than list pages: readReport returns
-	// limit x (days in range) stat rows, so the safe page size DEPENDS ON THE
-	// WINDOW. 50 entities is fine over a month (~1.5k rows) and a 406 "You are
-	// requiring too much data in one request" over three years (~55k). See
-	// reportLimitFor.
+
 	maxReportPageSize = 50
 	maxStatRowsPerReq = 1500
 	httpTimeout       = 120 * time.Second
-	// Reports are materialised asynchronously and read as empty until ready. An
-	// unfinished report and a genuinely empty one are the same payload,
-	// {"status":200,"report":[]}, so the only safe signal is createReport's
-	// totalCount: retry while it promises rows the read has not produced.
-	//
-	// The budget is nearly free. The retry loop only engages when a page comes
-	// back empty while createReport promised rows (see readReportPage's
-	// retryWhenEmpty), so a healthy report returns on the first read with no
-	// sleep at all. Only a failing window pays the full wait.
-	//
-	// Linear backoff: 15s, 30s, 45s, 60s, 75s, 90s, 105s — ~7min total.
+
 	reportReadAttempts = 8
 	reportReadBackoff  = 15 * time.Second
-
-	// accountColumn is the Sklik account stamped onto every row. Underscore-prefixed
-	// because WE add it — Sklik never returns it in a row payload — matching
-	// _ingestr_loaded_at and raw_hubspot._portal_id, the same fix for the same bug.
-	accountColumn = "_user_id"
+	accountColumn      = "_user_id"
 )
 
-// tableConfig describes one exposed table.
-//
-// kind "list"   -> a *.list method returning entities (a snapshot, no dates)
-// kind "report" -> the createReport/readReport pair (a per-day series)
 type tableConfig struct {
-	kind   string
-	method string // "campaigns", "groups", ... — the RPC namespace
-	// bareList: the .list method takes ONLY the user struct. conversions.list is
-	// the odd one out — passing the usual (restrictionFilter, displayOptions)
-	// pair gets a bare "Bad arguments".
-	bareList  bool
-	resultKey string // key holding the array in a *.list response
-	// scopeToCampaigns: createReport MUST carry a campaign restriction or the
-	// report comes back EMPTY with status 200. queries.createReport does; see
-	// the ⚠️ block on searchQueryColumns.
-	scopeToCampaigns bool
-	displayColumns   []string // report tables only
+	kind             string
+	method           string
+	bareList         bool // conversions.list accepts no filter or display options
+	resultKey        string
+	scopeToCampaigns bool // queries.createReport returns no rows without a scope
+	displayColumns   []string
 	primaryKeys      []string
-	incrementalKey   string // report tables only; "" for snapshots
+	incrementalKey   string
 }
 
-// `ctr` is deliberately absent here. queries.readReport rejects it with a bare
-// 400 even though campaigns.readReport accepts it — the displayColumns enums are
-// per-method and asymmetric. Callers can derive CTR from clicks and impressions.
-//
-// queries.createReport also returns an EMPTY report unless the restriction filter
-// scopes it to campaigns, groups or keywords. It is not an error but
-// `{"status":200,"statusMessage":"OK","report":[]}`, which reads as "this account
-// has no search terms": measured on a live account, no restriction returned 0 rows
-// while restricting to one campaign over the same window returned 165. Hence
-// scopeToCampaigns. campaigns.createReport does not share this behaviour, so a
-// working campaign report proves nothing about this one.
+// queries.readReport rejects ctr even though campaigns.readReport accepts it.
 var searchQueryColumns = []string{
 	"query",
-	// Entity columns make the raw rows joinable against the snapshot tables and
-	// are what makes the primary key unique — the same query is reported once
-	// per keyword that matched it.
 	"keyword.id", "keyword.name", "keyword.matchType",
 	"group.id", "group.name",
 	"campaign.id", "campaign.name",
@@ -122,11 +54,6 @@ var searchQueryColumns = []string{
 	"conversionValue", "transactions", "clickMoney", "impressionMoney", "totalMoney",
 }
 
-// ⚠️ Verified against https://api.sklik.cz/drak/campaigns.readReport.html.
-// DO NOT add columns without checking that enum: Sklik rejects the ENTIRE report
-// with an opaque "Bad arguments" if any single column is invalid. The impression
-// -share columns use the readReport vocabulary (`ish`), NOT the ish-prefixed
-// createReport restriction forms — mixing them up is exactly the 2026-04-26 bug.
 var campaignStatColumns = []string{
 	"id", "name",
 	"impressions", "clicks", "ctr", "avgCpc",
@@ -136,20 +63,12 @@ var campaignStatColumns = []string{
 	"ish", "exhaustedBudget", "stoppedBySchedule",
 }
 
-// `_user_id` is stamped on every row but is deliberately not part of any primary
-// key. One token reaches one account, so a single load cannot collide; keys stay on
-// Sklik's own ids. If several accounts are loaded into one destination table and two
-// ever share an entity id, the merge would keep only one of the rows — load each
-// account into its own table to avoid the question.
 var supportedTables = map[string]tableConfig{
-	// Entity snapshots — no date dimension. Sklik returns the current state.
 	"campaigns":   {kind: "list", method: "campaigns", resultKey: "campaigns", primaryKeys: []string{"id"}},
 	"groups":      {kind: "list", method: "groups", resultKey: "groups", primaryKeys: []string{"id"}},
 	"ads":         {kind: "list", method: "ads", resultKey: "ads", primaryKeys: []string{"id"}},
 	"keywords":    {kind: "list", method: "keywords", resultKey: "keywords", primaryKeys: []string{"id"}},
 	"conversions": {kind: "list", method: "conversions", resultKey: "conversions", primaryKeys: []string{"id"}, bareList: true},
-
-	// Report tables — one row per (entity, day).
 	"campaign_stats_daily": {
 		kind: "report", method: "campaigns", displayColumns: campaignStatColumns,
 		primaryKeys: []string{"id", "date"}, incrementalKey: "date",
@@ -157,10 +76,7 @@ var supportedTables = map[string]tableConfig{
 	"search_queries": {
 		kind: "report", method: "queries", displayColumns: searchQueryColumns,
 		scopeToCampaigns: true,
-		// keyword_id is part of the key because Sklik reports a query once per
-		// matching keyword; on (query, date) alone the merge would keep one
-		// arbitrary keyword's row and silently drop the rest of the spend.
-		primaryKeys: []string{"query", "keyword_id", "date"}, incrementalKey: "date",
+		primaryKeys:      []string{"query", "keyword_id", "date"}, incrementalKey: "date",
 	},
 }
 
@@ -172,8 +88,6 @@ func supportedTableNames() string {
 	return strings.Join(names, ", ")
 }
 
-// envelope is the common response wrapper. `session` is present on every
-// response and supersedes the one we sent.
 type envelope struct {
 	Status        int             `json:"status"`
 	StatusMessage string          `json:"statusMessage"`
@@ -193,8 +107,6 @@ type Source struct {
 	userID int64
 	client *http.Client
 
-	// accountID is the Sklik account every row of this run belongs to, stamped
-	// onto each emitted row as `user_id`. Resolved once in Connect.
 	accountID int64
 
 	lastEmptyPayload string
@@ -209,8 +121,6 @@ func NewSklikSource() *Source {
 
 func (s *Source) Schemes() []string { return []string{"sklik"} }
 
-// Sklik reports are filtered server-side by dateFrom/dateTo, and the entity
-// lists are snapshots with no date at all — so the source owns incrementality.
 func (s *Source) HandlesIncrementality() bool { return true }
 
 func (s *Source) Connect(ctx context.Context, uri string) error {
@@ -231,29 +141,19 @@ func (s *Source) Connect(ctx context.Context, uri string) error {
 		}
 		s.userID = id
 	}
-	// Fail fast on bad credentials rather than at first read.
 	if _, err = s.ensureSession(ctx, true); err != nil {
 		return err
 	}
 	return s.resolveAccountID(ctx)
 }
 
-// clientGetResponse is the client.get shape. Only the token owner's own userId
-// is read here; `foreignAccounts` lists managed accounts and is deliberately
-// ignored — one ingest run targets one account.
 type clientGetResponse struct {
 	User struct {
 		UserID int64 `json:"userId"`
 	} `json:"user"`
 }
 
-// resolveAccountID determines which Sklik account this run's rows belong to.
-//
-// It cannot simply echo s.userID: a URI that carries only a token leaves that
-// field 0, and stamping 0 would leave every row unattributed. When user_id is
-// omitted the account is the token owner's, and only client.get knows its id.
 func (s *Source) resolveAccountID(ctx context.Context) error {
-	// An explicitly targeted managed account is already the answer.
 	if s.userID != 0 {
 		s.accountID = s.userID
 		return nil
@@ -267,8 +167,6 @@ func (s *Source) resolveAccountID(ctx context.Context) error {
 		return fmt.Errorf("decode client.get: %w", err)
 	}
 	if r.User.UserID == 0 {
-		// Fail rather than emit rows that cannot be attributed to a brand —
-		// silently unattributable rows are the defect this field exists to fix.
 		return fmt.Errorf("sklik client.get returned no userId; refusing to emit unattributable rows")
 	}
 	s.accountID = r.User.UserID
@@ -277,7 +175,6 @@ func (s *Source) resolveAccountID(ctx context.Context) error {
 
 func (s *Source) Close(ctx context.Context) error { return nil }
 
-// post sends a positional-array JSON-RPC request.
 func (s *Source) post(ctx context.Context, method string, params []any) ([]byte, error) {
 	body, err := json.Marshal(params)
 	if err != nil {
@@ -301,8 +198,6 @@ func (s *Source) post(ctx context.Context, method string, params []any) ([]byte,
 	return buf.Bytes(), nil
 }
 
-// ensureSession returns a live session, logging in when needed. force=true
-// discards any cached session first (used after a 401).
 func (s *Source) ensureSession(ctx context.Context, force bool) (string, error) {
 	s.mu.Lock()
 	if !force && s.session != "" {
@@ -321,7 +216,6 @@ func (s *Source) ensureSession(ctx context.Context, force bool) (string, error) 
 		return "", fmt.Errorf("decode loginByToken: %w", err)
 	}
 	if env.Status < 200 || env.Status >= 300 {
-		// Deliberately does not echo statusMessage — it is a credential error.
 		return "", fmt.Errorf("sklik login failed with status %d (check the API token)", env.Status)
 	}
 	if env.Session == "" {
@@ -333,8 +227,6 @@ func (s *Source) ensureSession(ctx context.Context, force bool) (string, error) 
 	return env.Session, nil
 }
 
-// call issues an authenticated method, rotating the session from the response
-// and retrying once on 401 (expired session).
 func (s *Source) call(ctx context.Context, method string, extra ...any) (*envelope, error) {
 	return s.callOnce(ctx, method, extra, true)
 }
@@ -353,7 +245,6 @@ func (s *Source) callOnce(ctx context.Context, method string, extra []any, canRe
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return nil, fmt.Errorf("decode %s: %w", method, err)
 	}
-	// The refreshed session supersedes ours on EVERY response.
 	if env.Session != "" {
 		s.mu.Lock()
 		s.session = env.Session
@@ -368,8 +259,6 @@ func (s *Source) callOnce(ctx context.Context, method string, extra []any, canRe
 	if env.Status < 200 || env.Status >= 300 {
 		return nil, fmt.Errorf("sklik %s status %d: %s", method, env.Status, env.StatusMessage)
 	}
-	// Keep the raw payload for list responses, which put the array under a
-	// method-specific key rather than in `report`.
 	env.Report = raw
 	return &env, nil
 }
@@ -379,8 +268,6 @@ func (s *Source) GetTable(ctx context.Context, req source.TableRequest) (source.
 	if !ok {
 		return nil, fmt.Errorf("unsupported sklik table %q, supported tables are: %s", req.Name, supportedTableNames())
 	}
-	// merge for both kinds: report rows dedup on (entity, date), and entity
-	// snapshots dedup on id so a re-run refreshes rather than duplicates.
 	strategy := config.StrategyMerge
 	return &source.DynamicSourceTable{
 		TableName:           req.Name,
@@ -414,11 +301,7 @@ func (s *Source) read(ctx context.Context, table string, tc tableConfig, opts so
 	return results, nil
 }
 
-// readList pulls an entity snapshot via <method>.list.
 func (s *Source) readList(ctx context.Context, tc tableConfig, results chan<- source.RecordBatchResult, opts source.ReadOptions) error {
-	// displayOptions MUST carry offset/limit. An empty map is rejected with a
-	// bare "Bad arguments" — the same opaque 400 Sklik uses for every argument
-	// problem, which is why this is spelled out rather than left to defaults.
 	for offset := 0; ; offset += pageSize {
 		var env *envelope
 		var err error
@@ -438,7 +321,6 @@ func (s *Source) readList(ctx context.Context, tc tableConfig, results chan<- so
 		}
 		rawItems, ok := payload[tc.resultKey]
 		if !ok {
-			// An account with nothing configured returns no key at all.
 			return nil
 		}
 		var items []map[string]any
@@ -457,8 +339,6 @@ func (s *Source) readList(ctx context.Context, tc tableConfig, results chan<- so
 	}
 }
 
-// readReport runs createReport then pages readReport, flattening the nested
-// per-period stats into one row per (entity, date).
 func (s *Source) readReport(ctx context.Context, tc tableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	from, to := "", ""
 	if opts.IntervalStart != nil {
@@ -485,16 +365,9 @@ func (s *Source) readReport(ctx context.Context, tc tableConfig, opts source.Rea
 		restriction["campaign"] = map[string]any{"ids": ids}
 	}
 
-	// statGranularity=daily is what turns this into a time series. Without it
-	// Sklik returns ONE aggregate row for the whole range — the same trap Apple
-	// Search Ads has, and just as silent.
-	// includeCurrentDayStats MUST follow the data: Sklik rejects the report with
-	// "Current day's stats were requested, but today's date is not included in
-	// the date range" whenever it is true for a window that ends in the past.
-	// That makes it a backfill-only landmine — every historical chunk 400s while
-	// the nightly window works fine.
 	createOpts := map[string]any{
-		"statGranularity":        "daily",
+		"statGranularity": "daily",
+		// Sklik rejects this option for ranges that end before today.
 		"includeCurrentDayStats": windowIncludesToday(opts.IntervalEnd),
 	}
 
@@ -506,27 +379,16 @@ func (s *Source) readReport(ctx context.Context, tc tableConfig, opts source.Rea
 		return fmt.Errorf("%s.createReport returned no reportId", tc.method)
 	}
 
-	// createReport's totalCount is the ONLY way to tell "this window genuinely
-	// has no rows" from "the report is not materialised / we were throttled".
-	// Both look identical at readReport: {"status":200,"report":[]}. Without
-	// this check a throttled run is a GREEN run that ingests nothing, which is
-	// exactly how search_queries stayed empty across every brand and year.
 	expected := env.TotalCount
 
 	limit := reportLimitFor(opts.IntervalStart, opts.IntervalEnd)
 	emitted := 0
 	for offset := 0; ; offset += limit {
-		// statGranularity belongs to createReport ONLY. Repeating it here is
-		// another "Bad arguments" — the two calls take different vocabularies.
 		readOpts := map[string]any{
 			"offset":         offset,
 			"limit":          limit,
 			"displayColumns": tc.displayColumns,
-			// allowEmptyStatistics defaults to FALSE, which makes readReport drop
-			// every row whose statistics block is empty — returning `report: []`
-			// while createReport still advertises totalCount>0. That is the exact
-			// shape that made search_queries look like "this account has no search
-			// terms" for months. keywords.negative.readReport needs the same flag.
+			// The default drops entities whose statistics block is empty.
 			"allowEmptyStatistics": true,
 		}
 		rows, err := s.readReportPage(ctx, tc, env.ReportID, readOpts, offset == 0 && expected > 0)
@@ -545,43 +407,15 @@ func (s *Source) readReport(ctx context.Context, tc tableConfig, opts source.Rea
 		}
 	}
 
-	// A report that promised rows and delivered none is a failure, not an empty
-	// window. Surfacing it as an error is the whole point: a silent 0 here is
-	// indistinguishable from success in the job log.
 	if emitted == 0 && expected > 0 {
-		// ⚠️ DO NOT re-word this as "throttled". The previous text asserted
-		// throttling as the cause and cost a full investigation on 2026-08-19
-		// chasing a rate limit that was not there. Throttling is ONE cause of an
-		// empty-with-totalCount>0 report; an unfinished async report is another,
-		// and so is a window that genuinely has no rows.
-		//
-		// ⚠️ totalCount IS NOT A ROW COUNT FOR THIS WINDOW. Measured 2026-08-19:
-		// queries.createReport returned the SAME totalCount=5716 for a 2-day and a
-		// 30-day window, i.e. it is ~the account's keyword count and is window-
-		// INDEPENDENT. So `expected > 0` does not prove this window has rows, and
-		// this error can fire on a legitimately empty window — an account whose
-		// campaigns ran no search traffic at all cannot produce search terms.
-		//
-		// The window-scoped oracle is search impressions for the same account and
-		// window: empty report + impressions > 0 is a real fault, empty + zero
-		// impressions is not. That comparison needs the destination, which this
-		// source cannot reach, so treat this error as "look at it" rather than as
-		// proof of a fault.
 		return fmt.Errorf(
 			"%s.createReport reported totalCount=%d but readReport returned no rows after %d attempts over ~%s; "+
-				"causes, in order of likelihood: report not materialised in time, this window genuinely has no rows "+
-				"(totalCount is window-INDEPENDENT, ~the keyword count — it does NOT prove otherwise), or throttling "+
-				"(Sklik answers a throttled report with an empty 200, not a 429). Cross-check search impressions for "+
-				"this account+window before treating it as a fault. last payload: %s",
+				"the report may still be materialising, have no rows for this window, or be throttled; last payload: %s",
 			tc.method, expected, reportReadAttempts, totalReportPollBudget(), s.lastEmptyPayload)
 	}
 	return nil
 }
 
-// totalReportPollBudget is the wall-clock the empty-report retry loop can spend,
-// derived from the same constants the loop uses so the error message can never
-// quote a stale number. Linear backoff means the sleeps are
-// 1*backoff .. (attempts-1)*backoff, i.e. backoff * n(n+1)/2 for n = attempts-1.
 func totalReportPollBudget() time.Duration {
 	n := reportReadAttempts - 1
 	if n < 1 {
@@ -590,10 +424,7 @@ func totalReportPollBudget() time.Duration {
 	return reportReadBackoff * time.Duration(n*(n+1)/2)
 }
 
-// readReportPage pages readReport once, retrying while the report is still
-// empty but createReport said it has rows. Sklik materialises reports
-// asynchronously and answers reads against an unfinished report with an empty
-// (not erroring) payload, so a single read is a race.
+// Sklik returns an empty successful response while a report is still materialising.
 func (s *Source) readReportPage(ctx context.Context, tc tableConfig, reportID string, readOpts map[string]any, retryWhenEmpty bool) ([]map[string]any, error) {
 	attempts := 1
 	if retryWhenEmpty {
@@ -630,7 +461,6 @@ func (s *Source) readReportPage(ctx context.Context, tc tableConfig, reportID st
 	return rows, nil
 }
 
-// truncate keeps an error message readable when it carries a raw API payload.
 func truncate(raw json.RawMessage, n int) string {
 	if len(raw) <= n {
 		return string(raw)
@@ -638,10 +468,6 @@ func truncate(raw json.RawMessage, n int) string {
 	return string(raw[:n]) + "…"
 }
 
-// campaignIDs pages campaigns.list for the ids a scoped report needs. The
-// account's campaign count is small (tens), so this is one extra call, and it
-// includes paused/ended campaigns deliberately — a backfill covers windows in
-// which they were still running.
 func (s *Source) campaignIDs(ctx context.Context) ([]int64, error) {
 	var ids []int64
 	for offset := 0; ; offset += pageSize {
@@ -668,12 +494,6 @@ func (s *Source) campaignIDs(ctx context.Context) ([]int64, error) {
 	}
 }
 
-// flattenEntityRefs expands the nested entity objects the queries report
-// returns (`campaign`:{id,name}, `keyword`:{...}, `group`:{...}) into scalar
-// `campaign_id` / `campaign_name` / ... columns. Left nested, schema inference
-// lands them as JSON blobs, which are neither joinable nor usable as a primary
-// key. Sub-key spelling is kept verbatim (`keyword_matchType`) because raw
-// tables carry the vendor's vocabulary.
 func flattenEntityRefs(row map[string]any) {
 	for _, entity := range [...]string{"campaign", "group", "keyword"} {
 		nested, ok := row[entity].(map[string]any)
@@ -687,15 +507,6 @@ func flattenEntityRefs(row map[string]any) {
 	}
 }
 
-// flattenReport turns Sklik's nested report shape into flat rows.
-//
-// A readReport response looks like:
-//
-//	{"report":[{"id":123,"name":"X","stats":[{"date":"2026-01-01","clicks":5}, ...]}]}
-//
-// so each entity carries an array of per-day stats. We emit one row per stat,
-// merging the entity-level fields in. Rows without stats are skipped rather
-// than emitted with a null date, which would collide on the primary key.
 func flattenReport(raw json.RawMessage) ([]map[string]any, error) {
 	var payload struct {
 		Report []map[string]any `json:"report"`
@@ -724,11 +535,7 @@ func flattenReport(raw json.RawMessage) ([]map[string]any, error) {
 			if !ok {
 				continue
 			}
-			// Sklik returns the granularity date as a YYYYMMDD *integer*
-			// (20260804), which schema inference would otherwise land as a bare
-			// Int64 — unpartitionable, and not joinable against the real Date
-			// columns every other source produces. Normalise to time.Time so the
-			// Arrow layer maps it to a timestamp, per the repo's convention.
+			// Sklik returns daily dates as YYYYMMDD numbers.
 			if d, ok := normaliseSklikDate(stat["date"]); ok {
 				stat["date"] = d
 			}
@@ -746,20 +553,10 @@ func flattenReport(raw json.RawMessage) ([]map[string]any, error) {
 	return out, nil
 }
 
-// emit converts rows to Arrow, stamping the Sklik account onto every one.
-//
-// Sklik's payloads carry no account field of any kind, so rows from two accounts
-// are indistinguishable once they share a destination table. Both the list and the
-// report paths funnel through here, so this is the one place that needs the stamp.
-// The column is named for Sklik's own vocabulary for an account
-// (client.get -> user.userId).
 func (s *Source) emit(ctx context.Context, items []map[string]any, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	if len(items) == 0 {
 		return nil
 	}
-	// Stamped as a string rather than the int Sklik returns: account identifiers
-	// from other ad platforms are strings, and a string/int join is a type error at
-	// best and a silently empty result at worst.
 	account := strconv.FormatInt(s.accountID, 10)
 	for _, row := range items {
 		row[accountColumn] = account
@@ -776,9 +573,6 @@ func (s *Source) emit(ctx context.Context, items []map[string]any, opts source.R
 	return nil
 }
 
-// normaliseSklikDate converts Sklik's YYYYMMDD date representation to a
-// time.Time. Sklik has returned it as a JSON number in practice, but accept the
-// string form too rather than silently passing an unusable value through.
 func normaliseSklikDate(v any) (time.Time, bool) {
 	var raw string
 	switch t := v.(type) {
@@ -798,10 +592,6 @@ func normaliseSklikDate(v any) (time.Time, bool) {
 	return parsed, true
 }
 
-// reportLimitFor sizes a readReport page so that limit x days stays under what
-// Sklik will answer. readReport returns one stat row per entity PER DAY, so a
-// page size that is fine for a nightly 30-day pull produces a 406 over a
-// multi-year backfill. Callers therefore never have to think about it.
 func reportLimitFor(start, end *time.Time) int {
 	days := 31
 	if start != nil && end != nil {
@@ -819,8 +609,6 @@ func reportLimitFor(start, end *time.Time) int {
 	return limit
 }
 
-// windowIncludesToday reports whether the requested range reaches today, which is
-// the only case where Sklik accepts includeCurrentDayStats.
 func windowIncludesToday(end *time.Time) bool {
 	if end == nil {
 		return true

--- a/pkg/source/sklik/sklik.go
+++ b/pkg/source/sklik/sklik.go
@@ -1,0 +1,830 @@
+// Package sklik implements an ingestr source for the Seznam Sklik "Drak"
+// JSON-RPC API (v5). Sklik is the dominant paid-search platform in Czechia and
+// has no upstream ingestr connector.
+//
+// Docs: https://api.sklik.cz/drak/
+//
+// AUTH MODEL — this is the part that trips people up:
+//   - Each account has one permanent API token, generated in the Sklik UI.
+//   - client.loginByToken(<token>) returns a ROLLING session string.
+//   - Every subsequent call's first positional parameter is {session, userId?}.
+//   - Every response carries a REFRESHED session which MUST replace the old one.
+//     A connector that logs in once and reuses the first session will start
+//     failing with status 401 partway through a long run.
+//   - status 401 mid-run means "session expired": re-login once and retry.
+//   - Managed accounts: pass the foreign account's userId. Omit it (0) to target
+//     the token owner's own account.
+//
+// Transport is JSON-over-HTTP: the method name is the URL path and the params
+// are a positional JSON array in the body, mirroring the XML-RPC semantics 1:1.
+//
+// REPORT TABLES are a two-step flow, not a single GET:
+//
+//	<entity>.createReport(restrictionFilter, displayOptions) -> {reportId, totalCount}
+//	<entity>.readReport(reportId, {offset, limit, displayColumns, ...}) -> rows
+//
+// The report is materialised server-side, then paged. Stats come back nested as
+// a per-period array on each row, so we flatten them into one row per
+// (entity, date) — otherwise the destination gets an unusable array column.
+package sklik
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	apiVersion = "v5"
+	baseURL    = "https://api.sklik.cz/drak/json/" + apiVersion
+	pageSize   = 500
+	// Report pages are far smaller than list pages: readReport returns
+	// limit x (days in range) stat rows, so the safe page size DEPENDS ON THE
+	// WINDOW. 50 entities is fine over a month (~1.5k rows) and a 406 "You are
+	// requiring too much data in one request" over three years (~55k). See
+	// reportLimitFor.
+	maxReportPageSize = 50
+	maxStatRowsPerReq = 1500
+	httpTimeout       = 120 * time.Second
+	// Reports are materialised asynchronously and read as empty until ready. An
+	// unfinished report and a genuinely empty one are the same payload,
+	// {"status":200,"report":[]}, so the only safe signal is createReport's
+	// totalCount: retry while it promises rows the read has not produced.
+	//
+	// The budget is nearly free. The retry loop only engages when a page comes
+	// back empty while createReport promised rows (see readReportPage's
+	// retryWhenEmpty), so a healthy report returns on the first read with no
+	// sleep at all. Only a failing window pays the full wait.
+	//
+	// Linear backoff: 15s, 30s, 45s, 60s, 75s, 90s, 105s — ~7min total.
+	reportReadAttempts = 8
+	reportReadBackoff  = 15 * time.Second
+
+	// accountColumn is the Sklik account stamped onto every row. Underscore-prefixed
+	// because WE add it — Sklik never returns it in a row payload — matching
+	// _ingestr_loaded_at and raw_hubspot._portal_id, the same fix for the same bug.
+	accountColumn = "_user_id"
+)
+
+// tableConfig describes one exposed table.
+//
+// kind "list"   -> a *.list method returning entities (a snapshot, no dates)
+// kind "report" -> the createReport/readReport pair (a per-day series)
+type tableConfig struct {
+	kind   string
+	method string // "campaigns", "groups", ... — the RPC namespace
+	// bareList: the .list method takes ONLY the user struct. conversions.list is
+	// the odd one out — passing the usual (restrictionFilter, displayOptions)
+	// pair gets a bare "Bad arguments".
+	bareList  bool
+	resultKey string // key holding the array in a *.list response
+	// scopeToCampaigns: createReport MUST carry a campaign restriction or the
+	// report comes back EMPTY with status 200. queries.createReport does; see
+	// the ⚠️ block on searchQueryColumns.
+	scopeToCampaigns bool
+	displayColumns   []string // report tables only
+	primaryKeys      []string
+	incrementalKey   string // report tables only; "" for snapshots
+}
+
+// `ctr` is deliberately absent here. queries.readReport rejects it with a bare
+// 400 even though campaigns.readReport accepts it — the displayColumns enums are
+// per-method and asymmetric. Callers can derive CTR from clicks and impressions.
+//
+// queries.createReport also returns an EMPTY report unless the restriction filter
+// scopes it to campaigns, groups or keywords. It is not an error but
+// `{"status":200,"statusMessage":"OK","report":[]}`, which reads as "this account
+// has no search terms": measured on a live account, no restriction returned 0 rows
+// while restricting to one campaign over the same window returned 165. Hence
+// scopeToCampaigns. campaigns.createReport does not share this behaviour, so a
+// working campaign report proves nothing about this one.
+var searchQueryColumns = []string{
+	"query",
+	// Entity columns make the raw rows joinable against the snapshot tables and
+	// are what makes the primary key unique — the same query is reported once
+	// per keyword that matched it.
+	"keyword.id", "keyword.name", "keyword.matchType",
+	"group.id", "group.name",
+	"campaign.id", "campaign.name",
+	"impressions", "clicks", "avgCpc", "conversions",
+	"conversionValue", "transactions", "clickMoney", "impressionMoney", "totalMoney",
+}
+
+// ⚠️ Verified against https://api.sklik.cz/drak/campaigns.readReport.html.
+// DO NOT add columns without checking that enum: Sklik rejects the ENTIRE report
+// with an opaque "Bad arguments" if any single column is invalid. The impression
+// -share columns use the readReport vocabulary (`ish`), NOT the ish-prefixed
+// createReport restriction forms — mixing them up is exactly the 2026-04-26 bug.
+var campaignStatColumns = []string{
+	"id", "name",
+	"impressions", "clicks", "ctr", "avgCpc",
+	"conversions", "conversionValue", "transactions",
+	"clickMoney", "impressionMoney", "totalMoney",
+	"pno",
+	"ish", "exhaustedBudget", "stoppedBySchedule",
+}
+
+// `_user_id` is stamped on every row but is deliberately not part of any primary
+// key. One token reaches one account, so a single load cannot collide; keys stay on
+// Sklik's own ids. If several accounts are loaded into one destination table and two
+// ever share an entity id, the merge would keep only one of the rows — load each
+// account into its own table to avoid the question.
+var supportedTables = map[string]tableConfig{
+	// Entity snapshots — no date dimension. Sklik returns the current state.
+	"campaigns":   {kind: "list", method: "campaigns", resultKey: "campaigns", primaryKeys: []string{"id"}},
+	"groups":      {kind: "list", method: "groups", resultKey: "groups", primaryKeys: []string{"id"}},
+	"ads":         {kind: "list", method: "ads", resultKey: "ads", primaryKeys: []string{"id"}},
+	"keywords":    {kind: "list", method: "keywords", resultKey: "keywords", primaryKeys: []string{"id"}},
+	"conversions": {kind: "list", method: "conversions", resultKey: "conversions", primaryKeys: []string{"id"}, bareList: true},
+
+	// Report tables — one row per (entity, day).
+	"campaign_stats_daily": {
+		kind: "report", method: "campaigns", displayColumns: campaignStatColumns,
+		primaryKeys: []string{"id", "date"}, incrementalKey: "date",
+	},
+	"search_queries": {
+		kind: "report", method: "queries", displayColumns: searchQueryColumns,
+		scopeToCampaigns: true,
+		// keyword_id is part of the key because Sklik reports a query once per
+		// matching keyword; on (query, date) alone the merge would keep one
+		// arbitrary keyword's row and silently drop the rest of the spend.
+		primaryKeys: []string{"query", "keyword_id", "date"}, incrementalKey: "date",
+	},
+}
+
+func supportedTableNames() string {
+	names := make([]string, 0, len(supportedTables))
+	for n := range supportedTables {
+		names = append(names, n)
+	}
+	return strings.Join(names, ", ")
+}
+
+// envelope is the common response wrapper. `session` is present on every
+// response and supersedes the one we sent.
+type envelope struct {
+	Status        int             `json:"status"`
+	StatusMessage string          `json:"statusMessage"`
+	Session       string          `json:"session"`
+	ReportID      string          `json:"reportId"`
+	TotalCount    int             `json:"totalCount"`
+	Report        json.RawMessage `json:"report"`
+}
+
+type userArg struct {
+	Session string `json:"session"`
+	UserID  int64  `json:"userId,omitempty"`
+}
+
+type Source struct {
+	token  string
+	userID int64
+	client *http.Client
+
+	// accountID is the Sklik account every row of this run belongs to, stamped
+	// onto each emitted row as `user_id`. Resolved once in Connect.
+	accountID int64
+
+	lastEmptyPayload string
+
+	mu      sync.Mutex
+	session string
+}
+
+func NewSklikSource() *Source {
+	return &Source{client: &http.Client{Timeout: httpTimeout}}
+}
+
+func (s *Source) Schemes() []string { return []string{"sklik"} }
+
+// Sklik reports are filtered server-side by dateFrom/dateTo, and the entity
+// lists are snapshots with no date at all — so the source owns incrementality.
+func (s *Source) HandlesIncrementality() bool { return true }
+
+func (s *Source) Connect(ctx context.Context, uri string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return fmt.Errorf("invalid sklik URI: %w", err)
+	}
+	q := parsed.Query()
+
+	s.token = q.Get("token")
+	if s.token == "" {
+		return fmt.Errorf("token is required in sklik URI: sklik://?token=<api_token>")
+	}
+	if raw := q.Get("user_id"); raw != "" {
+		id, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return fmt.Errorf("user_id must be numeric, got %q", raw)
+		}
+		s.userID = id
+	}
+	// Fail fast on bad credentials rather than at first read.
+	if _, err = s.ensureSession(ctx, true); err != nil {
+		return err
+	}
+	return s.resolveAccountID(ctx)
+}
+
+// clientGetResponse is the client.get shape. Only the token owner's own userId
+// is read here; `foreignAccounts` lists managed accounts and is deliberately
+// ignored — one ingest run targets one account.
+type clientGetResponse struct {
+	User struct {
+		UserID int64 `json:"userId"`
+	} `json:"user"`
+}
+
+// resolveAccountID determines which Sklik account this run's rows belong to.
+//
+// It cannot simply echo s.userID: a URI that carries only a token leaves that
+// field 0, and stamping 0 would leave every row unattributed. When user_id is
+// omitted the account is the token owner's, and only client.get knows its id.
+func (s *Source) resolveAccountID(ctx context.Context) error {
+	// An explicitly targeted managed account is already the answer.
+	if s.userID != 0 {
+		s.accountID = s.userID
+		return nil
+	}
+	env, err := s.call(ctx, "client.get")
+	if err != nil {
+		return fmt.Errorf("resolve sklik account: %w", err)
+	}
+	var r clientGetResponse
+	if err := json.Unmarshal(env.Report, &r); err != nil {
+		return fmt.Errorf("decode client.get: %w", err)
+	}
+	if r.User.UserID == 0 {
+		// Fail rather than emit rows that cannot be attributed to a brand —
+		// silently unattributable rows are the defect this field exists to fix.
+		return fmt.Errorf("sklik client.get returned no userId; refusing to emit unattributable rows")
+	}
+	s.accountID = r.User.UserID
+	return nil
+}
+
+func (s *Source) Close(ctx context.Context) error { return nil }
+
+// post sends a positional-array JSON-RPC request.
+func (s *Source) post(ctx context.Context, method string, params []any) ([]byte, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal params: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/"+method, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("sklik %s: %w", method, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return nil, fmt.Errorf("read %s response: %w", method, err)
+	}
+	return buf.Bytes(), nil
+}
+
+// ensureSession returns a live session, logging in when needed. force=true
+// discards any cached session first (used after a 401).
+func (s *Source) ensureSession(ctx context.Context, force bool) (string, error) {
+	s.mu.Lock()
+	if !force && s.session != "" {
+		sess := s.session
+		s.mu.Unlock()
+		return sess, nil
+	}
+	s.mu.Unlock()
+
+	raw, err := s.post(ctx, "client.loginByToken", []any{s.token})
+	if err != nil {
+		return "", err
+	}
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return "", fmt.Errorf("decode loginByToken: %w", err)
+	}
+	if env.Status < 200 || env.Status >= 300 {
+		// Deliberately does not echo statusMessage — it is a credential error.
+		return "", fmt.Errorf("sklik login failed with status %d (check the API token)", env.Status)
+	}
+	if env.Session == "" {
+		return "", fmt.Errorf("sklik loginByToken returned an empty session")
+	}
+	s.mu.Lock()
+	s.session = env.Session
+	s.mu.Unlock()
+	return env.Session, nil
+}
+
+// call issues an authenticated method, rotating the session from the response
+// and retrying once on 401 (expired session).
+func (s *Source) call(ctx context.Context, method string, extra ...any) (*envelope, error) {
+	return s.callOnce(ctx, method, extra, true)
+}
+
+func (s *Source) callOnce(ctx context.Context, method string, extra []any, canRetry bool) (*envelope, error) {
+	sess, err := s.ensureSession(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	params := append([]any{userArg{Session: sess, UserID: s.userID}}, extra...)
+	raw, err := s.post(ctx, method, params)
+	if err != nil {
+		return nil, err
+	}
+	var env envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", method, err)
+	}
+	// The refreshed session supersedes ours on EVERY response.
+	if env.Session != "" {
+		s.mu.Lock()
+		s.session = env.Session
+		s.mu.Unlock()
+	}
+	if env.Status == 401 && canRetry {
+		if _, err := s.ensureSession(ctx, true); err != nil {
+			return nil, err
+		}
+		return s.callOnce(ctx, method, extra, false)
+	}
+	if env.Status < 200 || env.Status >= 300 {
+		return nil, fmt.Errorf("sklik %s status %d: %s", method, env.Status, env.StatusMessage)
+	}
+	// Keep the raw payload for list responses, which put the array under a
+	// method-specific key rather than in `report`.
+	env.Report = raw
+	return &env, nil
+}
+
+func (s *Source) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	tc, ok := supportedTables[req.Name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported sklik table %q, supported tables are: %s", req.Name, supportedTableNames())
+	}
+	// merge for both kinds: report rows dedup on (entity, date), and entity
+	// snapshots dedup on id so a re-run refreshes rather than duplicates.
+	strategy := config.StrategyMerge
+	return &source.DynamicSourceTable{
+		TableName:           req.Name,
+		TablePrimaryKeys:    tc.primaryKeys,
+		TableIncrementalKey: tc.incrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("sklik source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, req.Name, tc, opts)
+		},
+	}, nil
+}
+
+func (s *Source) read(ctx context.Context, table string, tc tableConfig, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 4)
+	go func() {
+		defer close(results)
+		var err error
+		if tc.kind == "report" {
+			err = s.readReport(ctx, tc, opts, results)
+		} else {
+			err = s.readList(ctx, tc, results, opts)
+		}
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+	return results, nil
+}
+
+// readList pulls an entity snapshot via <method>.list.
+func (s *Source) readList(ctx context.Context, tc tableConfig, results chan<- source.RecordBatchResult, opts source.ReadOptions) error {
+	// displayOptions MUST carry offset/limit. An empty map is rejected with a
+	// bare "Bad arguments" — the same opaque 400 Sklik uses for every argument
+	// problem, which is why this is spelled out rather than left to defaults.
+	for offset := 0; ; offset += pageSize {
+		var env *envelope
+		var err error
+		if tc.bareList {
+			env, err = s.call(ctx, tc.method+".list")
+		} else {
+			env, err = s.call(ctx, tc.method+".list",
+				map[string]any{},
+				map[string]any{"offset": offset, "limit": pageSize})
+		}
+		if err != nil {
+			return err
+		}
+		var payload map[string]json.RawMessage
+		if err := json.Unmarshal(env.Report, &payload); err != nil {
+			return fmt.Errorf("decode %s.list: %w", tc.method, err)
+		}
+		rawItems, ok := payload[tc.resultKey]
+		if !ok {
+			// An account with nothing configured returns no key at all.
+			return nil
+		}
+		var items []map[string]any
+		if err := json.Unmarshal(rawItems, &items); err != nil {
+			return fmt.Errorf("decode %s.list items: %w", tc.method, err)
+		}
+		if len(items) == 0 {
+			return nil
+		}
+		if err := s.emit(ctx, items, opts, results); err != nil {
+			return err
+		}
+		if tc.bareList || len(items) < pageSize {
+			return nil
+		}
+	}
+}
+
+// readReport runs createReport then pages readReport, flattening the nested
+// per-period stats into one row per (entity, date).
+func (s *Source) readReport(ctx context.Context, tc tableConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	from, to := "", ""
+	if opts.IntervalStart != nil {
+		from = opts.IntervalStart.Format("2006-01-02")
+	}
+	if opts.IntervalEnd != nil {
+		to = opts.IntervalEnd.Format("2006-01-02")
+	}
+	restriction := map[string]any{}
+	if from != "" {
+		restriction["dateFrom"] = from
+	}
+	if to != "" {
+		restriction["dateTo"] = to
+	}
+	if tc.scopeToCampaigns {
+		ids, err := s.campaignIDs(ctx)
+		if err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			return nil
+		}
+		restriction["campaign"] = map[string]any{"ids": ids}
+	}
+
+	// statGranularity=daily is what turns this into a time series. Without it
+	// Sklik returns ONE aggregate row for the whole range — the same trap Apple
+	// Search Ads has, and just as silent.
+	// includeCurrentDayStats MUST follow the data: Sklik rejects the report with
+	// "Current day's stats were requested, but today's date is not included in
+	// the date range" whenever it is true for a window that ends in the past.
+	// That makes it a backfill-only landmine — every historical chunk 400s while
+	// the nightly window works fine.
+	createOpts := map[string]any{
+		"statGranularity":        "daily",
+		"includeCurrentDayStats": windowIncludesToday(opts.IntervalEnd),
+	}
+
+	env, err := s.call(ctx, tc.method+".createReport", restriction, createOpts)
+	if err != nil {
+		return err
+	}
+	if env.ReportID == "" {
+		return fmt.Errorf("%s.createReport returned no reportId", tc.method)
+	}
+
+	// createReport's totalCount is the ONLY way to tell "this window genuinely
+	// has no rows" from "the report is not materialised / we were throttled".
+	// Both look identical at readReport: {"status":200,"report":[]}. Without
+	// this check a throttled run is a GREEN run that ingests nothing, which is
+	// exactly how search_queries stayed empty across every brand and year.
+	expected := env.TotalCount
+
+	limit := reportLimitFor(opts.IntervalStart, opts.IntervalEnd)
+	emitted := 0
+	for offset := 0; ; offset += limit {
+		// statGranularity belongs to createReport ONLY. Repeating it here is
+		// another "Bad arguments" — the two calls take different vocabularies.
+		readOpts := map[string]any{
+			"offset":         offset,
+			"limit":          limit,
+			"displayColumns": tc.displayColumns,
+			// allowEmptyStatistics defaults to FALSE, which makes readReport drop
+			// every row whose statistics block is empty — returning `report: []`
+			// while createReport still advertises totalCount>0. That is the exact
+			// shape that made search_queries look like "this account has no search
+			// terms" for months. keywords.negative.readReport needs the same flag.
+			"allowEmptyStatistics": true,
+		}
+		rows, err := s.readReportPage(ctx, tc, env.ReportID, readOpts, offset == 0 && expected > 0)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		if err := s.emit(ctx, rows, opts, results); err != nil {
+			return err
+		}
+		emitted += len(rows)
+		if len(rows) < limit {
+			break
+		}
+	}
+
+	// A report that promised rows and delivered none is a failure, not an empty
+	// window. Surfacing it as an error is the whole point: a silent 0 here is
+	// indistinguishable from success in the job log.
+	if emitted == 0 && expected > 0 {
+		// ⚠️ DO NOT re-word this as "throttled". The previous text asserted
+		// throttling as the cause and cost a full investigation on 2026-08-19
+		// chasing a rate limit that was not there. Throttling is ONE cause of an
+		// empty-with-totalCount>0 report; an unfinished async report is another,
+		// and so is a window that genuinely has no rows.
+		//
+		// ⚠️ totalCount IS NOT A ROW COUNT FOR THIS WINDOW. Measured 2026-08-19:
+		// queries.createReport returned the SAME totalCount=5716 for a 2-day and a
+		// 30-day window, i.e. it is ~the account's keyword count and is window-
+		// INDEPENDENT. So `expected > 0` does not prove this window has rows, and
+		// this error can fire on a legitimately empty window — an account whose
+		// campaigns ran no search traffic at all cannot produce search terms.
+		//
+		// The window-scoped oracle is search impressions for the same account and
+		// window: empty report + impressions > 0 is a real fault, empty + zero
+		// impressions is not. That comparison needs the destination, which this
+		// source cannot reach, so treat this error as "look at it" rather than as
+		// proof of a fault.
+		return fmt.Errorf(
+			"%s.createReport reported totalCount=%d but readReport returned no rows after %d attempts over ~%s; "+
+				"causes, in order of likelihood: report not materialised in time, this window genuinely has no rows "+
+				"(totalCount is window-INDEPENDENT, ~the keyword count — it does NOT prove otherwise), or throttling "+
+				"(Sklik answers a throttled report with an empty 200, not a 429). Cross-check search impressions for "+
+				"this account+window before treating it as a fault. last payload: %s",
+			tc.method, expected, reportReadAttempts, totalReportPollBudget(), s.lastEmptyPayload)
+	}
+	return nil
+}
+
+// totalReportPollBudget is the wall-clock the empty-report retry loop can spend,
+// derived from the same constants the loop uses so the error message can never
+// quote a stale number. Linear backoff means the sleeps are
+// 1*backoff .. (attempts-1)*backoff, i.e. backoff * n(n+1)/2 for n = attempts-1.
+func totalReportPollBudget() time.Duration {
+	n := reportReadAttempts - 1
+	if n < 1 {
+		return 0
+	}
+	return reportReadBackoff * time.Duration(n*(n+1)/2)
+}
+
+// readReportPage pages readReport once, retrying while the report is still
+// empty but createReport said it has rows. Sklik materialises reports
+// asynchronously and answers reads against an unfinished report with an empty
+// (not erroring) payload, so a single read is a race.
+func (s *Source) readReportPage(ctx context.Context, tc tableConfig, reportID string, readOpts map[string]any, retryWhenEmpty bool) ([]map[string]any, error) {
+	attempts := 1
+	if retryWhenEmpty {
+		attempts = reportReadAttempts
+	}
+	var rows []map[string]any
+	var lastRaw json.RawMessage
+	defer func() {
+		if len(rows) == 0 && retryWhenEmpty {
+			s.lastEmptyPayload = truncate(lastRaw, 500)
+		}
+	}()
+	for attempt := range attempts {
+		if attempt > 0 {
+			select {
+			case <-time.After(time.Duration(attempt) * reportReadBackoff):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		page, err := s.call(ctx, tc.method+".readReport", reportID, readOpts)
+		if err != nil {
+			return nil, err
+		}
+		rows, err = flattenReport(page.Report)
+		if err != nil {
+			return nil, err
+		}
+		if len(rows) > 0 {
+			return rows, nil
+		}
+		lastRaw = page.Report
+	}
+	return rows, nil
+}
+
+// truncate keeps an error message readable when it carries a raw API payload.
+func truncate(raw json.RawMessage, n int) string {
+	if len(raw) <= n {
+		return string(raw)
+	}
+	return string(raw[:n]) + "…"
+}
+
+// campaignIDs pages campaigns.list for the ids a scoped report needs. The
+// account's campaign count is small (tens), so this is one extra call, and it
+// includes paused/ended campaigns deliberately — a backfill covers windows in
+// which they were still running.
+func (s *Source) campaignIDs(ctx context.Context) ([]int64, error) {
+	var ids []int64
+	for offset := 0; ; offset += pageSize {
+		env, err := s.call(ctx, "campaigns.list",
+			map[string]any{},
+			map[string]any{"offset": offset, "limit": pageSize})
+		if err != nil {
+			return nil, err
+		}
+		var payload struct {
+			Campaigns []struct {
+				ID int64 `json:"id"`
+			} `json:"campaigns"`
+		}
+		if err := json.Unmarshal(env.Report, &payload); err != nil {
+			return nil, fmt.Errorf("decode campaigns.list: %w", err)
+		}
+		for _, c := range payload.Campaigns {
+			ids = append(ids, c.ID)
+		}
+		if len(payload.Campaigns) < pageSize {
+			return ids, nil
+		}
+	}
+}
+
+// flattenEntityRefs expands the nested entity objects the queries report
+// returns (`campaign`:{id,name}, `keyword`:{...}, `group`:{...}) into scalar
+// `campaign_id` / `campaign_name` / ... columns. Left nested, schema inference
+// lands them as JSON blobs, which are neither joinable nor usable as a primary
+// key. Sub-key spelling is kept verbatim (`keyword_matchType`) because raw
+// tables carry the vendor's vocabulary.
+func flattenEntityRefs(row map[string]any) {
+	for _, entity := range [...]string{"campaign", "group", "keyword"} {
+		nested, ok := row[entity].(map[string]any)
+		if !ok {
+			continue
+		}
+		delete(row, entity)
+		for k, v := range nested {
+			row[entity+"_"+k] = v
+		}
+	}
+}
+
+// flattenReport turns Sklik's nested report shape into flat rows.
+//
+// A readReport response looks like:
+//
+//	{"report":[{"id":123,"name":"X","stats":[{"date":"2026-01-01","clicks":5}, ...]}]}
+//
+// so each entity carries an array of per-day stats. We emit one row per stat,
+// merging the entity-level fields in. Rows without stats are skipped rather
+// than emitted with a null date, which would collide on the primary key.
+func flattenReport(raw json.RawMessage) ([]map[string]any, error) {
+	var payload struct {
+		Report []map[string]any `json:"report"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, fmt.Errorf("decode readReport: %w", err)
+	}
+	out := make([]map[string]any, 0, len(payload.Report))
+	for _, item := range payload.Report {
+		statsRaw, ok := item["stats"]
+		if !ok {
+			continue
+		}
+		stats, ok := statsRaw.([]any)
+		if !ok {
+			continue
+		}
+		base := make(map[string]any, len(item))
+		for k, v := range item {
+			if k != "stats" {
+				base[k] = v
+			}
+		}
+		for _, st := range stats {
+			stat, ok := st.(map[string]any)
+			if !ok {
+				continue
+			}
+			// Sklik returns the granularity date as a YYYYMMDD *integer*
+			// (20260804), which schema inference would otherwise land as a bare
+			// Int64 — unpartitionable, and not joinable against the real Date
+			// columns every other source produces. Normalise to time.Time so the
+			// Arrow layer maps it to a timestamp, per the repo's convention.
+			if d, ok := normaliseSklikDate(stat["date"]); ok {
+				stat["date"] = d
+			}
+			row := make(map[string]any, len(base)+len(stat))
+			for k, v := range base {
+				row[k] = v
+			}
+			for k, v := range stat {
+				row[k] = v
+			}
+			flattenEntityRefs(row)
+			out = append(out, row)
+		}
+	}
+	return out, nil
+}
+
+// emit converts rows to Arrow, stamping the Sklik account onto every one.
+//
+// Sklik's payloads carry no account field of any kind, so rows from two accounts
+// are indistinguishable once they share a destination table. Both the list and the
+// report paths funnel through here, so this is the one place that needs the stamp.
+// The column is named for Sklik's own vocabulary for an account
+// (client.get -> user.userId).
+func (s *Source) emit(ctx context.Context, items []map[string]any, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	// Stamped as a string rather than the int Sklik returns: account identifiers
+	// from other ad platforms are strings, and a string/int join is a type error at
+	// best and a silently empty result at worst.
+	account := strconv.FormatInt(s.accountID, 10)
+	for _, row := range items {
+		row[accountColumn] = account
+	}
+	rec, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("convert sklik rows to arrow: %w", err)
+	}
+	select {
+	case results <- source.RecordBatchResult{Batch: rec}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+// normaliseSklikDate converts Sklik's YYYYMMDD date representation to a
+// time.Time. Sklik has returned it as a JSON number in practice, but accept the
+// string form too rather than silently passing an unusable value through.
+func normaliseSklikDate(v any) (time.Time, bool) {
+	var raw string
+	switch t := v.(type) {
+	case float64:
+		raw = strconv.FormatInt(int64(t), 10)
+	case int64:
+		raw = strconv.FormatInt(t, 10)
+	case string:
+		raw = strings.ReplaceAll(t, "-", "")
+	default:
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse("20060102", raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+// reportLimitFor sizes a readReport page so that limit x days stays under what
+// Sklik will answer. readReport returns one stat row per entity PER DAY, so a
+// page size that is fine for a nightly 30-day pull produces a 406 over a
+// multi-year backfill. Callers therefore never have to think about it.
+func reportLimitFor(start, end *time.Time) int {
+	days := 31
+	if start != nil && end != nil {
+		if d := int(end.Sub(*start).Hours()/24) + 1; d > 0 {
+			days = d
+		}
+	}
+	limit := maxStatRowsPerReq / days
+	if limit > maxReportPageSize {
+		limit = maxReportPageSize
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	return limit
+}
+
+// windowIncludesToday reports whether the requested range reaches today, which is
+// the only case where Sklik accepts includeCurrentDayStats.
+func windowIncludesToday(end *time.Time) bool {
+	if end == nil {
+		return true
+	}
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	return !end.UTC().Truncate(24 * time.Hour).Before(today)
+}

--- a/pkg/source/sklik/sklik_test.go
+++ b/pkg/source/sklik/sklik_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/bruin-data/ingestr/pkg/source"
 )
 
-// The queries report nests the entity a row belongs to. Left nested, schema
-// inference turns them into JSON blobs and `keyword_id` — part of the primary
-// key — never exists, so the merge collapses every keyword that matched a
-// query down to one arbitrary row.
 func TestFlattenReportExpandsEntityRefs(t *testing.T) {
 	raw := json.RawMessage(`{"report":[{
 		"query":"kavovar deloni",
@@ -55,9 +51,6 @@ func TestFlattenReportExpandsEntityRefs(t *testing.T) {
 	}
 }
 
-// search_queries must stay scoped to campaigns: an unrestricted
-// queries.createReport returns status 200 with an EMPTY report rather than an
-// error, which is indistinguishable from "this account has no search terms".
 func TestSearchQueriesIsCampaignScoped(t *testing.T) {
 	tc := supportedTables["search_queries"]
 	if !tc.scopeToCampaigns {
@@ -74,9 +67,6 @@ func TestSearchQueriesIsCampaignScoped(t *testing.T) {
 	}
 }
 
-// Every emitted row must carry the account it came from. Sklik's payloads have no
-// account field, so without the stamp rows from two accounts sharing a destination
-// table cannot be told apart.
 func TestEmitStampsAccountOnEveryRow(t *testing.T) {
 	s := &Source{accountID: 123456}
 	items := []map[string]any{
@@ -101,10 +91,6 @@ func TestEmitStampsAccountOnEveryRow(t *testing.T) {
 	}
 }
 
-// ⚠️ THE TRAP THIS LOCKS: each brand's CronJob passes only a token and no
-// user_id, so s.userID is 0 for all three. Resolving the account must therefore
-// consult client.get rather than echoing the configured value — echoing it would
-// stamp 0 on every brand and reproduce the original defect while looking fixed.
 func TestResolveAccountIDPrefersExplicitManagedAccount(t *testing.T) {
 	s := &Source{userID: 987}
 	if err := s.resolveAccountID(context.Background()); err != nil {
@@ -114,7 +100,6 @@ func TestResolveAccountIDPrefersExplicitManagedAccount(t *testing.T) {
 		t.Errorf("accountID = %d, want the explicitly targeted managed account 987", s.accountID)
 	}
 
-	// With no user_id configured the account must come from client.get.
 	owner := &Source{client: stubClient(map[string]string{
 		"client.loginByToken": `{"status":200,"session":"s1"}`,
 		"client.get":          `{"status":200,"session":"s2","user":{"userId":555}}`,
@@ -127,9 +112,6 @@ func TestResolveAccountIDPrefersExplicitManagedAccount(t *testing.T) {
 	}
 }
 
-// A client.get that yields no userId must fail the run. Stamping the zero value
-// instead would land rows that look attributed and are not — the exact failure
-// this column exists to prevent, made harder to spot.
 func TestResolveAccountIDRefusesZero(t *testing.T) {
 	s := &Source{client: stubClient(map[string]string{
 		"client.loginByToken": `{"status":200,"session":"s1"}`,
@@ -144,8 +126,6 @@ func TestResolveAccountIDRefusesZero(t *testing.T) {
 	}
 }
 
-// stubClient serves canned JSON per RPC method name (the last path segment),
-// so the real call/session path is exercised without touching the network.
 func stubClient(byMethod map[string]string) *http.Client {
 	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		parts := strings.Split(r.URL.Path, "/")
@@ -165,7 +145,6 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
-// Regression lock for the "v0.2.1 trap" — see the comment on searchQueryColumns.
 func TestSearchQueryColumnsExcludeCTR(t *testing.T) {
 	for _, c := range searchQueryColumns {
 		if c == "ctr" {
@@ -174,18 +153,11 @@ func TestSearchQueryColumnsExcludeCTR(t *testing.T) {
 	}
 }
 
-// The account is stamped on every row but is deliberately not in any primary key —
-// see the note on supportedTables. Primary keys become the destination's sort order
-// on several destinations, so adding it is a breaking change for existing tables
-// rather than a cleanup. This locks the choice so it is made on purpose.
 func TestAccountIsNotInPrimaryKeys(t *testing.T) {
 	for name, tc := range supportedTables {
 		for _, pk := range tc.primaryKeys {
 			if pk == accountColumn {
-				t.Errorf("%s has %s in its primary key %v — that changes the destination sort "+
-					"order and is a breaking change for existing tables. If that is intended, "+
-					"do it deliberately; if not, remove it.",
-					name, accountColumn, tc.primaryKeys)
+				t.Errorf("%s has %s in its primary key %v", name, accountColumn, tc.primaryKeys)
 			}
 		}
 	}

--- a/pkg/source/sklik/sklik_test.go
+++ b/pkg/source/sklik/sklik_test.go
@@ -1,0 +1,192 @@
+package sklik
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+// The queries report nests the entity a row belongs to. Left nested, schema
+// inference turns them into JSON blobs and `keyword_id` — part of the primary
+// key — never exists, so the merge collapses every keyword that matched a
+// query down to one arbitrary row.
+func TestFlattenReportExpandsEntityRefs(t *testing.T) {
+	raw := json.RawMessage(`{"report":[{
+		"query":"kavovar deloni",
+		"campaign":{"id":3456225,"name":"[SEA] Brand"},
+		"group":{"id":115928034,"name":"Espresso"},
+		"keyword":{"id":2590421096,"name":"kavovar","matchType":"phrase"},
+		"stats":[{"date":20260701,"clicks":3,"impressions":11}]
+	}]}`)
+
+	rows, err := flattenReport(raw)
+	if err != nil {
+		t.Fatalf("flattenReport: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	row := rows[0]
+
+	for _, nested := range []string{"campaign", "group", "keyword"} {
+		if _, ok := row[nested]; ok {
+			t.Errorf("%q survived flattening as a nested object", nested)
+		}
+	}
+	for col, want := range map[string]any{
+		"campaign_id":       float64(3456225),
+		"campaign_name":     "[SEA] Brand",
+		"group_id":          float64(115928034),
+		"keyword_id":        float64(2590421096),
+		"keyword_matchType": "phrase",
+		"query":             "kavovar deloni",
+	} {
+		if got := row[col]; got != want {
+			t.Errorf("%s = %v (%T), want %v", col, got, got, want)
+		}
+	}
+	if _, ok := row["date"]; !ok {
+		t.Error("date missing; the per-day stat was not merged in")
+	}
+}
+
+// search_queries must stay scoped to campaigns: an unrestricted
+// queries.createReport returns status 200 with an EMPTY report rather than an
+// error, which is indistinguishable from "this account has no search terms".
+func TestSearchQueriesIsCampaignScoped(t *testing.T) {
+	tc := supportedTables["search_queries"]
+	if !tc.scopeToCampaigns {
+		t.Fatal("search_queries lost scopeToCampaigns; the report will silently return 0 rows")
+	}
+	var hasKeywordID bool
+	for _, pk := range tc.primaryKeys {
+		if pk == "keyword_id" {
+			hasKeywordID = true
+		}
+	}
+	if !hasKeywordID {
+		t.Error("keyword_id dropped from the primary key; rows for the same query will overwrite each other")
+	}
+}
+
+// Every emitted row must carry the account it came from. Sklik's payloads have no
+// account field, so without the stamp rows from two accounts sharing a destination
+// table cannot be told apart.
+func TestEmitStampsAccountOnEveryRow(t *testing.T) {
+	s := &Source{accountID: 123456}
+	items := []map[string]any{
+		{"id": 527122, "name": "Rezervacni system"},
+		{"id": 855744, "name": "cz-anketa_GNR-FRE-EXT"},
+	}
+
+	ctx := context.Background()
+	results := make(chan source.RecordBatchResult, 1)
+	if err := s.emit(ctx, items, source.ReadOptions{}, results); err != nil {
+		t.Fatalf("emit: %v", err)
+	}
+
+	for i, row := range items {
+		got, ok := row[accountColumn]
+		if !ok {
+			t.Fatalf("row %d has no %s; it is unattributable once landed", i, accountColumn)
+		}
+		if got != "123456" {
+			t.Errorf("row %d %s = %v (%T), want the string \"123456\" so the seed join is String↔String", i, accountColumn, got, got)
+		}
+	}
+}
+
+// ⚠️ THE TRAP THIS LOCKS: each brand's CronJob passes only a token and no
+// user_id, so s.userID is 0 for all three. Resolving the account must therefore
+// consult client.get rather than echoing the configured value — echoing it would
+// stamp 0 on every brand and reproduce the original defect while looking fixed.
+func TestResolveAccountIDPrefersExplicitManagedAccount(t *testing.T) {
+	s := &Source{userID: 987}
+	if err := s.resolveAccountID(context.Background()); err != nil {
+		t.Fatalf("resolveAccountID: %v", err)
+	}
+	if s.accountID != 987 {
+		t.Errorf("accountID = %d, want the explicitly targeted managed account 987", s.accountID)
+	}
+
+	// With no user_id configured the account must come from client.get.
+	owner := &Source{client: stubClient(map[string]string{
+		"client.loginByToken": `{"status":200,"session":"s1"}`,
+		"client.get":          `{"status":200,"session":"s2","user":{"userId":555}}`,
+	})}
+	if err := owner.resolveAccountID(context.Background()); err != nil {
+		t.Fatalf("resolveAccountID via client.get: %v", err)
+	}
+	if owner.accountID != 555 {
+		t.Errorf("accountID = %d, want the token owner's 555 from client.get", owner.accountID)
+	}
+}
+
+// A client.get that yields no userId must fail the run. Stamping the zero value
+// instead would land rows that look attributed and are not — the exact failure
+// this column exists to prevent, made harder to spot.
+func TestResolveAccountIDRefusesZero(t *testing.T) {
+	s := &Source{client: stubClient(map[string]string{
+		"client.loginByToken": `{"status":200,"session":"s1"}`,
+		"client.get":          `{"status":200,"session":"s2","user":{}}`,
+	})}
+	err := s.resolveAccountID(context.Background())
+	if err == nil {
+		t.Fatal("resolveAccountID accepted a missing userId; rows would be stamped 0")
+	}
+	if s.accountID != 0 {
+		t.Errorf("accountID = %d, want it left unset after refusing", s.accountID)
+	}
+}
+
+// stubClient serves canned JSON per RPC method name (the last path segment),
+// so the real call/session path is exercised without touching the network.
+func stubClient(byMethod map[string]string) *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		parts := strings.Split(r.URL.Path, "/")
+		body, ok := byMethod[parts[len(parts)-1]]
+		if !ok {
+			body = `{"status":404,"statusMessage":"unstubbed method"}`
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// Regression lock for the "v0.2.1 trap" — see the comment on searchQueryColumns.
+func TestSearchQueryColumnsExcludeCTR(t *testing.T) {
+	for _, c := range searchQueryColumns {
+		if c == "ctr" {
+			t.Fatal("ctr is rejected by queries.readReport and 400s the entire report")
+		}
+	}
+}
+
+// The account is stamped on every row but is deliberately not in any primary key —
+// see the note on supportedTables. Primary keys become the destination's sort order
+// on several destinations, so adding it is a breaking change for existing tables
+// rather than a cleanup. This locks the choice so it is made on purpose.
+func TestAccountIsNotInPrimaryKeys(t *testing.T) {
+	for name, tc := range supportedTables {
+		for _, pk := range tc.primaryKeys {
+			if pk == accountColumn {
+				t.Errorf("%s has %s in its primary key %v — that changes the destination sort "+
+					"order and is a breaking change for existing tables. If that is intended, "+
+					"do it deliberately; if not, remove it.",
+					name, accountColumn, tc.primaryKeys)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds [Sklik](https://www.sklik.cz/) as a source. Sklik is the paid-search advertising
platform of Seznam.cz, the dominant search engine in Czechia — for Czech advertisers it
sits alongside Google Ads rather than behind it, and there is currently no way to get its
spend into a warehouse through ingestr.

The connector speaks Sklik's JSON-RPC API and exposes five entity snapshots plus two
report tables.

## Changes

- **`pkg/source/sklik/sklik.go`** — the source. Handles Sklik's session model
  (`client.loginByToken` returns a *rolling* session that changes on every response,
  including re-login when one expires mid-run), the `*.list` methods, and the
  asynchronous `createReport` / `readReport` pair.
- **`pkg/source/sklik/register.go`** — registers the `sklik` scheme.
- **`pkg/source/sklik/sklik_test.go`** — covers report flattening, the account stamp,
  and a lock-in test for the primary-key choice.
- **`internal/server/connectors.go`** — catalog entry.
- **`docs/supported-sources/sklik.md`**, **`docs/.vitepress/config.mjs`**,
  **`docs/supported-sources/platforms.md`** — docs page and both indexes.

### Tables

| Table | Primary key | Incremental | Strategy |
|---|---|---|---|
| `campaigns`, `groups`, `ads`, `keywords`, `conversions` | `id` | — | merge |
| `campaign_stats_daily` | `id`, `date` | `date` | merge |
| `search_queries` | `query`, `keyword_id`, `date` | `date` | merge |

`search_queries` keys on `keyword_id` as well as `(query, date)` because Sklik reports
the same search term once per matching keyword; without it the merge keeps one arbitrary
keyword's row per query and silently drops the rest of the spend.

### Three Sklik API behaviours worth knowing about

These are the reason several parts of the code look defensive, so flagging them for review:

1. **Throttling degrades to an empty HTTP 200, not a 429.** Sklik rate-limits per account
   per minute, and over the limit a report returns
   `{"status":200,"statusMessage":"OK","report":[]}`. A throttled report and a genuinely
   empty one are byte-identical, so a run can quietly load nothing and look healthy. The
   only reliable signal is `createReport`'s `totalCount`: the source retries with a linear
   backoff while it promises rows the read has not produced, and the retry loop only
   engages in that case — a healthy report never sleeps.
2. **`queries.createReport` returns empty unless scoped.** Without a campaign/group/keyword
   restriction it yields `report: []` with `status: 200`, which reads as "this account has
   no search terms". On a live account: unrestricted → 0 rows; restricted to one campaign
   over the same window → 165. `campaigns.createReport` does not behave this way, so a
   working campaign report proves nothing about the search-term one.
3. **`displayColumns` enums are per-method and asymmetric.** `ctr` is accepted by
   `campaigns.readReport` and rejected by `queries.readReport`, and Sklik answers with a
   bare `400 Bad arguments` for the whole report with no field-level detail. `ctr` is
   therefore deliberately absent from the search-query columns.

All three are documented in the docs page and in comments at the relevant code.

## How to test

```bash
ingestr ingest \
  --source-uri 'sklik://?token=<api_token>' \
  --source-table campaigns \
  --dest-uri duckdb:///sklik.duckdb \
  --dest-table main.campaigns
```

Report tables take `--interval-start` / `--interval-end`. A Sklik account with an API
token is needed; the token is generated in the Sklik UI.

`go test ./pkg/source/sklik/` covers the pure logic without network access.

## Risk & rollback

- **Risk:** low. Purely additive — one new package, one catalog line, three docs files.
  No existing source, destination or shared code path is touched, so nothing can regress
  for current users.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format-ci`, `make lint` — 0 issues)
- [x] Integration tests pass if affected — not affected; no shared code path is touched
- [x] No unrelated changes included
- [x] Tested locally against a live Sklik account

## Security

- [x] No secrets, credentials, or PII in this change — the token is supplied via the URI
      and never logged
- [x] No new dependencies with known vulnerabilities — no new dependencies at all
- [x] Security implications considered

## Related issues

None found.
