### PR TITLE
feat: add Vertica destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,12 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Vertica</td>
+        <td>-</td>
+        <td>✅</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>Vitess</td>
         <td>✅</td>
         <td>✅</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -167,6 +167,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Socrata", link: "/supported-sources/socrata.md" },
               { text: "SQLite", link: "/supported-sources/sqlite.md" },
               { text: "StarRocks", link: "/supported-sources/starrocks.md" },
+              { text: "Vertica", link: "/supported-sources/vertica.md" },
               { text: "Vitess", link: "/supported-sources/vitess.md" },
               {
                 text: "Experimental",

--- a/docs/supported-sources/vertica.md
+++ b/docs/supported-sources/vertica.md
@@ -1,0 +1,77 @@
+# Vertica
+
+[Vertica](https://www.vertica.com/) is a columnar, massively parallel processing (MPP) analytical database built for large-scale analytics, available on-premises, in the cloud, and as a free Community Edition.
+
+ingestr supports Vertica as a destination.
+
+## URI format
+The URI format for Vertica is as follows:
+
+```plaintext
+vertica://<username>:<password>@<host>:<port>/<database>
+```
+
+URI parameters:
+- `username`: the Vertica user (required)
+- `password`: the password for the user
+- `host`: the Vertica hostname or IP address
+- `port`: the Vertica port (default: `5433`)
+- `database`: the database to write into
+
+The following optional connection settings can be passed as query parameters:
+
+- `tlsmode`: TLS behavior — `none` (default, plaintext), `prefer` (TLS if the server supports it), `server` (TLS with CA verification), or `server-strict` (also verifies the hostname). Use `tlsmode=server` or `tlsmode=server-strict` over untrusted networks.
+- `autocommit`: `1` to enable (default) or `0` to disable autocommit.
+- `use_prepared_statements`: `1` to use server-side prepared statements (default) or `0` to disable them.
+- `connection_load_balance`: `1` to let the server redirect the connection across nodes for load balancing (off by default).
+- `backup_server_node`: a comma-separated list of `host:port` pairs to fail over to if the primary host is unreachable.
+
+```plaintext
+vertica://user:pass@host:5433/analytics?tlsmode=server-strict&connection_load_balance=1
+```
+
+## Table naming
+Vertica organizes tables as `schema.table`. You can specify the destination table in either of these forms:
+
+```plaintext
+table            # created in the connection's current schema (usually "public")
+schema.table     # fully qualified
+```
+
+The schema is created automatically if it does not already exist.
+
+## Setting Vertica as a destination
+
+Use the `--dest-uri` and `--dest-table` flags to load data into Vertica:
+
+```bash
+ingestr ingest \
+    --source-uri 'postgres://user:pass@localhost:5432/analytics' \
+    --source-table 'public.users' \
+    --dest-uri 'vertica://dbadmin:pass@localhost:5433/VMart' \
+    --dest-table 'public.users'
+```
+
+## Supported strategies
+Vertica supports the following load strategies:
+
+- `replace` (default): stages the data and atomically swaps it into the target table
+- `append`: inserts the incoming rows into the target table
+- `merge`: upserts rows by primary key using a `MERGE` statement
+- `delete+insert`: replaces rows in the incremental window and inserts the new rows
+
+Primary keys are required for the `merge` strategy.
+
+## Testing locally
+
+Vertica offers a free Community Edition Docker image you can use to try ingestr:
+
+```bash
+docker run -d -p 5433:5433 -p 5444:5444 --name vertica-ce vertica/vertica-ce:12.0.4-0
+```
+
+The Community Edition starts with the `VMart` database and the `dbadmin` user (no password), so the destination URI is:
+
+```plaintext
+vertica://dbadmin@localhost:5433/VMart
+```

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/redpanda v0.42.0
 	github.com/trinodb/trino-go-client v0.333.0
 	github.com/urfave/cli/v3 v3.0.0-beta1
+	github.com/vertica/vertica-sql-go v1.3.8
 	github.com/xuri/excelize/v2 v2.11.0
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78
 	go.mongodb.org/mongo-driver v1.17.7
@@ -229,6 +230,8 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.7.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
+	github.com/elastic/go-sysinfo v1.8.1 // indirect
+	github.com/elastic/go-windows v1.0.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
@@ -284,6 +287,7 @@ require (
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.4.0 // indirect
 	github.com/kr/fs v0.1.0 // indirect
@@ -427,6 +431,7 @@ require (
 	gopkg.in/DataDog/dd-trace-go.v1 v1.74.6 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
 	k8s.io/apimachinery v0.35.1 // indirect
 	k8s.io/client-go v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1050,6 +1050,10 @@ github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203 h1:XBBHcIb256gUJ
 github.com/eiannone/keyboard v0.0.0-20220611211555-0d226195f203/go.mod h1:E1jcSv8FaEny+OP/5k9UxZVw9YFWGj7eI4KR/iOBqCg=
 github.com/elastic/elastic-transport-go/v8 v8.8.0 h1:7k1Ua+qluFr6p1jfJjGDl97ssJS/P7cHNInzfxgBQAo=
 github.com/elastic/elastic-transport-go/v8 v8.8.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
+github.com/elastic/go-sysinfo v1.8.1 h1:4Yhj+HdV6WjbCRgGdZpPJ8lZQlXZLKDAeIkmQ/VRvi4=
+github.com/elastic/go-sysinfo v1.8.1/go.mod h1:JfllUnzoQV/JRYymbH3dO1yggI3mV2oTKSXsDHM+uIM=
+github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=
+github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -1398,8 +1402,11 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 h1:rp+c0RAYOWj8l6qbCUTSiRLG/iKnW3K3/QfPPuSsBt4=
+github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=
@@ -1851,6 +1858,8 @@ github.com/uptrace/bun/extra/bundebug v1.2.18 h1:5cgkqdvhpSHIEONazSytm4RWYFneNtc
 github.com/uptrace/bun/extra/bundebug v1.2.18/go.mod h1:M+U9YJVJcmk0RrszCb2Q1oskJiJ0LuC44FxDhZLP1ws=
 github.com/urfave/cli/v3 v3.0.0-beta1 h1:6DTaaUarcM0wX7qj5Hcvs+5Dm3dyUTBbEwIWAjcw9Zg=
 github.com/urfave/cli/v3 v3.0.0-beta1/go.mod h1:FnIeEMYu+ko8zP1F9Ypr3xkZMIDqW3DR92yUtY39q1Y=
+github.com/vertica/vertica-sql-go v1.3.8 h1:FomjkM3cam9yE6zSic31flNWPLdsZbYGK9ihlLtbF1Y=
+github.com/vertica/vertica-sql-go v1.3.8/go.mod h1:c4OZ8lq1Ztc18w8a0nG+dzQh69BzJRcKN2LZOnYbERI=
 github.com/vmihailenco/msgpack/v4 v4.3.13 h1:A2wsiTbvp63ilDaWmsk2wjx6xZdxQOvpiNlKBGKKXKI=
 github.com/vmihailenco/msgpack/v4 v4.3.13/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
@@ -2737,6 +2746,7 @@ gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -2756,6 +2766,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+howett.net/plist v0.0.0-20181124034731-591f970eefbb h1:jhnBjNi9UFpfpl8YZhA9CrOqpnJdvzuiHsl/dnxl11M=
+howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 k8s.io/apimachinery v0.35.1 h1:yxO6gV555P1YV0SANtnTjXYfiivaTPvCTKX6w6qdDsU=
 k8s.io/apimachinery v0.35.1/go.mod h1:jQCgFZFR1F4Ik7hvr2g84RTJSZegBc8yHgFWKn//hns=
 k8s.io/client-go v0.32.3 h1:RKPVltzopkSgHS7aS98QdscAgtgah/+zmpAogooIqVU=

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -411,6 +411,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("trustpilot", "Trustpilot", []string{"trustpilot"}, true, false),
 		genericURIConnector("twilio", "Twilio", []string{"twilio"}, true, false),
 		genericURIConnector("typeform", "Typeform", []string{"typeform"}, true, false),
+		genericURIConnector("vertica", "Vertica", []string{"vertica"}, false, true),
 		genericURIConnector("wise", "Wise", []string{"wise"}, true, false),
 		genericURIConnector("wistia", "Wistia", []string{"wistia"}, true, false),
 		genericURIConnector("zendesk", "Zendesk", []string{"zendesk"}, true, false),

--- a/licenses.lock.yml
+++ b/licenses.lock.yml
@@ -779,6 +779,11 @@ dependencies:
       licenses:
         - Apache-2.0
       status: allowed
+    - module: github.com/elastic/go-sysinfo
+      version: v1.8.1
+      licenses:
+        - Apache-2.0
+      status: allowed
     - module: github.com/emirpasic/gods
       version: v1.18.1
       licenses:
@@ -1098,6 +1103,11 @@ dependencies:
       status: allowed
     - module: github.com/jinzhu/inflection
       version: v1.0.0
+      licenses:
+        - MIT
+      status: allowed
+    - module: github.com/joeshaw/multierror
+      version: v0.0.0-20140124173710-69b34d4ec901
       licenses:
         - MIT
       status: allowed
@@ -1691,6 +1701,11 @@ dependencies:
       licenses:
         - MIT
       status: allowed
+    - module: github.com/vertica/vertica-sql-go
+      version: v1.3.8
+      licenses:
+        - Apache-2.0
+      status: allowed
     - module: github.com/vmihailenco/msgpack/v5
       version: v5.4.1
       licenses:
@@ -1975,6 +1990,11 @@ dependencies:
       version: v3.0.1
       licenses:
         - MIT
+      status: allowed
+    - module: howett.net/plist
+      version: v0.0.0-20181124034731-591f970eefbb
+      licenses:
+        - BSD-2-Clause
       status: allowed
     - module: k8s.io/apimachinery
       version: v0.35.1

--- a/pkg/destination/interface_compliance_test.go
+++ b/pkg/destination/interface_compliance_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination/sqlite"
 	"github.com/bruin-data/ingestr/pkg/destination/synapse"
 	"github.com/bruin-data/ingestr/pkg/destination/trino"
+	"github.com/bruin-data/ingestr/pkg/destination/vertica"
 	"github.com/bruin-data/ingestr/pkg/destination/vitess"
 )
 
@@ -196,6 +197,7 @@ var (
 	_ destination.Destination = (*sqlite.SQLiteDestination)(nil)
 	_ destination.Destination = (*synapse.SynapseDestination)(nil)
 	_ destination.Destination = (*trino.TrinoDestination)(nil)
+	_ destination.Destination = (*vertica.VerticaDestination)(nil)
 )
 
 // Optional strategy interfaces the Iceberg destination implements natively.

--- a/pkg/destination/vertica/helpers.go
+++ b/pkg/destination/vertica/helpers.go
@@ -1,0 +1,210 @@
+package vertica
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// COPY FROM STDIN control bytes. They are unlikely to appear in real data, and
+// any that do are escaped, so embedded delimiters, terminators, and the NULL
+// marker survive the round trip. NULL is distinguished from the empty string.
+const (
+	copyDelimiter  = 0x01
+	copyRecordTerm = 0x02
+	copyNull       = 0x03
+	copyEscape     = 0x04
+)
+
+func quoteColumn(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+func quoteColumns(names []string) []string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = quoteColumn(n)
+	}
+	return out
+}
+
+// splitSchemaTable splits a possibly schema-qualified name into its schema and
+// table parts. An unqualified name returns an empty schema.
+func splitSchemaTable(table string) (string, string) {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", table
+}
+
+func quoteTable(table string) string {
+	schemaName, name := splitSchemaTable(table)
+	if schemaName != "" {
+		return quoteColumn(schemaName) + "." + quoteColumn(name)
+	}
+	return quoteColumn(name)
+}
+
+// filterColumns returns the columns not present in exclude (case-insensitive).
+func filterColumns(columns []string, exclude []string) []string {
+	excludeSet := make(map[string]struct{}, len(exclude))
+	for _, c := range exclude {
+		excludeSet[strings.ToLower(c)] = struct{}{}
+	}
+	out := make([]string, 0, len(columns))
+	for _, c := range columns {
+		if _, ok := excludeSet[strings.ToLower(c)]; !ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func sourceColumnRefs(columns []string, alias string) []string {
+	out := make([]string, len(columns))
+	for i, c := range columns {
+		out[i] = alias + "." + quoteColumn(c)
+	}
+	return out
+}
+
+func buildJoinCondition(keys []string, targetAlias, sourceAlias string) string {
+	conditions := make([]string, len(keys))
+	for i, k := range keys {
+		conditions[i] = fmt.Sprintf("%s.%s = %s.%s", targetAlias, quoteColumn(k), sourceAlias, quoteColumn(k))
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+// buildUpdateSet renders the SET clause for a MERGE. Vertica rejects a target
+// alias on the assigned column, so the left-hand side is left unqualified.
+func buildUpdateSet(columns []string, sourceAlias string) string {
+	sets := make([]string, len(columns))
+	for i, c := range columns {
+		sets[i] = fmt.Sprintf("%s = %s.%s", quoteColumn(c), sourceAlias, quoteColumn(c))
+	}
+	return strings.Join(sets, ", ")
+}
+
+// appendCopyValue encodes one Arrow value into the COPY FROM STDIN stream,
+// writing the NULL marker for nulls and escaping any control bytes otherwise.
+func appendCopyValue(buf *bytes.Buffer, arr arrow.Array, idx int) {
+	if arr.IsNull(idx) {
+		buf.WriteByte(copyNull)
+		return
+	}
+
+	switch a := arr.(type) {
+	case *array.Boolean:
+		if a.Value(idx) {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case *array.Int8:
+		writeCopyString(buf, strconv.FormatInt(int64(a.Value(idx)), 10))
+	case *array.Int16:
+		writeCopyString(buf, strconv.FormatInt(int64(a.Value(idx)), 10))
+	case *array.Int32:
+		writeCopyString(buf, strconv.FormatInt(int64(a.Value(idx)), 10))
+	case *array.Int64:
+		writeCopyString(buf, strconv.FormatInt(a.Value(idx), 10))
+	case *array.Uint8:
+		writeCopyString(buf, strconv.FormatUint(uint64(a.Value(idx)), 10))
+	case *array.Uint16:
+		writeCopyString(buf, strconv.FormatUint(uint64(a.Value(idx)), 10))
+	case *array.Uint32:
+		writeCopyString(buf, strconv.FormatUint(uint64(a.Value(idx)), 10))
+	case *array.Uint64:
+		writeCopyString(buf, strconv.FormatUint(a.Value(idx), 10))
+	case *array.Float32:
+		writeCopyString(buf, strconv.FormatFloat(float64(a.Value(idx)), 'g', -1, 32))
+	case *array.Float64:
+		writeCopyString(buf, strconv.FormatFloat(a.Value(idx), 'g', -1, 64))
+	case *array.String:
+		writeCopyString(buf, a.Value(idx))
+	case *array.LargeString:
+		writeCopyString(buf, a.Value(idx))
+	case *array.Binary:
+		writeCopyBytes(buf, a.Value(idx))
+	case *array.LargeBinary:
+		writeCopyBytes(buf, a.Value(idx))
+	case *array.Date32:
+		writeCopyString(buf, a.Value(idx).ToTime().Format("2006-01-02"))
+	case *array.Date64:
+		writeCopyString(buf, a.Value(idx).ToTime().Format("2006-01-02"))
+	case *array.Time64:
+		micros := int64(a.Value(idx))
+		if a.DataType().(*arrow.Time64Type).Unit == arrow.Nanosecond {
+			micros /= 1_000
+		}
+		secs := micros / 1_000_000
+		writeCopyString(buf, fmt.Sprintf("%02d:%02d:%02d.%06d", secs/3600, (secs%3600)/60, secs%60, micros%1_000_000))
+	case *array.Timestamp:
+		t := a.Value(idx).ToTime(a.DataType().(*arrow.TimestampType).Unit).UTC()
+		writeCopyString(buf, t.Format("2006-01-02 15:04:05.000000-07:00"))
+	case *array.Decimal128:
+		writeCopyString(buf, a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale)))
+	case *array.Decimal256:
+		writeCopyString(buf, a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale)))
+	case array.ExtensionArray:
+		appendCopyValue(buf, a.Storage(), idx)
+	case *array.MonthInterval:
+		writeCopyString(buf, formatISOInterval(int64(a.Value(idx)), 0, 0))
+	case *array.DayTimeInterval:
+		v := a.Value(idx)
+		writeCopyString(buf, formatISOInterval(0, int64(v.Days), int64(v.Milliseconds)*1_000_000))
+	case *array.MonthDayNanoInterval:
+		v := a.Value(idx)
+		writeCopyString(buf, formatISOInterval(int64(v.Months), int64(v.Days), v.Nanoseconds))
+	case *array.List, *array.LargeList, *array.Map, *array.Struct:
+		writeCopyString(buf, marshalArrowJSON(arr, idx))
+	default:
+		writeCopyString(buf, arr.ValueStr(idx))
+	}
+}
+
+// formatISOInterval renders an interval as an ISO 8601 duration so it survives
+// as a portable, parseable string in Vertica's text-typed interval column.
+func formatISOInterval(months, days, nanos int64) string {
+	var b strings.Builder
+	b.WriteByte('P')
+	if months != 0 {
+		fmt.Fprintf(&b, "%dM", months)
+	}
+	if days != 0 {
+		fmt.Fprintf(&b, "%dD", days)
+	}
+	if nanos != 0 || (months == 0 && days == 0) {
+		secs := float64(nanos) / 1e9
+		fmt.Fprintf(&b, "T%gS", secs)
+	}
+	return b.String()
+}
+
+func marshalArrowJSON(arr arrow.Array, idx int) string {
+	data, err := json.Marshal(arr.GetOneForMarshal(idx))
+	if err != nil {
+		return arr.ValueStr(idx)
+	}
+	return string(data)
+}
+
+func writeCopyString(buf *bytes.Buffer, s string) {
+	writeCopyBytes(buf, []byte(s))
+}
+
+func writeCopyBytes(buf *bytes.Buffer, b []byte) {
+	for _, c := range b {
+		if c >= copyDelimiter && c <= copyEscape {
+			buf.WriteByte(copyEscape)
+		}
+		buf.WriteByte(c)
+	}
+}

--- a/pkg/destination/vertica/mapper.go
+++ b/pkg/destination/vertica/mapper.go
@@ -1,0 +1,113 @@
+package vertica
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+const (
+	maxVarcharLength   = 65000
+	maxNumericPrecison = 1024
+)
+
+// MapDataTypeToVertica maps an internal schema.Column to a Vertica DDL type.
+// isKey requests a bounded, key-eligible type for primary/merge-key columns
+// (Vertica cannot use LONG VARCHAR / LONG VARBINARY columns as keys).
+func MapDataTypeToVertica(col schema.Column, isKey bool) string {
+	switch col.DataType {
+	case schema.TypeBoolean:
+		return "BOOLEAN"
+	case schema.TypeInt8, schema.TypeInt16, schema.TypeInt32, schema.TypeInt64:
+		// Every Vertica integer type is a 64-bit signed INT.
+		return "INT"
+	case schema.TypeFloat32, schema.TypeFloat64:
+		// Vertica has a single 64-bit floating point type.
+		return "FLOAT"
+	case schema.TypeDecimal:
+		precision := col.Precision
+		scale := col.Scale
+		if precision <= 0 {
+			precision, scale = 38, 9
+		}
+		if precision > maxNumericPrecison {
+			precision = maxNumericPrecison
+		}
+		if scale < 0 {
+			scale = 0
+		}
+		if scale > precision {
+			scale = precision
+		}
+		return fmt.Sprintf("NUMERIC(%d, %d)", precision, scale)
+	case schema.TypeString, schema.TypeUUID, schema.TypeInterval:
+		if col.MaxLength > 0 && col.MaxLength <= maxVarcharLength {
+			return fmt.Sprintf("VARCHAR(%d)", col.MaxLength)
+		}
+		if isKey {
+			return fmt.Sprintf("VARCHAR(%d)", maxVarcharLength)
+		}
+		return "LONG VARCHAR"
+	case schema.TypeBinary:
+		if isKey {
+			return fmt.Sprintf("VARBINARY(%d)", maxVarcharLength)
+		}
+		return "LONG VARBINARY"
+	case schema.TypeDate:
+		return "DATE"
+	case schema.TypeTime:
+		return "TIME"
+	case schema.TypeTimestamp:
+		return "TIMESTAMP"
+	case schema.TypeTimestampTZ:
+		return "TIMESTAMPTZ"
+	case schema.TypeJSON, schema.TypeArray:
+		// Vertica has no scalar JSON type; carry serialized JSON as text.
+		return "LONG VARCHAR"
+	default:
+		if isKey {
+			return fmt.Sprintf("VARCHAR(%d)", maxVarcharLength)
+		}
+		return "LONG VARCHAR"
+	}
+}
+
+// mapVerticaTypeToSchema maps a Vertica catalog data type to the internal type
+// system. The catalog reports lengths inline (e.g. "varchar(65000)"), so only
+// the leading type name is significant.
+func mapVerticaTypeToSchema(dataType string) schema.DataType {
+	base := strings.ToLower(strings.TrimSpace(dataType))
+	if idx := strings.IndexByte(base, '('); idx >= 0 {
+		base = strings.TrimSpace(base[:idx])
+	}
+	switch base {
+	case "boolean":
+		return schema.TypeBoolean
+	case "int", "integer", "bigint", "int8", "smallint", "tinyint":
+		return schema.TypeInt64
+	case "float", "float8", "double precision", "real":
+		return schema.TypeFloat64
+	case "numeric", "decimal", "number", "money":
+		return schema.TypeDecimal
+	case "char", "varchar", "long varchar":
+		return schema.TypeString
+	case "binary", "varbinary", "long varbinary", "bytea", "raw":
+		return schema.TypeBinary
+	case "uuid":
+		return schema.TypeString
+	case "date":
+		return schema.TypeDate
+	case "time", "timetz", "time with timezone":
+		return schema.TypeTime
+	case "timestamp":
+		return schema.TypeTimestamp
+	case "timestamptz", "timestamp with timezone":
+		return schema.TypeTimestampTZ
+	default:
+		if strings.HasPrefix(base, "interval") {
+			return schema.TypeString
+		}
+		return schema.TypeString
+	}
+}

--- a/pkg/destination/vertica/register.go
+++ b/pkg/destination/vertica/register.go
@@ -1,0 +1,10 @@
+package vertica
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterDestination(
+		[]string{"vertica"},
+		func() interface{} { return NewVerticaDestination() },
+	)
+}

--- a/pkg/destination/vertica/vertica.go
+++ b/pkg/destination/vertica/vertica.go
@@ -271,7 +271,10 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 
 	// Vertica renames multiple tables atomically in one statement, so target and
 	// staging are swapped in a single step and the displaced target is dropped.
-	oldName := destination.ShortenIdentifier(targetName+"_old", targetName+"_old", destination.MaxIdentifierLength("vertica"))
+	oldName, err := d.freeOldName(ctx, targetSchema, targetName)
+	if err != nil {
+		return err
+	}
 	swapSQL := fmt.Sprintf("ALTER TABLE %s, %s RENAME TO %s, %s",
 		quoteTable(targetTable), quoteTable(stagingTable), quoteColumn(oldName), quoteColumn(targetName))
 	if _, err := d.db.ExecContext(ctx, swapSQL); err != nil {
@@ -287,6 +290,32 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 		config.Debug("[VERTICA] Warning: failed to drop old table %s after swap: %v", oldTable, err)
 	}
 	return nil
+}
+
+// freeOldName returns a table name in targetSchema not currently occupied, used
+// as the transient landing spot for the displaced target during an atomic swap.
+// A leftover "<target>_old" from a crashed prior swap (or a real user table)
+// would otherwise make the rename collide and leave the load unpublished.
+func (d *VerticaDestination) freeOldName(ctx context.Context, targetSchema, targetName string) (string, error) {
+	maxLen := destination.MaxIdentifierLength("vertica")
+	for i := 0; ; i++ {
+		base := targetName + "_old"
+		if i > 0 {
+			base = fmt.Sprintf("%s_old_%d", targetName, i+1)
+		}
+		name := destination.ShortenIdentifier(base, base, maxLen)
+		qualified := name
+		if targetSchema != "" {
+			qualified = targetSchema + "." + name
+		}
+		exists, err := d.tableExists(ctx, qualified)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			return name, nil
+		}
+	}
 }
 
 // copySwapTable handles a swap where staging lives in a different schema (Vertica

