### PR TITLE
test(python): make goreleaser asset-name test independent of runner libc

### DIFF
--- a/tests/python/test_ingestr_package.py
+++ b/tests/python/test_ingestr_package.py
@@ -353,7 +353,8 @@ class IngestrPackageTest(unittest.TestCase):
     def test_release_platform_uses_goreleaser_asset_names(self):
         with patch("platform.system", return_value="Linux"):
             with patch("platform.machine", return_value="aarch64"):
-                release = ingestr_runner._release_platform()
+                with patch("ingestr._runner._linux_uses_musl", return_value=False):
+                    release = ingestr_runner._release_platform()
 
         self.assertEqual(ingestr_runner._release_archive_name(release), "ingestr_Linux_arm64.tar.gz")
 


### PR DESCRIPTION
The Python SDK test `test_release_platform_uses_goreleaser_asset_names` called the real `_linux_uses_musl()`, which globs `/lib` and `/usr/lib` for `ld-musl-*.so.1`. On a runner image whose filesystem carries a musl loader, the Linux branch of the test hits the glibc guard in `_release_platform()` and raises, failing the test — even though nothing in the code changed.

This surfaced when a recently rolled-out `ubuntu-latest` runner image started shipping a musl loader: the same code that passed on `main` began failing on freshly scheduled CI runs.