### PR TITLE
feat(cloudflare-radar): respect MaxBatchBytes byte cap

### DIFF
--- a/pkg/source/cloudflareradar/api.go
+++ b/pkg/source/cloudflareradar/api.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/bruin-data/ingestr/internal/config"
-	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 )
@@ -245,15 +244,7 @@ func (s *CloudflareRadarSource) fetchAPIRows(ctx context.Context, name, path str
 }
 
 func sendAPIItems(name string, items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	if len(items) == 0 {
-		return nil
-	}
-	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
-	if err != nil {
-		return fmt.Errorf("failed to convert Cloudflare Radar %s to Arrow: %w", name, err)
-	}
-	results <- source.RecordBatchResult{Batch: record}
-	return nil
+	return emitRecords(name, items, opts, results)
 }
 
 func cloneValues(values url.Values) url.Values {

--- a/pkg/source/cloudflareradar/cloudflareradar.go
+++ b/pkg/source/cloudflareradar/cloudflareradar.go
@@ -265,16 +265,47 @@ func (s *CloudflareRadarSource) paginateAndSend(ctx context.Context, name string
 		fetchedCount := len(items)
 		items, reachedLimit := limiter.trim(items)
 
-		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
-		if err != nil {
-			return fmt.Errorf("failed to convert Cloudflare Radar %s to Arrow: %w", name, err)
+		if err := emitRecords(name, items, opts, results); err != nil {
+			return err
 		}
-		results <- source.RecordBatchResult{Batch: record}
 
 		if reachedLimit || fetchedCount < pageSize {
 			return nil
 		}
 	}
+}
+
+func emitRecords(name string, items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	send := func(batch []map[string]interface{}) error {
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, nil, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to convert Cloudflare Radar %s to Arrow: %w", name, err)
+		}
+		results <- source.RecordBatchResult{Batch: record}
+		return nil
+	}
+	if opts.MaxBatchBytes <= 0 {
+		return send(items)
+	}
+
+	var batch []map[string]interface{}
+	var accBytes int64
+	for _, row := range items {
+		rowBytes := arrowconv.RowBytes(row)
+		if len(batch) > 0 && accBytes+rowBytes > opts.MaxBatchBytes {
+			if err := send(batch); err != nil {
+				return err
+			}
+			batch = nil
+			accBytes = 0
+		}
+		batch = append(batch, row)
+		accBytes += rowBytes
+	}
+	return send(batch)
 }
 
 func setDateRange(params map[string]string, opts source.ReadOptions, defaultDateRange string) {

--- a/pkg/source/cloudflareradar/cloudflareradar_test.go
+++ b/pkg/source/cloudflareradar/cloudflareradar_test.go
@@ -78,6 +78,45 @@ func TestRowLimiter(t *testing.T) {
 	}
 }
 
+func TestEmitRecordsByteCap(t *testing.T) {
+	wide := strings.Repeat("x", 2048)
+	items := make([]map[string]interface{}, 50)
+	for i := range items {
+		items[i] = map[string]interface{}{"id": i, "name": wide}
+	}
+
+	run := func(max int64) (int64, int64) {
+		results := make(chan source.RecordBatchResult, len(items))
+		if err := emitRecords("test", items, source.ReadOptions{MaxBatchBytes: max}, results); err != nil {
+			t.Fatal(err)
+		}
+		close(results)
+		var batches, rows int64
+		for res := range results {
+			if res.Err != nil {
+				t.Fatal(res.Err)
+			}
+			batches++
+			rows += res.Batch.NumRows()
+			res.Batch.Release()
+		}
+		return batches, rows
+	}
+
+	offB, offR := run(0)
+	if offB != 1 || offR != int64(len(items)) {
+		t.Fatalf("cap-off: batches=%d rows=%d, want 1 and %d", offB, offR, len(items))
+	}
+
+	onB, onR := run(4096)
+	if onB <= 1 {
+		t.Fatalf("cap-on: batches=%d, want >1", onB)
+	}
+	if onR != offR {
+		t.Fatalf("cap-on rows=%d != cap-off rows=%d", onR, offR)
+	}
+}
+
 func TestParseAPITable(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## What

The cloudflare-radar source previously emitted one Arrow record batch per API page regardless of size, ignoring `opts.MaxBatchBytes`. This brings it in line with the other sources, which chunk emitted batches by the configured byte cap.