--- a/pkg/destination/vertica/vertica.go
+++ b/pkg/destination/vertica/vertica.go
@@ -96,7 +96,7 @@ func (d *VerticaDestination) PrepareTable(ctx context.Context, opts destination.
 		return nil
 	}
 
-	createSQL := buildCreateTableSQL(opts.Table, opts.Schema, opts.PrimaryKeys)
+	createSQL := buildCreateTableSQL(opts.Table, opts.Schema, opts.PrimaryKeys, true)
 	if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
 		config.LogFailedQuery(createSQL, err)
 		return fmt.Errorf("failed to create table: %w", err)
@@ -300,19 +300,29 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 	return nil
 }
 
+// maxTransientNameAttempts bounds the search for a free swap-time table name so a
+// pathological schema full of colliding names cannot loop forever.
+const maxTransientNameAttempts = 1000
+
+// transientCandidate renders the i-th candidate name derived from base.
+func transientCandidate(base string, i int) string {
+	candidate := base
+	if i > 0 {
+		candidate = fmt.Sprintf("%s_%d", base, i+1)
+	}
+	return destination.ShortenIdentifier(candidate, candidate, destination.MaxIdentifierLength("vertica"))
+}
+
 // freeTransientName returns a name in schemaName that no table currently
 // occupies, derived from base with a numeric suffix on collision. It never drops
 // an existing table, so an unrelated table sharing the base name is stepped over
 // rather than destroyed. base comes from the run-unique staging name, so
-// concurrent jobs never probe the same candidates.
+// concurrent jobs never probe the same candidates. The caller must consume the
+// name atomically (an ALTER ... RENAME fails rather than reusing a table), since
+// this only reflects existence at probe time.
 func (d *VerticaDestination) freeTransientName(ctx context.Context, schemaName, base string) (string, error) {
-	maxLen := destination.MaxIdentifierLength("vertica")
-	for i := 0; ; i++ {
-		candidate := base
-		if i > 0 {
-			candidate = fmt.Sprintf("%s_%d", base, i+1)
-		}
-		name := destination.ShortenIdentifier(candidate, candidate, maxLen)
+	for i := 0; i < maxTransientNameAttempts; i++ {
+		name := transientCandidate(base, i)
 		qualified := name
 		if schemaName != "" {
 			qualified = schemaName + "." + name
@@ -325,6 +335,33 @@ func (d *VerticaDestination) freeTransientName(ctx context.Context, schemaName, 
 			return name, nil
 		}
 	}
+	return "", fmt.Errorf("could not allocate a free transient table name for %s", base)
+}
+
+// createTransientTable strictly creates a table (no IF NOT EXISTS) under a free
+// name derived from base, advancing past names already taken. The strict create
+// makes claiming the name atomic, so the returned table is always one this call
+// created — later writes and drops can never touch an unrelated table.
+func (d *VerticaDestination) createTransientTable(ctx context.Context, schemaName, base string, tableSchema *schema.TableSchema, primaryKeys []string) (string, error) {
+	for i := 0; i < maxTransientNameAttempts; i++ {
+		name := transientCandidate(base, i)
+		qualified := name
+		if schemaName != "" {
+			qualified = schemaName + "." + name
+		}
+		createSQL := buildCreateTableSQL(qualified, tableSchema, primaryKeys, false)
+		if _, err := d.db.ExecContext(ctx, createSQL); err == nil {
+			return qualified, nil
+		}
+		exists, existsErr := d.tableExists(ctx, qualified)
+		if existsErr != nil {
+			return "", existsErr
+		}
+		if !exists {
+			return "", fmt.Errorf("failed to create transient table %s", qualified)
+		}
+	}
+	return "", fmt.Errorf("could not allocate a free transient table name for %s", base)
 }
 
 // copySwapTable handles a swap where staging lives in a different schema (Vertica
@@ -338,22 +375,12 @@ func (d *VerticaDestination) copySwapTable(ctx context.Context, opts destination
 	targetSchema, _ := splitSchemaTable(opts.TargetTable)
 	_, stagingName := splitSchemaTable(opts.StagingTable)
 
-	// Probe for a free temp name instead of dropping whatever holds the staging
-	// basename in the target schema, so an unrelated table is never destroyed.
-	tempName, err := d.freeTransientName(ctx, targetSchema, stagingName)
+	// Strictly create the temp landing table under a free name rather than probing
+	// then PrepareTable's CREATE ... IF NOT EXISTS, which would silently reuse a
+	// table that appeared after the probe. The strict create claims the name
+	// atomically, so the copy and any cleanup only ever touch a table we created.
+	tempTable, err := d.createTransientTable(ctx, targetSchema, stagingName, opts.Schema, opts.PrimaryKeys)
 	if err != nil {
-		return err
-	}
-	tempTable := tempName
-	if targetSchema != "" {
-		tempTable = targetSchema + "." + tempName
-	}
-
-	if err := d.PrepareTable(ctx, destination.PrepareOptions{
-		Table:       tempTable,
-		Schema:      opts.Schema,
-		PrimaryKeys: opts.PrimaryKeys,
-	}); err != nil {
 		return err
 	}
 
@@ -640,7 +667,7 @@ func (d *VerticaDestination) sameSchema(left, right string) bool {
 	return resolve(left) == resolve(right)
 }
 
-func buildCreateTableSQL(table string, tableSchema *schema.TableSchema, primaryKeys []string) string {
+func buildCreateTableSQL(table string, tableSchema *schema.TableSchema, primaryKeys []string, ifNotExists bool) string {
 	pkSet := make(map[string]bool, len(primaryKeys))
 	for _, k := range primaryKeys {
 		pkSet[strings.ToLower(k)] = true
@@ -659,7 +686,11 @@ func buildCreateTableSQL(table string, tableSchema *schema.TableSchema, primaryK
 		colDefs = append(colDefs, fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(quoteColumns(primaryKeys), ", ")))
 	}
 
-	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)", quoteTable(table), strings.Join(colDefs, ",\n  "))
+	ifNotExistsClause := ""
+	if ifNotExists {
+		ifNotExistsClause = "IF NOT EXISTS "
+	}
+	return fmt.Sprintf("CREATE TABLE %s%s (\n  %s\n)", ifNotExistsClause, quoteTable(table), strings.Join(colDefs, ",\n  "))
 }
 
 func (d *VerticaDestination) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {

--- a/pkg/destination/vertica/vertica.go
+++ b/pkg/destination/vertica/vertica.go
@@ -1,0 +1,642 @@
+package vertica
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablename"
+	vertigo "github.com/vertica/vertica-sql-go"
+)
+
+const (
+	defaultVerticaSchema        = "public"
+	defaultVerticaStagingSchema = "_bruin_staging"
+	dedupRowNumberColumn        = "__bruin_dedup_rn"
+)
+
+// copyOptions is the COPY FROM STDIN clause matching the control-byte encoding
+// in appendCopyValue. Control bytes are used so real delimiters, newlines, and
+// NULL markers in the data never collide with the format.
+const copyOptions = `DELIMITER E'\001' RECORD TERMINATOR E'\002' NULL E'\003' ESCAPE AS E'\004' ABORT ON ERROR`
+
+// VerticaDestination loads data into Vertica over the native protocol via the
+// vertica-sql-go database/sql driver.
+type VerticaDestination struct {
+	db            *sql.DB
+	uri           string
+	currentSchema string
+}
+
+func NewVerticaDestination() *VerticaDestination {
+	return &VerticaDestination{}
+}
+
+func (d *VerticaDestination) Schemes() []string { return []string{"vertica"} }
+
+func (d *VerticaDestination) GetScheme() string { return "vertica" }
+
+func (d *VerticaDestination) Connect(ctx context.Context, uri string) error {
+	db, err := sql.Open("vertica", uri)
+	if err != nil {
+		return fmt.Errorf("failed to open Vertica connection: %w", err)
+	}
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to ping Vertica: %w", err)
+	}
+
+	d.db = db
+	d.uri = uri
+	d.currentSchema = defaultVerticaSchema
+	var currentSchema sql.NullString
+	if err := db.QueryRowContext(ctx, "SELECT CURRENT_SCHEMA").Scan(&currentSchema); err == nil && currentSchema.Valid && currentSchema.String != "" {
+		d.currentSchema = currentSchema.String
+	}
+	config.Debug("[VERTICA] Connected (schema: %s)", d.currentSchema)
+	return nil
+}
+
+func (d *VerticaDestination) Close(ctx context.Context) error {
+	if d.db != nil {
+		return d.db.Close()
+	}
+	return nil
+}
+
+func (d *VerticaDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	if err := tablename.TwoLevel("vertica").CheckName(opts.Table); err != nil {
+		return err
+	}
+
+	if err := d.ensureSchema(ctx, opts.Table); err != nil {
+		return err
+	}
+
+	if opts.DropFirst {
+		if err := d.DropTable(ctx, opts.Table); err != nil {
+			return err
+		}
+	}
+
+	if opts.Schema == nil {
+		return nil
+	}
+
+	createSQL := buildCreateTableSQL(opts.Table, opts.Schema, opts.PrimaryKeys)
+	if _, err := d.db.ExecContext(ctx, createSQL); err != nil {
+		config.LogFailedQuery(createSQL, err)
+		return fmt.Errorf("failed to create table: %w", err)
+	}
+	return nil
+}
+
+func (d *VerticaDestination) ensureSchema(ctx context.Context, table string) error {
+	schemaName, _ := splitSchemaTable(table)
+	if schemaName == "" {
+		return nil
+	}
+	// Skip creation when the schema already exists: built-in schemas such as
+	// "public" are reserved names that CREATE SCHEMA rejects outright.
+	var count int
+	existsQuery := "SELECT COUNT(*) FROM v_catalog.schemata WHERE schema_name = ?"
+	if err := d.db.QueryRowContext(ctx, existsQuery, schemaName).Scan(&count); err != nil {
+		return fmt.Errorf("failed to check schema %s: %w", schemaName, err)
+	}
+	if count > 0 {
+		return nil
+	}
+	createSchema := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoteColumn(schemaName))
+	if _, err := d.db.ExecContext(ctx, createSchema); err != nil {
+		config.LogFailedQuery(createSchema, err)
+		return fmt.Errorf("failed to ensure schema %s: %w", schemaName, err)
+	}
+	return nil
+}
+
+func (d *VerticaDestination) DropTable(ctx context.Context, table string) error {
+	dropSQL := fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", quoteTable(table))
+	if _, err := d.db.ExecContext(ctx, dropSQL); err != nil {
+		config.LogFailedQuery(dropSQL, err)
+		return fmt.Errorf("failed to drop table %s: %w", table, err)
+	}
+	return nil
+}
+
+func (d *VerticaDestination) Write(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	return d.WriteParallel(ctx, records, opts)
+}
+
+func (d *VerticaDestination) WriteParallel(ctx context.Context, records <-chan source.RecordBatchResult, opts destination.WriteOptions) error {
+	startTime := time.Now()
+	var totalRows int64
+	var batchNum int
+
+	for result := range records {
+		if result.Err != nil {
+			if result.Batch != nil {
+				result.Batch.Release()
+			}
+			return result.Err
+		}
+		if result.Batch == nil {
+			continue
+		}
+
+		batchNum++
+		rows, err := d.writeRecordBatch(ctx, result.Batch, opts.Table)
+		result.Batch.Release()
+		if err != nil {
+			return fmt.Errorf("failed to write batch %d: %w", batchNum, err)
+		}
+		totalRows += rows
+	}
+
+	config.Debug("[VERTICA] Wrote %d rows in %d batches in %v", totalRows, batchNum, time.Since(startTime))
+	return nil
+}
+
+// writeRecordBatch streams the batch to Vertica with COPY FROM STDIN, the bulk
+// loader Vertica is built around and the only path that scales to large volumes.
+func (d *VerticaDestination) writeRecordBatch(ctx context.Context, record arrow.RecordBatch, table string) (int64, error) {
+	numRows := int(record.NumRows())
+	numCols := int(record.NumCols())
+	if numRows == 0 || numCols == 0 {
+		return 0, nil
+	}
+
+	colNames := make([]string, numCols)
+	for i := 0; i < numCols; i++ {
+		colNames[i] = quoteColumn(record.Schema().Field(i).Name)
+	}
+	columnList := strings.Join(colNames, ", ")
+
+	pr, pw := io.Pipe()
+	go func() {
+		var buf bytes.Buffer
+		var writeErr error
+		cols := make([]arrow.Array, numCols)
+		for c := 0; c < numCols; c++ {
+			cols[c] = record.Column(c)
+		}
+		for r := 0; r < numRows; r++ {
+			buf.Reset()
+			for c := 0; c < numCols; c++ {
+				if c > 0 {
+					buf.WriteByte(copyDelimiter)
+				}
+				appendCopyValue(&buf, cols[c], r)
+			}
+			buf.WriteByte(copyRecordTerm)
+			if _, writeErr = pw.Write(buf.Bytes()); writeErr != nil {
+				break
+			}
+		}
+		_ = pw.CloseWithError(writeErr)
+	}()
+
+	vCtx := vertigo.NewVerticaContext(ctx)
+	if err := vCtx.SetCopyInputStream(pr); err != nil {
+		_ = pr.CloseWithError(err)
+		return 0, fmt.Errorf("failed to set copy input stream: %w", err)
+	}
+
+	copySQL := fmt.Sprintf("COPY %s (%s) FROM STDIN %s", quoteTable(table), columnList, copyOptions)
+	if _, err := d.db.ExecContext(vCtx, copySQL); err != nil {
+		_ = pr.CloseWithError(err)
+		config.LogFailedQuery(copySQL, err)
+		return 0, fmt.Errorf("failed to copy rows: %w", err)
+	}
+	return int64(numRows), nil
+}
+
+func (d *VerticaDestination) SwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	startSwap := time.Now()
+	if err := tablename.TwoLevel("vertica").CheckName(opts.StagingTable); err != nil {
+		return err
+	}
+	if err := tablename.TwoLevel("vertica").CheckName(opts.TargetTable); err != nil {
+		return err
+	}
+
+	stagingSchema, _ := splitSchemaTable(opts.StagingTable)
+	targetSchema, _ := splitSchemaTable(opts.TargetTable)
+
+	if err := d.ensureSchema(ctx, opts.TargetTable); err != nil {
+		return err
+	}
+
+	if !d.sameSchema(stagingSchema, targetSchema) {
+		return d.copySwapTable(ctx, opts)
+	}
+
+	if err := d.renameSwap(ctx, opts.StagingTable, opts.TargetTable); err != nil {
+		return err
+	}
+	config.Debug("[VERTICA] Table swap completed in %v", time.Since(startSwap))
+	return nil
+}
+
+// renameSwap moves stagingTable onto targetTable within a single schema using
+// Vertica's atomic multi-table rename, dropping the displaced target afterward.
+func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targetTable string) error {
+	targetSchema, targetName := splitSchemaTable(targetTable)
+
+	targetExists, err := d.tableExists(ctx, targetTable)
+	if err != nil {
+		return err
+	}
+
+	if !targetExists {
+		renameSQL := fmt.Sprintf("ALTER TABLE %s RENAME TO %s", quoteTable(stagingTable), quoteColumn(targetName))
+		if _, err := d.db.ExecContext(ctx, renameSQL); err != nil {
+			config.LogFailedQuery(renameSQL, err)
+			return fmt.Errorf("failed to rename staging table %s to %s: %w", stagingTable, targetTable, err)
+		}
+		return nil
+	}
+
+	// Vertica renames multiple tables atomically in one statement, so target and
+	// staging are swapped in a single step and the displaced target is dropped.
+	oldName := destination.ShortenIdentifier(targetName+"_old", targetName+"_old", destination.MaxIdentifierLength("vertica"))
+	swapSQL := fmt.Sprintf("ALTER TABLE %s, %s RENAME TO %s, %s",
+		quoteTable(targetTable), quoteTable(stagingTable), quoteColumn(oldName), quoteColumn(targetName))
+	if _, err := d.db.ExecContext(ctx, swapSQL); err != nil {
+		config.LogFailedQuery(swapSQL, err)
+		return fmt.Errorf("failed to swap staging table %s into %s: %w", stagingTable, targetTable, err)
+	}
+
+	oldTable := oldName
+	if targetSchema != "" {
+		oldTable = targetSchema + "." + oldName
+	}
+	if err := d.DropTable(ctx, oldTable); err != nil {
+		config.Debug("[VERTICA] Warning: failed to drop old table %s after swap: %v", oldTable, err)
+	}
+	return nil
+}
+
+// copySwapTable handles a swap where staging lives in a different schema (Vertica
+// cannot rename across schemas). It loads the replacement into a temp table in
+// the target schema first so the existing target survives until the atomic swap.
+func (d *VerticaDestination) copySwapTable(ctx context.Context, opts destination.SwapOptions) error {
+	if opts.Schema == nil {
+		return fmt.Errorf("cannot swap %s to %s across schemas without schema", opts.StagingTable, opts.TargetTable)
+	}
+
+	targetSchema, _ := splitSchemaTable(opts.TargetTable)
+	_, stagingName := splitSchemaTable(opts.StagingTable)
+	tempTable := stagingName
+	if targetSchema != "" {
+		tempTable = targetSchema + "." + stagingName
+	}
+
+	if err := d.DropTable(ctx, tempTable); err != nil {
+		return err
+	}
+	if err := d.PrepareTable(ctx, destination.PrepareOptions{
+		Table:       tempTable,
+		Schema:      opts.Schema,
+		PrimaryKeys: opts.PrimaryKeys,
+	}); err != nil {
+		return err
+	}
+
+	colList := strings.Join(quoteColumns(opts.Schema.ColumnNames()), ", ")
+	copySQL := fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s",
+		quoteTable(tempTable), colList, colList, quoteTable(opts.StagingTable))
+	if _, err := d.db.ExecContext(ctx, copySQL); err != nil {
+		config.LogFailedQuery(copySQL, err)
+		_ = d.DropTable(ctx, tempTable)
+		return fmt.Errorf("failed to copy staging rows into target: %w", err)
+	}
+
+	if err := d.renameSwap(ctx, tempTable, opts.TargetTable); err != nil {
+		_ = d.DropTable(ctx, tempTable)
+		return err
+	}
+	if err := d.DropTable(ctx, opts.StagingTable); err != nil {
+		config.Debug("[VERTICA] Warning: failed to drop staging table %s after swap: %v", opts.StagingTable, err)
+	}
+	return nil
+}
+
+func (d *VerticaDestination) MergeTable(ctx context.Context, opts destination.MergeOptions) error {
+	startMerge := time.Now()
+	if len(opts.PrimaryKeys) == 0 {
+		return fmt.Errorf("vertica merge requires at least one primary key")
+	}
+
+	targetColumns := destination.DestinationColumns(opts.Columns)
+	nonPKColumns := filterColumns(targetColumns, opts.PrimaryKeys)
+
+	orderBy := strings.Join(quoteColumns(opts.PrimaryKeys), ", ")
+	if opts.IncrementalKey != "" {
+		orderBy = quoteColumn(opts.IncrementalKey) + " DESC"
+	}
+	source := dedupSource(targetColumns, opts.PrimaryKeys, quoteTable(opts.StagingTable), orderBy)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "MERGE INTO %s target\nUSING %s\nON (%s)\n",
+		quoteTable(opts.TargetTable), source, buildJoinCondition(opts.PrimaryKeys, "target", "source"))
+	if len(nonPKColumns) > 0 {
+		fmt.Fprintf(&b, "WHEN MATCHED THEN UPDATE SET %s\n", buildUpdateSet(nonPKColumns, "source"))
+	}
+	fmt.Fprintf(&b, "WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)",
+		strings.Join(quoteColumns(targetColumns), ", "),
+		strings.Join(sourceColumnRefs(targetColumns, "source"), ", "))
+	mergeSQL := b.String()
+
+	config.Debug("[MERGE] Executing MERGE: %s", mergeSQL)
+	if _, err := d.db.ExecContext(ctx, mergeSQL); err != nil {
+		config.LogFailedQuery(mergeSQL, err)
+		return fmt.Errorf("failed to merge records: %w", err)
+	}
+
+	config.Debug("[MERGE] Merge completed in %v", time.Since(startMerge))
+	return nil
+}
+
+// dedupSource keeps one row per primary key (Vertica MERGE rejects duplicates).
+// It can't use destination.DedupStagingSelect: Vertica forbids that helper's (SELECT NULL) order-by inside an OVER clause, so we order by the keys instead.
+func dedupSource(columns, primaryKeys []string, tableExpr, orderBy string) string {
+	quotedColumns := strings.Join(quoteColumns(columns), ", ")
+	rowNum := quoteColumn(uniqueInternalName(columns, dedupRowNumberColumn))
+	return fmt.Sprintf(
+		"(SELECT %s FROM (SELECT %s, ROW_NUMBER() OVER (PARTITION BY %s ORDER BY %s) AS %s FROM %s) numbered WHERE %s = 1) source",
+		quotedColumns,
+		quotedColumns,
+		strings.Join(quoteColumns(primaryKeys), ", "),
+		orderBy,
+		rowNum,
+		tableExpr,
+		rowNum,
+	)
+}
+
+// uniqueInternalName returns base, or base_2/base_3/... when it collides
+// (case-insensitively) with an existing column, so internal aliases never clash.
+func uniqueInternalName(columns []string, base string) string {
+	used := make(map[string]struct{}, len(columns))
+	for _, c := range columns {
+		used[strings.ToLower(c)] = struct{}{}
+	}
+	candidate := base
+	for suffix := 2; ; suffix++ {
+		if _, ok := used[strings.ToLower(candidate)]; !ok {
+			return candidate
+		}
+		candidate = fmt.Sprintf("%s_%d", base, suffix)
+	}
+}
+
+func (d *VerticaDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
+	startOp := time.Now()
+	quotedColumns := quoteColumns(opts.Columns)
+	colList := strings.Join(quotedColumns, ", ")
+
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	key := quoteColumn(opts.IncrementalKey)
+	deleteSQL := fmt.Sprintf("DELETE FROM %s WHERE %s >= ? AND %s <= ?", quoteTable(opts.TargetTable), key, key)
+	if _, err := tx.ExecContext(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
+		config.LogFailedQuery(deleteSQL, err)
+		return fmt.Errorf("failed to delete records: %w", err)
+	}
+
+	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s",
+		quoteTable(opts.TargetTable), colList, colList, quoteTable(opts.StagingTable))
+	if len(opts.PrimaryKeys) > 0 {
+		orderBy := strings.Join(quoteColumns(opts.PrimaryKeys), ", ")
+		if opts.IncrementalKey != "" {
+			orderBy = key + " DESC"
+		}
+		insertSQL = fmt.Sprintf("INSERT INTO %s (%s) SELECT %s FROM %s",
+			quoteTable(opts.TargetTable), colList, colList,
+			dedupSource(opts.Columns, opts.PrimaryKeys, quoteTable(opts.StagingTable), orderBy))
+	}
+	if _, err := tx.ExecContext(ctx, insertSQL); err != nil {
+		config.LogFailedQuery(insertSQL, err)
+		return fmt.Errorf("failed to insert records: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	config.Debug("[DELETE+INSERT] Completed in %v", time.Since(startOp))
+	return nil
+}
+
+func (d *VerticaDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
+	return fmt.Errorf("vertica: scd2 strategy is not supported")
+}
+
+func (d *VerticaDestination) Exec(ctx context.Context, query string, args ...interface{}) error {
+	_, err := d.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+	}
+	return err
+}
+
+func (d *VerticaDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
+	tx, err := d.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &verticaTransaction{tx: tx}, nil
+}
+
+type verticaTransaction struct {
+	tx *sql.Tx
+}
+
+func (t *verticaTransaction) Exec(ctx context.Context, query string, args ...interface{}) error {
+	_, err := t.tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+	}
+	return err
+}
+
+func (t *verticaTransaction) Commit(ctx context.Context) error   { return t.tx.Commit() }
+func (t *verticaTransaction) Rollback(ctx context.Context) error { return t.tx.Rollback() }
+
+func (d *VerticaDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
+	schemaName, tableName := d.effectiveSchemaTable(table)
+
+	query := `
+		SELECT column_name, data_type, is_nullable, numeric_precision, numeric_scale, character_maximum_length
+		FROM v_catalog.columns
+		WHERE table_schema = ? AND table_name = ?
+		ORDER BY ordinal_position`
+
+	rows, err := d.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return nil, fmt.Errorf("failed to query table schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []schema.Column
+	for rows.Next() {
+		var colName, dataType string
+		var nullable bool
+		var precision, scale, charLen sql.NullInt64
+		if err := rows.Scan(&colName, &dataType, &nullable, &precision, &scale, &charLen); err != nil {
+			return nil, fmt.Errorf("failed to scan column: %w", err)
+		}
+		col := schema.Column{
+			Name:     colName,
+			DataType: mapVerticaTypeToSchema(dataType),
+			Nullable: nullable,
+		}
+		if precision.Valid {
+			col.Precision = int(precision.Int64)
+		}
+		if scale.Valid {
+			col.Scale = int(scale.Int64)
+		}
+		if charLen.Valid {
+			col.MaxLength = int(charLen.Int64)
+		}
+		columns = append(columns, col)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+	if len(columns) == 0 {
+		return nil, nil
+	}
+
+	primaryKeys, err := d.getPrimaryKeys(ctx, schemaName, tableName)
+	if err != nil {
+		return nil, err
+	}
+	pkSet := make(map[string]bool, len(primaryKeys))
+	for _, k := range primaryKeys {
+		pkSet[strings.ToLower(k)] = true
+	}
+	for i := range columns {
+		columns[i].IsPrimaryKey = pkSet[strings.ToLower(columns[i].Name)]
+	}
+
+	return &schema.TableSchema{
+		Name:        tableName,
+		Schema:      schemaName,
+		Columns:     columns,
+		PrimaryKeys: primaryKeys,
+	}, nil
+}
+
+func (d *VerticaDestination) getPrimaryKeys(ctx context.Context, schemaName, tableName string) ([]string, error) {
+	query := `
+		SELECT column_name
+		FROM v_catalog.primary_keys
+		WHERE table_schema = ? AND table_name = ?
+		ORDER BY ordinal_position`
+	rows, err := d.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+		return nil, fmt.Errorf("failed to query primary keys: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("failed to scan primary key: %w", err)
+		}
+		keys = append(keys, key)
+	}
+	return keys, rows.Err()
+}
+
+func (d *VerticaDestination) tableExists(ctx context.Context, table string) (bool, error) {
+	schemaName, tableName := d.effectiveSchemaTable(table)
+	var count int
+	query := "SELECT COUNT(*) FROM v_catalog.tables WHERE table_schema = ? AND table_name = ?"
+	if err := d.db.QueryRowContext(ctx, query, schemaName, tableName).Scan(&count); err != nil {
+		return false, fmt.Errorf("failed to check table existence: %w", err)
+	}
+	return count > 0, nil
+}
+
+func (d *VerticaDestination) effectiveSchemaTable(table string) (string, string) {
+	schemaName, tableName := splitSchemaTable(table)
+	if schemaName == "" {
+		schemaName = d.currentSchema
+	}
+	return schemaName, tableName
+}
+
+func (d *VerticaDestination) sameSchema(left, right string) bool {
+	resolve := func(s string) string {
+		if s == "" {
+			return d.currentSchema
+		}
+		return s
+	}
+	return resolve(left) == resolve(right)
+}
+
+func buildCreateTableSQL(table string, tableSchema *schema.TableSchema, primaryKeys []string) string {
+	pkSet := make(map[string]bool, len(primaryKeys))
+	for _, k := range primaryKeys {
+		pkSet[strings.ToLower(k)] = true
+	}
+
+	colDefs := make([]string, 0, len(tableSchema.Columns)+1)
+	for _, col := range tableSchema.Columns {
+		isKey := col.IsPrimaryKey || pkSet[strings.ToLower(col.Name)]
+		def := fmt.Sprintf("%s %s", quoteColumn(col.Name), MapDataTypeToVertica(col, isKey))
+		if isKey {
+			def += " NOT NULL"
+		}
+		colDefs = append(colDefs, def)
+	}
+	if len(primaryKeys) > 0 {
+		colDefs = append(colDefs, fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(quoteColumns(primaryKeys), ", ")))
+	}
+
+	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n)", quoteTable(table), strings.Join(colDefs, ",\n  "))
+}
+
+func (d *VerticaDestination) ReplaceStagingPolicy() destination.ReplaceStagingPolicy {
+	return destination.ReplaceStagingPolicy{
+		DefaultPlacement:     destination.ReplaceStagingTargetSchema,
+		DefaultTargetSchema:  d.currentSchema,
+		DefaultManagedSchema: defaultVerticaStagingSchema,
+	}
+}
+
+func (d *VerticaDestination) ManagedStagingPolicy() destination.ReplaceStagingPolicy {
+	return d.ReplaceStagingPolicy()
+}
+
+func (d *VerticaDestination) SupportsReplaceStrategy() bool      { return true }
+func (d *VerticaDestination) SupportsAppendStrategy() bool       { return true }
+func (d *VerticaDestination) SupportsMergeStrategy() bool        { return true }
+func (d *VerticaDestination) SupportsDeleteInsertStrategy() bool { return true }
+func (d *VerticaDestination) SupportsSCD2Strategy() bool         { return false }
+func (d *VerticaDestination) SupportsAtomicSwap() bool           { return true }
+
+var _ destination.Destination = (*VerticaDestination)(nil)

--- a/pkg/destination/vertica/vertica.go
+++ b/pkg/destination/vertica/vertica.go
@@ -254,6 +254,7 @@ func (d *VerticaDestination) SwapTable(ctx context.Context, opts destination.Swa
 // Vertica's atomic multi-table rename, dropping the displaced target afterward.
 func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targetTable string) error {
 	targetSchema, targetName := splitSchemaTable(targetTable)
+	_, stagingName := splitSchemaTable(stagingTable)
 
 	targetExists, err := d.tableExists(ctx, targetTable)
 	if err != nil {
@@ -269,12 +270,21 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 		return nil
 	}
 
-	// Vertica renames multiple tables atomically in one statement, so target and
-	// staging are swapped in a single step and the displaced target is dropped.
-	oldName, err := d.freeOldName(ctx, targetSchema, targetName)
-	if err != nil {
+	// The transient backup name is derived from the staging name, which is unique
+	// per run, so concurrent replace jobs never contend for it and it never
+	// collides with an unrelated table. Any same-name leftover can only be this
+	// job's own crashed prior run, so dropping it before the swap is safe.
+	oldName := destination.ShortenIdentifier(stagingName+"_old", stagingName+"_old", destination.MaxIdentifierLength("vertica"))
+	oldTable := oldName
+	if targetSchema != "" {
+		oldTable = targetSchema + "." + oldName
+	}
+	if err := d.DropTable(ctx, oldTable); err != nil {
 		return err
 	}
+
+	// Vertica renames multiple tables atomically in one statement, so target and
+	// staging are swapped in a single step and the displaced target is dropped.
 	swapSQL := fmt.Sprintf("ALTER TABLE %s, %s RENAME TO %s, %s",
 		quoteTable(targetTable), quoteTable(stagingTable), quoteColumn(oldName), quoteColumn(targetName))
 	if _, err := d.db.ExecContext(ctx, swapSQL); err != nil {
@@ -282,40 +292,10 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 		return fmt.Errorf("failed to swap staging table %s into %s: %w", stagingTable, targetTable, err)
 	}
 
-	oldTable := oldName
-	if targetSchema != "" {
-		oldTable = targetSchema + "." + oldName
-	}
 	if err := d.DropTable(ctx, oldTable); err != nil {
 		config.Debug("[VERTICA] Warning: failed to drop old table %s after swap: %v", oldTable, err)
 	}
 	return nil
-}
-
-// freeOldName returns a table name in targetSchema not currently occupied, used
-// as the transient landing spot for the displaced target during an atomic swap.
-// A leftover "<target>_old" from a crashed prior swap (or a real user table)
-// would otherwise make the rename collide and leave the load unpublished.
-func (d *VerticaDestination) freeOldName(ctx context.Context, targetSchema, targetName string) (string, error) {
-	maxLen := destination.MaxIdentifierLength("vertica")
-	for i := 0; ; i++ {
-		base := targetName + "_old"
-		if i > 0 {
-			base = fmt.Sprintf("%s_old_%d", targetName, i+1)
-		}
-		name := destination.ShortenIdentifier(base, base, maxLen)
-		qualified := name
-		if targetSchema != "" {
-			qualified = targetSchema + "." + name
-		}
-		exists, err := d.tableExists(ctx, qualified)
-		if err != nil {
-			return "", err
-		}
-		if !exists {
-			return name, nil
-		}
-	}
 }
 
 // copySwapTable handles a swap where staging lives in a different schema (Vertica

--- a/pkg/destination/vertica/vertica.go
+++ b/pkg/destination/vertica/vertica.go
@@ -271,16 +271,14 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 	}
 
 	// The transient backup name is derived from the staging name, which is unique
-	// per run, so concurrent replace jobs never contend for it and it never
-	// collides with an unrelated table. Any same-name leftover can only be this
-	// job's own crashed prior run, so dropping it before the swap is safe.
+	// per run, so concurrent replace jobs never contend for it and it will not
+	// collide with an unrelated table. The name is never dropped beforehand: if it
+	// were somehow occupied the atomic rename below fails cleanly, leaving both
+	// staging and target intact rather than destroying whatever held the name.
 	oldName := destination.ShortenIdentifier(stagingName+"_old", stagingName+"_old", destination.MaxIdentifierLength("vertica"))
 	oldTable := oldName
 	if targetSchema != "" {
 		oldTable = targetSchema + "." + oldName
-	}
-	if err := d.DropTable(ctx, oldTable); err != nil {
-		return err
 	}
 
 	// Vertica renames multiple tables atomically in one statement, so target and
@@ -292,6 +290,8 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 		return fmt.Errorf("failed to swap staging table %s into %s: %w", stagingTable, targetTable, err)
 	}
 
+	// oldTable now holds the displaced target this swap just created, so dropping
+	// it is safe.
 	if err := d.DropTable(ctx, oldTable); err != nil {
 		config.Debug("[VERTICA] Warning: failed to drop old table %s after swap: %v", oldTable, err)
 	}

--- a/pkg/destination/vertica/vertica.go
+++ b/pkg/destination/vertica/vertica.go
@@ -270,12 +270,14 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 		return nil
 	}
 
-	// The transient backup name is derived from the staging name, which is unique
-	// per run, so concurrent replace jobs never contend for it and it will not
-	// collide with an unrelated table. The name is never dropped beforehand: if it
-	// were somehow occupied the atomic rename below fails cleanly, leaving both
-	// staging and target intact rather than destroying whatever held the name.
-	oldName := destination.ShortenIdentifier(stagingName+"_old", stagingName+"_old", destination.MaxIdentifierLength("vertica"))
+	// Pick a free name for the displaced target rather than dropping whatever
+	// holds a fixed one: probing never destroys an unrelated table, and basing it
+	// on the run-unique staging name keeps concurrent replace jobs from ever
+	// probing the same candidates.
+	oldName, err := d.freeTransientName(ctx, targetSchema, stagingName+"_old")
+	if err != nil {
+		return err
+	}
 	oldTable := oldName
 	if targetSchema != "" {
 		oldTable = targetSchema + "." + oldName
@@ -298,6 +300,33 @@ func (d *VerticaDestination) renameSwap(ctx context.Context, stagingTable, targe
 	return nil
 }
 
+// freeTransientName returns a name in schemaName that no table currently
+// occupies, derived from base with a numeric suffix on collision. It never drops
+// an existing table, so an unrelated table sharing the base name is stepped over
+// rather than destroyed. base comes from the run-unique staging name, so
+// concurrent jobs never probe the same candidates.
+func (d *VerticaDestination) freeTransientName(ctx context.Context, schemaName, base string) (string, error) {
+	maxLen := destination.MaxIdentifierLength("vertica")
+	for i := 0; ; i++ {
+		candidate := base
+		if i > 0 {
+			candidate = fmt.Sprintf("%s_%d", base, i+1)
+		}
+		name := destination.ShortenIdentifier(candidate, candidate, maxLen)
+		qualified := name
+		if schemaName != "" {
+			qualified = schemaName + "." + name
+		}
+		exists, err := d.tableExists(ctx, qualified)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			return name, nil
+		}
+	}
+}
+
 // copySwapTable handles a swap where staging lives in a different schema (Vertica
 // cannot rename across schemas). It loads the replacement into a temp table in
 // the target schema first so the existing target survives until the atomic swap.
@@ -308,14 +337,18 @@ func (d *VerticaDestination) copySwapTable(ctx context.Context, opts destination
 
 	targetSchema, _ := splitSchemaTable(opts.TargetTable)
 	_, stagingName := splitSchemaTable(opts.StagingTable)
-	tempTable := stagingName
-	if targetSchema != "" {
-		tempTable = targetSchema + "." + stagingName
-	}
 
-	if err := d.DropTable(ctx, tempTable); err != nil {
+	// Probe for a free temp name instead of dropping whatever holds the staging
+	// basename in the target schema, so an unrelated table is never destroyed.
+	tempName, err := d.freeTransientName(ctx, targetSchema, stagingName)
+	if err != nil {
 		return err
 	}
+	tempTable := tempName
+	if targetSchema != "" {
+		tempTable = targetSchema + "." + tempName
+	}
+
 	if err := d.PrepareTable(ctx, destination.PrepareOptions{
 		Table:       tempTable,
 		Schema:      opts.Schema,

--- a/pkg/destination/vertica/vertica_test.go
+++ b/pkg/destination/vertica/vertica_test.go
@@ -234,9 +234,12 @@ func TestRenameSwapBackupNameFromStaging(t *testing.T) {
 	existsQuery := `SELECT COUNT\(\*\) FROM v_catalog\.tables WHERE table_schema = \? AND table_name = \?`
 	mock.ExpectQuery(existsQuery).WithArgs("public", "users").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	// The backup name is derived from the unique staging name and is never dropped
-	// before the swap, so no pre-existing table is destroyed. The atomic rename
-	// displaces the target onto it, and only that displaced target is dropped after.
+	// The backup name is derived from the unique staging name and probed for
+	// availability (never dropped beforehand), so no pre-existing table is
+	// destroyed. The atomic rename displaces the target onto it, and only that
+	// displaced target is dropped after.
+	mock.ExpectQuery(existsQuery).WithArgs("public", "users_stg_run1_old").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectExec(`ALTER TABLE "public"."users", "public"."users_stg_run1" RENAME TO "users_stg_run1_old", "users"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(`DROP TABLE IF EXISTS "public"."users_stg_run1_old" CASCADE`).
@@ -244,6 +247,30 @@ func TestRenameSwapBackupNameFromStaging(t *testing.T) {
 
 	if err := d.renameSwap(context.Background(), "public.users_stg_run1", "public.users"); err != nil {
 		t.Fatalf("renameSwap() error: %v", err)
+	}
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestFreeTransientNameStepsOverOccupied(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	d := &VerticaDestination{db: db, currentSchema: "public"}
+
+	existsQuery := `SELECT COUNT\(\*\) FROM v_catalog\.tables WHERE table_schema = \? AND table_name = \?`
+	// The base name and its first suffix are taken by unrelated tables; the probe
+	// steps over both without issuing any DROP, then settles on the free name.
+	mock.ExpectQuery(existsQuery).WithArgs("public", "stg_old").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(existsQuery).WithArgs("public", "stg_old_2").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(existsQuery).WithArgs("public", "stg_old_3").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	got, err := d.freeTransientName(context.Background(), "public", "stg_old")
+	require.NoError(t, err)
+	if got != "stg_old_3" {
+		t.Errorf("freeTransientName() = %q, want stg_old_3", got)
 	}
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/destination/vertica/vertica_test.go
+++ b/pkg/destination/vertica/vertica_test.go
@@ -234,10 +234,9 @@ func TestRenameSwapBackupNameFromStaging(t *testing.T) {
 	existsQuery := `SELECT COUNT\(\*\) FROM v_catalog\.tables WHERE table_schema = \? AND table_name = \?`
 	mock.ExpectQuery(existsQuery).WithArgs("public", "users").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	// The backup name is derived from the unique staging name, dropped before the
-	// swap, then the atomic rename displaces the target onto it.
-	mock.ExpectExec(`DROP TABLE IF EXISTS "public"."users_stg_run1_old" CASCADE`).
-		WillReturnResult(sqlmock.NewResult(0, 0))
+	// The backup name is derived from the unique staging name and is never dropped
+	// before the swap, so no pre-existing table is destroyed. The atomic rename
+	// displaces the target onto it, and only that displaced target is dropped after.
 	mock.ExpectExec(`ALTER TABLE "public"."users", "public"."users_stg_run1" RENAME TO "users_stg_run1_old", "users"`).
 		WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec(`DROP TABLE IF EXISTS "public"."users_stg_run1_old" CASCADE`).

--- a/pkg/destination/vertica/vertica_test.go
+++ b/pkg/destination/vertica/vertica_test.go
@@ -3,6 +3,7 @@ package vertica
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -102,7 +103,7 @@ func TestBuildCreateTableSQL(t *testing.T) {
 			{Name: "amount", DataType: schema.TypeDecimal, Precision: 10, Scale: 2},
 		},
 	}
-	got := buildCreateTableSQL("public.users", tableSchema, []string{"id"})
+	got := buildCreateTableSQL("public.users", tableSchema, []string{"id"}, true)
 
 	for _, want := range []string{
 		`CREATE TABLE IF NOT EXISTS "public"."users"`,
@@ -271,6 +272,32 @@ func TestFreeTransientNameStepsOverOccupied(t *testing.T) {
 	require.NoError(t, err)
 	if got != "stg_old_3" {
 		t.Errorf("freeTransientName() = %q, want stg_old_3", got)
+	}
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreateTransientTableStrictAndAdvances(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	d := &VerticaDestination{db: db, currentSchema: "public"}
+
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt64}}}
+	existsQuery := `SELECT COUNT\(\*\) FROM v_catalog\.tables WHERE table_schema = \? AND table_name = \?`
+
+	// First strict create fails because the name is already taken; the helper
+	// confirms it exists and advances to the next candidate, which creates cleanly.
+	mock.ExpectExec(`CREATE TABLE "public"."stg" `).
+		WillReturnError(fmt.Errorf("ERROR 4155: Object \"stg\" already exists"))
+	mock.ExpectQuery(existsQuery).WithArgs("public", "stg").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectExec(`CREATE TABLE "public"."stg_2" `).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	got, err := d.createTransientTable(context.Background(), "public", "stg", tableSchema, nil)
+	require.NoError(t, err)
+	if got != "public.stg_2" {
+		t.Errorf("createTransientTable() = %q, want public.stg_2", got)
 	}
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/destination/vertica/vertica_test.go
+++ b/pkg/destination/vertica/vertica_test.go
@@ -225,26 +225,26 @@ func TestDedupSourceColumnCollision(t *testing.T) {
 	}
 }
 
-func TestFreeOldName(t *testing.T) {
+func TestRenameSwapBackupNameFromStaging(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 	d := &VerticaDestination{db: db, currentSchema: "public"}
 
 	existsQuery := `SELECT COUNT\(\*\) FROM v_catalog\.tables WHERE table_schema = \? AND table_name = \?`
-
-	// users_old and users_old_2 already exist, so the third candidate is chosen.
-	mock.ExpectQuery(existsQuery).WithArgs("public", "users_old").
+	mock.ExpectQuery(existsQuery).WithArgs("public", "users").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(existsQuery).WithArgs("public", "users_old_2").
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
-	mock.ExpectQuery(existsQuery).WithArgs("public", "users_old_3").
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	// The backup name is derived from the unique staging name, dropped before the
+	// swap, then the atomic rename displaces the target onto it.
+	mock.ExpectExec(`DROP TABLE IF EXISTS "public"."users_stg_run1_old" CASCADE`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`ALTER TABLE "public"."users", "public"."users_stg_run1" RENAME TO "users_stg_run1_old", "users"`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`DROP TABLE IF EXISTS "public"."users_stg_run1_old" CASCADE`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
 
-	got, err := d.freeOldName(context.Background(), "public", "users")
-	require.NoError(t, err)
-	if got != "users_old_3" {
-		t.Errorf("freeOldName() = %q, want users_old_3", got)
+	if err := d.renameSwap(context.Background(), "public.users_stg_run1", "public.users"); err != nil {
+		t.Fatalf("renameSwap() error: %v", err)
 	}
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/pkg/destination/vertica/vertica_test.go
+++ b/pkg/destination/vertica/vertica_test.go
@@ -2,13 +2,16 @@ package vertica
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapDataTypeToVertica(t *testing.T) {
@@ -220,6 +223,30 @@ func TestDedupSourceColumnCollision(t *testing.T) {
 	if !strings.Contains(got, `WHERE "__bruin_dedup_rn_2" = 1`) {
 		t.Errorf("expected WHERE on collision-avoiding alias in:\n%s", got)
 	}
+}
+
+func TestFreeOldName(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	d := &VerticaDestination{db: db, currentSchema: "public"}
+
+	existsQuery := `SELECT COUNT\(\*\) FROM v_catalog\.tables WHERE table_schema = \? AND table_name = \?`
+
+	// users_old and users_old_2 already exist, so the third candidate is chosen.
+	mock.ExpectQuery(existsQuery).WithArgs("public", "users_old").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(existsQuery).WithArgs("public", "users_old_2").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+	mock.ExpectQuery(existsQuery).WithArgs("public", "users_old_3").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	got, err := d.freeOldName(context.Background(), "public", "users")
+	require.NoError(t, err)
+	if got != "users_old_3" {
+		t.Errorf("freeOldName() = %q, want users_old_3", got)
+	}
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestUniqueInternalName(t *testing.T) {

--- a/pkg/destination/vertica/vertica_test.go
+++ b/pkg/destination/vertica/vertica_test.go
@@ -1,0 +1,235 @@
+package vertica
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+func TestMapDataTypeToVertica(t *testing.T) {
+	tests := []struct {
+		name  string
+		col   schema.Column
+		isKey bool
+		want  string
+	}{
+		{"bool", schema.Column{DataType: schema.TypeBoolean}, false, "BOOLEAN"},
+		{"int16", schema.Column{DataType: schema.TypeInt16}, false, "INT"},
+		{"int32", schema.Column{DataType: schema.TypeInt32}, false, "INT"},
+		{"int64", schema.Column{DataType: schema.TypeInt64}, false, "INT"},
+		{"float32", schema.Column{DataType: schema.TypeFloat32}, false, "FLOAT"},
+		{"float64", schema.Column{DataType: schema.TypeFloat64}, false, "FLOAT"},
+		{"decimal", schema.Column{DataType: schema.TypeDecimal, Precision: 18, Scale: 4}, false, "NUMERIC(18, 4)"},
+		{"decimal default", schema.Column{DataType: schema.TypeDecimal}, false, "NUMERIC(38, 9)"},
+		{"string default", schema.Column{DataType: schema.TypeString}, false, "LONG VARCHAR"},
+		{"string default key", schema.Column{DataType: schema.TypeString}, true, "VARCHAR(65000)"},
+		{"string bounded", schema.Column{DataType: schema.TypeString, MaxLength: 100}, false, "VARCHAR(100)"},
+		{"date", schema.Column{DataType: schema.TypeDate}, false, "DATE"},
+		{"time", schema.Column{DataType: schema.TypeTime}, false, "TIME"},
+		{"timestamp", schema.Column{DataType: schema.TypeTimestamp}, false, "TIMESTAMP"},
+		{"timestamptz", schema.Column{DataType: schema.TypeTimestampTZ}, false, "TIMESTAMPTZ"},
+		{"binary", schema.Column{DataType: schema.TypeBinary}, false, "LONG VARBINARY"},
+		{"binary key", schema.Column{DataType: schema.TypeBinary}, true, "VARBINARY(65000)"},
+		{"json", schema.Column{DataType: schema.TypeJSON}, false, "LONG VARCHAR"},
+		{"array", schema.Column{DataType: schema.TypeArray, ArrayType: schema.TypeInt64}, false, "LONG VARCHAR"},
+		{"uuid", schema.Column{DataType: schema.TypeUUID}, false, "LONG VARCHAR"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MapDataTypeToVertica(tt.col, tt.isKey); got != tt.want {
+				t.Errorf("MapDataTypeToVertica() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapVerticaTypeToSchema(t *testing.T) {
+	tests := []struct {
+		in   string
+		want schema.DataType
+	}{
+		{"boolean", schema.TypeBoolean},
+		{"int", schema.TypeInt64},
+		{"bigint", schema.TypeInt64},
+		{"float", schema.TypeFloat64},
+		{"numeric(38,9)", schema.TypeDecimal},
+		{"varchar(65000)", schema.TypeString},
+		{"long varchar", schema.TypeString},
+		{"varbinary(80)", schema.TypeBinary},
+		{"date", schema.TypeDate},
+		{"timestamp", schema.TypeTimestamp},
+		{"timestamptz", schema.TypeTimestampTZ},
+		{"uuid", schema.TypeString},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := mapVerticaTypeToSchema(tt.in); got != tt.want {
+				t.Errorf("mapVerticaTypeToSchema(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQuoteTable(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"users", `"users"`},
+		{"public.users", `"public"."users"`},
+		{`we"ird`, `"we""ird"`},
+	}
+	for _, tt := range tests {
+		if got := quoteTable(tt.in); got != tt.want {
+			t.Errorf("quoteTable(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestBuildCreateTableSQL(t *testing.T) {
+	tableSchema := &schema.TableSchema{
+		Columns: []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "name", DataType: schema.TypeString},
+			{Name: "amount", DataType: schema.TypeDecimal, Precision: 10, Scale: 2},
+		},
+	}
+	got := buildCreateTableSQL("public.users", tableSchema, []string{"id"})
+
+	for _, want := range []string{
+		`CREATE TABLE IF NOT EXISTS "public"."users"`,
+		`"id" INT NOT NULL`,
+		`"name" LONG VARCHAR`,
+		`"amount" NUMERIC(10, 2)`,
+		`PRIMARY KEY ("id")`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildCreateTableSQL() missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestAppendCopyValue(t *testing.T) {
+	pool := memory.NewGoAllocator()
+
+	strB := array.NewStringBuilder(pool)
+	defer strB.Release()
+	strB.Append("plain")
+	strB.Append("")
+	strB.AppendNull()
+	// control bytes that must be escaped so they survive the COPY stream
+	strB.Append(string([]byte{copyDelimiter, 'a', copyRecordTerm, 'b', copyNull, 'c', copyEscape}))
+	strArr := strB.NewArray()
+	defer strArr.Release()
+
+	got := func(idx int) []byte {
+		var buf bytes.Buffer
+		appendCopyValue(&buf, strArr, idx)
+		return buf.Bytes()
+	}
+
+	if !bytes.Equal(got(0), []byte("plain")) {
+		t.Errorf("plain string mis-encoded: %q", got(0))
+	}
+	if len(got(1)) != 0 {
+		t.Errorf("empty string should encode to empty bytes, got %q", got(1))
+	}
+	if !bytes.Equal(got(2), []byte{copyNull}) {
+		t.Errorf("null should encode to NULL marker, got %q", got(2))
+	}
+	wantEscaped := []byte{
+		copyEscape, copyDelimiter, 'a', copyEscape, copyRecordTerm, 'b',
+		copyEscape, copyNull, 'c', copyEscape, copyEscape,
+	}
+	if !bytes.Equal(got(3), wantEscaped) {
+		t.Errorf("control bytes not escaped: got %v want %v", got(3), wantEscaped)
+	}
+
+	intB := array.NewInt64Builder(pool)
+	defer intB.Release()
+	intB.Append(-42)
+	intB.AppendNull()
+	intArr := intB.NewArray()
+	defer intArr.Release()
+	var buf bytes.Buffer
+	appendCopyValue(&buf, intArr, 0)
+	if buf.String() != "-42" {
+		t.Errorf("int encode = %q, want -42", buf.String())
+	}
+	buf.Reset()
+	appendCopyValue(&buf, intArr, 1)
+	if !bytes.Equal(buf.Bytes(), []byte{copyNull}) {
+		t.Errorf("null int should encode to NULL marker, got %q", buf.Bytes())
+	}
+
+	tsB := array.NewTimestampBuilder(pool, &arrow.TimestampType{Unit: arrow.Microsecond})
+	defer tsB.Release()
+	tsB.Append(arrow.Timestamp(1673790330123456)) // 2023-01-15 13:45:30.123456 UTC
+	tsArr := tsB.NewArray()
+	defer tsArr.Release()
+	buf.Reset()
+	appendCopyValue(&buf, tsArr, 0)
+	if got := buf.String(); got != "2023-01-15 13:45:30.123456+00:00" {
+		t.Errorf("timestamp encode = %q", got)
+	}
+}
+
+func TestFormatISOInterval(t *testing.T) {
+	tests := []struct {
+		months, days, nanos int64
+		want                string
+	}{
+		{0, 3, 0, "P3D"},
+		{1, 0, 0, "P1M"},
+		{0, 0, 5_400_000_000_000, "PT5400S"},
+		{0, 0, 0, "PT0S"},
+		{1, 2, 3_000_000_000, "P1M2DT3S"},
+	}
+	for _, tt := range tests {
+		if got := formatISOInterval(tt.months, tt.days, tt.nanos); got != tt.want {
+			t.Errorf("formatISOInterval(%d,%d,%d) = %q, want %q", tt.months, tt.days, tt.nanos, got, tt.want)
+		}
+	}
+}
+
+func TestDedupSource(t *testing.T) {
+	got := dedupSource([]string{"id", "name"}, []string{"id"}, `"public"."stg"`, `"id" DESC`)
+	for _, want := range []string{
+		`ROW_NUMBER() OVER (PARTITION BY "id" ORDER BY "id" DESC)`,
+		`FROM "public"."stg"`,
+		`WHERE "__bruin_dedup_rn" = 1`,
+		`) source`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("dedupSource() missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestDedupSourceColumnCollision(t *testing.T) {
+	// A user column named __bruin_dedup_rn must not collide with the row-number alias.
+	got := dedupSource([]string{"id", "__bruin_dedup_rn"}, []string{"id"}, `"public"."stg"`, `"id"`)
+	if !strings.Contains(got, `AS "__bruin_dedup_rn_2"`) {
+		t.Errorf("expected collision-avoiding alias __bruin_dedup_rn_2 in:\n%s", got)
+	}
+	if !strings.Contains(got, `WHERE "__bruin_dedup_rn_2" = 1`) {
+		t.Errorf("expected WHERE on collision-avoiding alias in:\n%s", got)
+	}
+}
+
+func TestUniqueInternalName(t *testing.T) {
+	if got := uniqueInternalName([]string{"id", "name"}, "rn"); got != "rn" {
+		t.Errorf("uniqueInternalName no collision = %q, want rn", got)
+	}
+	if got := uniqueInternalName([]string{"id", "RN"}, "rn"); got != "rn_2" {
+		t.Errorf("uniqueInternalName case-insensitive collision = %q, want rn_2", got)
+	}
+	if got := uniqueInternalName([]string{"rn", "rn_2"}, "rn"); got != "rn_3" {
+		t.Errorf("uniqueInternalName double collision = %q, want rn_3", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds [Vertica](https://www.vertica.com/) as an ingestr **destination**, using the `vertica-sql-go` driver (Apache-2.0, pure Go). Requested in #1131 for DWH workloads (sources: Postgres/CSV/XLSX, volumes up to ~100 GB, run via the Python SDK).

## What it does

- **Bulk load via `COPY FROM STDIN`** — streamed through an `io.Pipe` (bounded memory) with a control-byte encoding, so it scales to large volumes and safely handles embedded delimiters, newlines, and the null/empty-string distinction. Row-based `INSERT` was rejected both for scale and because Vertica has no multi-row `VALUES`.
- **Strategies:** `replace` (staging + atomic multi-table `RENAME` swap), `append`, `merge`, `delete+insert`. `scd2` reports a clear unsupported error.
- **Type coverage:** booleans, all ints→`INT`, floats→`FLOAT`, `decimal`→`NUMERIC(p,s)`, strings/UUID, binary→`(LONG) VARBINARY`, `date`/`time`/`timestamp`/`timestamptz` at microsecond precision (UTC-correct), and `json`/`array`/`interval` carried as text (Vertica has no native type for these).
- **Schema handling:** auto-creates the target schema; skips reserved built-ins like `public`.