### PR TITLE
feat(source): add SatisMeter source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -264,6 +264,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "RevenueCat", link: "/supported-sources/revenuecat.md" },
               { text: "S3", link: "/supported-sources/s3.md" },
               { text: "Salesforce", link: "/supported-sources/salesforce.md" },
+              { text: "SatisMeter", link: "/supported-sources/satismeter.md" },
               { text: "SendGrid", link: "/supported-sources/sendgrid.md" },
               { text: "SFTP", link: "/supported-sources/sftp.md"},
               { text: "SharePoint", link: "/supported-sources/sharepoint.md" },

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -30,6 +30,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Google Analytics](/supported-sources/google_analytics.md)
 - [Mixpanel](/supported-sources/mixpanel.md)
 - [PostHog](/supported-sources/posthog.md)
+- [SatisMeter](/supported-sources/satismeter.md)
 - [SurveyMonkey](/supported-sources/surveymonkey.md)
 - [Trustpilot](/supported-sources/trustpilot.md)
 - [Wistia](/supported-sources/wistia.md)

--- a/docs/supported-sources/satismeter.md
+++ b/docs/supported-sources/satismeter.md
@@ -1,0 +1,59 @@
+# SatisMeter
+
+[SatisMeter](https://www.satismeter.com/) collects in-app NPS, CSAT and CES survey
+responses.
+
+ingestr supports SatisMeter as a source.
+
+## URI format
+
+```
+satismeter://?api_key=<api_key>&project_id=<project_id>
+```
+
+Both parameters are required:
+
+- `api_key` — created in the SatisMeter UI under **Settings → Integrations → API**.
+  The key is scoped to a single project.
+- `project_id` — the project the key belongs to. Every endpoint is nested under
+  `/projects/{projectId}`, so it cannot be inferred from the key.
+
+## Tables
+
+| Table       | Description                                                                                   |
+|-------------|-----------------------------------------------------------------------------------------------|
+| `responses` | Individual survey responses: the answer payload, the responding user, device, location, language, referrer and a `created` timestamp. |
+| `campaigns` | The surveys defined in the project — id, name, type (`nps` / `csat` / …) and state.             |
+| `project`   | Project metadata: name, default language, branding.                                            |
+
+`responses` is loaded incrementally on its `created` timestamp. `campaigns` and
+`project` are small snapshots that are re-fetched in full and de-duplicated on `id`;
+neither tracks deletions, so a survey removed in SatisMeter remains in the table.
+
+Nested objects (`answers`, `user`, `device`, `location`) are passed through as JSON
+rather than flattened.
+
+### A note on date ranges
+
+SatisMeter's responses endpoint defaults to **the last 30 days** when no start date
+is supplied. ingestr always sends an explicit start date, so a run without
+`--interval-start` fetches the full history rather than silently returning a month.
+Pass `--interval-start` / `--interval-end` to narrow it.
+
+### Personal data
+
+Response records embed the respondent's email, name, user id and the full custom
+trait bag exactly as SatisMeter returns them. Treat the destination table as
+containing personal data.
+
+## Example
+
+```sh
+ingestr ingest \
+  --source-uri 'satismeter://?api_key=sm_abc123&project_id=5bb480aaebf3ed0004c6f3dd' \
+  --source-table 'responses' \
+  --dest-uri duckdb:///satismeter.duckdb \
+  --dest-table 'dest.responses'
+```
+
+<img alt="satismeter" src="../media/satismeter.png" />

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -390,6 +390,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("ripestat", "RIPEstat", []string{"ripestat"}, true, false),
 		genericURIConnector("revenuecat", "RevenueCat", []string{"revenuecat"}, true, false),
 		genericURIConnector("salesforce", "Salesforce", []string{"salesforce"}, true, false),
+		genericURIConnector("satismeter", "SatisMeter", []string{"satismeter"}, true, false),
 		genericURIConnector("sendgrid", "SendGrid", []string{"sendgrid"}, true, false),
 		genericURIConnector("sharepoint", "SharePoint", []string{"sharepoint"}, true, false),
 		genericURIConnector("shopify", "Shopify", []string{"shopify"}, true, false),

--- a/pkg/source/satismeter/register.go
+++ b/pkg/source/satismeter/register.go
@@ -1,0 +1,10 @@
+package satismeter
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"satismeter"},
+		func() interface{} { return NewSatisMeterSource() },
+	)
+}

--- a/pkg/source/satismeter/satismeter.go
+++ b/pkg/source/satismeter/satismeter.go
@@ -1,0 +1,336 @@
+// Package satismeter implements an ingestr source for the SatisMeter REST API
+// v3 — NPS / CSAT / CES survey responses.
+//
+// Docs: https://app.satismeter.com/apidoc
+//
+// AUTH: a project-scoped API key (Settings > Integrations > API), sent as
+// `Authorization: Bearer <key>`. Because the key is scoped to one project, the
+// project id must be supplied alongside it — every endpoint is nested under
+// /projects/{projectId}.
+//
+// ⚠️⚠️ THE ONE TRAP THAT MATTERS: `startDate` DEFAULTS TO 30 DAYS AGO.
+//
+// /responses applies a server-side default of "last 30 days" when startDate is
+// omitted. It is not an error and there is no warning — you simply get a recent
+// slice that looks like the whole dataset. This source therefore ALWAYS sends an
+// explicit startDate, falling back to `historyFloor` when the pipeline gives no
+// interval, so "no interval" means "everything" rather than "the last month".
+//
+// PII: response objects embed `user.email`, `user.name`, `user.userId` and the
+// whole `user.traits` bag verbatim. They are passed through unmodified — treat
+// the destination table accordingly.
+package satismeter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	baseURL = "https://app.satismeter.com/api/v3"
+
+	// pageSize is the documented maximum (1-100, default 20).
+	maxPageSize = 100
+
+	// maxPages bounds the cursor loop. /responses reports hasNextPage, so this
+	// is a backstop against a server that never stops advertising a next page,
+	// not the normal exit path. 100 pages x 100 rows = 1M responses.
+	maxPages = 10000
+
+	// SatisMeter documents NO rate limit, so this is a deliberately conservative
+	// self-imposed ceiling rather than 80% of a published number: 5 req/s with a
+	// small burst. Revisit if the vendor ever publishes real limits.
+	rateLimit      = 5.0
+	rateLimitBurst = 5
+
+	// historyFloor is the explicit startDate used when the pipeline supplies no
+	// interval. SatisMeter predates none of our accounts by much, but the point
+	// is to defeat the 30-day server-side default rather than to be exact.
+	historyFloor = "2010-01-01T00:00:00Z"
+)
+
+// supportedTables maps a table name to how it is read.
+//
+// campaign statistics is deliberately NOT exposed. It is a single aggregate row
+// per (campaign, window) with no date dimension, so backfilling it over
+// different windows silently rewrites the same key with different totals — the
+// same failure the Apple Search Ads *_reports tables have. It is also fully
+// derivable from `responses`, which we do ingest.
+var supportedTables = map[string]struct{}{
+	"responses": {},
+	"campaigns": {},
+	"project":   {},
+}
+
+type SatisMeterSource struct {
+	client    *httpclient.Client
+	projectID string
+}
+
+func NewSatisMeterSource() *SatisMeterSource {
+	return &SatisMeterSource{}
+}
+
+func (s *SatisMeterSource) Schemes() []string {
+	return []string{"satismeter"}
+}
+
+func (s *SatisMeterSource) HandlesIncrementality() bool {
+	return false
+}
+
+func (s *SatisMeterSource) Connect(ctx context.Context, uri string) error {
+	apiKey, projectID, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+	s.projectID = projectID
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(baseURL),
+		httpclient.WithTimeout(60*time.Second),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithAuth(httpclient.NewBearerAuth(apiKey)),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithHeader("Accept", "application/json"),
+	)
+	config.Debug("[SATISMETER] connected, project %s", projectID)
+	return nil
+}
+
+func (s *SatisMeterSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func parseURI(uri string) (apiKey, projectID string, err error) {
+	if !strings.HasPrefix(uri, "satismeter://") {
+		return "", "", fmt.Errorf("invalid satismeter URI: must start with satismeter://")
+	}
+	rest := strings.TrimPrefix(strings.TrimPrefix(uri, "satismeter://"), "?")
+	values, err := url.ParseQuery(rest)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse satismeter URI query: %w", err)
+	}
+	apiKey = values.Get("api_key")
+	if apiKey == "" {
+		return "", "", fmt.Errorf("api_key is required in satismeter URI")
+	}
+	projectID = values.Get("project_id")
+	if projectID == "" {
+		return "", "", fmt.Errorf("project_id is required in satismeter URI")
+	}
+	return apiKey, projectID, nil
+}
+
+func isValidTable(name string) bool {
+	_, ok := supportedTables[name]
+	return ok
+}
+
+func supportedTableNames() string {
+	names := make([]string, 0, len(supportedTables))
+	for n := range supportedTables {
+		names = append(names, n)
+	}
+	return strings.Join(names, ", ")
+}
+
+func (s *SatisMeterSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	if !isValidTable(req.Name) {
+		return nil, fmt.Errorf("unsupported satismeter table %q, supported tables are: %s", req.Name, supportedTableNames())
+	}
+
+	// `created` is server-side filterable on /responses, which makes it a real
+	// incremental key. campaigns/project are small snapshots with no time filter
+	// and no update timestamp — merge on their stable id keeps re-runs
+	// idempotent. Neither tracks deletions.
+	incrementalKey := ""
+	if req.Name == "responses" {
+		incrementalKey = "created"
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           req.Name,
+		TablePrimaryKeys:    []string{"id"},
+		TableIncrementalKey: incrementalKey,
+		TableStrategy:       config.StrategyMerge,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("satismeter source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, req.Name, opts)
+		},
+	}, nil
+}
+
+func (s *SatisMeterSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+	go func() {
+		defer close(results)
+		var err error
+		switch table {
+		case "responses":
+			err = s.readResponses(ctx, opts, results)
+		case "campaigns":
+			err = s.readCampaigns(ctx, opts, results)
+		case "project":
+			err = s.readProject(ctx, opts, results)
+		default:
+			err = fmt.Errorf("unsupported satismeter table: %s", table)
+		}
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+	return results, nil
+}
+
+// readResponses pages /responses with a cursor, filtering server-side on the
+// requested interval.
+func (s *SatisMeterSource) readResponses(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SATISMETER] reading responses")
+
+	// Always explicit — see the ⚠️ in the package doc. An omitted startDate is
+	// silently rewritten by SatisMeter to "30 days ago".
+	startDate := historyFloor
+	if opts.IntervalStart != nil {
+		startDate = opts.IntervalStart.UTC().Format(time.RFC3339)
+	}
+	endDate := ""
+	if opts.IntervalEnd != nil {
+		endDate = opts.IntervalEnd.UTC().Format(time.RFC3339)
+	}
+
+	endpoint := "/projects/" + url.PathEscape(s.projectID) + "/responses"
+	cursor := ""
+	for page := 0; ; page++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if page >= maxPages {
+			config.Debug("[SATISMETER] hit maxPages=%d on responses, stopping", maxPages)
+			return fmt.Errorf("responses exceeded the %d page guard; narrow the interval", maxPages)
+		}
+
+		req := s.client.R(ctx).
+			SetQueryParam("pageSize", strconv.Itoa(maxPageSize)).
+			SetQueryParam("startDate", startDate)
+		if endDate != "" {
+			req = req.SetQueryParam("endDate", endDate)
+		}
+		if cursor != "" {
+			req = req.SetQueryParam("pageCursor", cursor)
+		}
+
+		resp, err := req.Get(endpoint)
+		if err != nil {
+			return fmt.Errorf("failed to fetch responses: %w", err)
+		}
+		if !resp.IsSuccess() {
+			return fmt.Errorf("responses returned status %d: %s", resp.StatusCode(), resp.String())
+		}
+
+		var payload struct {
+			Data []map[string]interface{} `json:"data"`
+			Page struct {
+				HasNextPage    bool   `json:"hasNextPage"`
+				NextPageCursor string `json:"nextPageCursor"`
+			} `json:"page"`
+		}
+		// UseNumber: response `answers[].value` and the numeric user traits can
+		// exceed float64 precision once ids leak into them.
+		dec := json.NewDecoder(strings.NewReader(string(resp.Body())))
+		dec.UseNumber()
+		if err := dec.Decode(&payload); err != nil {
+			return fmt.Errorf("failed to parse responses payload: %w", err)
+		}
+
+		if len(payload.Data) > 0 {
+			if err := emit(payload.Data, opts, results); err != nil {
+				return fmt.Errorf("failed to convert responses to Arrow: %w", err)
+			}
+			config.Debug("[SATISMETER] responses page %d: %d rows", page, len(payload.Data))
+		}
+
+		if !payload.Page.HasNextPage || payload.Page.NextPageCursor == "" {
+			return nil
+		}
+		cursor = payload.Page.NextPageCursor
+	}
+}
+
+// readCampaigns fetches the survey list. The endpoint returns everything in one
+// call — it advertises no cursor and takes no date filter.
+func (s *SatisMeterSource) readCampaigns(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SATISMETER] reading campaigns")
+	endpoint := "/projects/" + url.PathEscape(s.projectID) + "/campaigns"
+	resp, err := s.client.R(ctx).Get(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to fetch campaigns: %w", err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("campaigns returned status %d: %s", resp.StatusCode(), resp.String())
+	}
+	var payload struct {
+		Data []map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.Body(), &payload); err != nil {
+		return fmt.Errorf("failed to parse campaigns payload: %w", err)
+	}
+	if len(payload.Data) == 0 {
+		return nil
+	}
+	return emit(payload.Data, opts, results)
+}
+
+// readProject fetches the single project object. It is returned bare, not
+// wrapped in a `data` envelope like the collection endpoints.
+func (s *SatisMeterSource) readProject(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SATISMETER] reading project")
+	endpoint := "/projects/" + url.PathEscape(s.projectID)
+	resp, err := s.client.R(ctx).Get(endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to fetch project: %w", err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("project returned status %d: %s", resp.StatusCode(), resp.String())
+	}
+	var item map[string]interface{}
+	if err := json.Unmarshal(resp.Body(), &item); err != nil {
+		return fmt.Errorf("failed to parse project payload: %w", err)
+	}
+	if len(item) == 0 {
+		return nil
+	}
+	// Some deployments nest the object under `data`; accept both rather than
+	// landing a single row whose only column is a JSON blob.
+	if inner, ok := item["data"].(map[string]interface{}); ok && len(item) == 1 {
+		item = inner
+	}
+	return emit([]map[string]interface{}{item}, opts, results)
+}
+
+func emit(items []map[string]interface{}, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return err
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	return nil
+}

--- a/pkg/source/satismeter/satismeter_test.go
+++ b/pkg/source/satismeter/satismeter_test.go
@@ -1,0 +1,161 @@
+package satismeter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		uri         string
+		wantKey     string
+		wantProject string
+		wantErr     string
+	}{
+		{
+			name:        "valid",
+			uri:         "satismeter://?api_key=abc123&project_id=5bb480aaebf3ed0004c6f3dd",
+			wantKey:     "abc123",
+			wantProject: "5bb480aaebf3ed0004c6f3dd",
+		},
+		{
+			name:        "order does not matter",
+			uri:         "satismeter://?project_id=p1&api_key=k1",
+			wantKey:     "k1",
+			wantProject: "p1",
+		},
+		{
+			name:    "missing api_key",
+			uri:     "satismeter://?project_id=p1",
+			wantErr: "api_key is required",
+		},
+		{
+			// project_id is not optional: the API key is project-scoped but every
+			// endpoint still nests under /projects/{id}, so a missing id would
+			// produce a 404 rather than a sensible default.
+			name:    "missing project_id",
+			uri:     "satismeter://?api_key=k1",
+			wantErr: "project_id is required",
+		},
+		{
+			name:    "empty",
+			uri:     "satismeter://",
+			wantErr: "api_key is required",
+		},
+		{
+			name:    "wrong scheme",
+			uri:     "https://?api_key=k1&project_id=p1",
+			wantErr: "must start with satismeter://",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, project, err := parseURI(tt.uri)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if key != tt.wantKey {
+				t.Errorf("api_key = %q, want %q", key, tt.wantKey)
+			}
+			if project != tt.wantProject {
+				t.Errorf("project_id = %q, want %q", project, tt.wantProject)
+			}
+		})
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	for _, ok := range []string{"responses", "campaigns", "project"} {
+		if !isValidTable(ok) {
+			t.Errorf("isValidTable(%q) = false, want true", ok)
+		}
+	}
+	for _, bad := range []string{"", "Responses", "RESPONSES", "response", "unknown", "campaign_statistics"} {
+		if isValidTable(bad) {
+			t.Errorf("isValidTable(%q) = true, want false", bad)
+		}
+	}
+}
+
+// campaign_statistics is intentionally absent — it is a single aggregate row per
+// (campaign, window) with no date dimension, so backfilling it across windows
+// silently rewrites the same key. See the comment on supportedTables.
+func TestCampaignStatisticsNotExposed(t *testing.T) {
+	if _, ok := supportedTables["campaign_statistics"]; ok {
+		t.Fatal("campaign_statistics is exposed; a windowed aggregate with no date column rewrites itself on every backfill")
+	}
+}
+
+// The pagination envelope is what terminates the responses loop. If SatisMeter
+// ever renames these fields the loop would exit after one page and quietly
+// ingest only the first 100 rows, so pin the decoding here.
+func TestResponsesPageEnvelopeDecodes(t *testing.T) {
+	raw := `{"data":[{"id":"r1","created":"2026-08-02T18:02:23.420Z"}],
+	         "page":{"hasNextPage":true,"nextPageCursor":"WzE3ODU2","size":1}}`
+
+	var payload struct {
+		Data []map[string]interface{} `json:"data"`
+		Page struct {
+			HasNextPage    bool   `json:"hasNextPage"`
+			NextPageCursor string `json:"nextPageCursor"`
+		} `json:"page"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Data) != 1 || payload.Data[0]["id"] != "r1" {
+		t.Errorf("data not decoded: %+v", payload.Data)
+	}
+	if !payload.Page.HasNextPage {
+		t.Error("hasNextPage = false, want true")
+	}
+	if payload.Page.NextPageCursor != "WzE3ODU2" {
+		t.Errorf("nextPageCursor = %q", payload.Page.NextPageCursor)
+	}
+}
+
+// The final page omits nextPageCursor; the loop must stop rather than re-request
+// page one forever with an empty cursor.
+func TestResponsesLastPageStops(t *testing.T) {
+	raw := `{"data":[{"id":"r9"}],"page":{"hasNextPage":false,"size":1}}`
+	var payload struct {
+		Page struct {
+			HasNextPage    bool   `json:"hasNextPage"`
+			NextPageCursor string `json:"nextPageCursor"`
+		} `json:"page"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload.Page.HasNextPage || payload.Page.NextPageCursor != "" {
+		t.Fatal("last page should have hasNextPage=false and no cursor")
+	}
+}
+
+// maxPageSize must stay within the documented 1-100 range; sending 0 or >100
+// gets silently clamped to the default of 20 and quadruples the request count.
+func TestMaxPageSizeWithinDocumentedRange(t *testing.T) {
+	if maxPageSize < 1 || maxPageSize > 100 {
+		t.Fatalf("maxPageSize = %d, SatisMeter documents 1-100", maxPageSize)
+	}
+}
+
+// historyFloor defeats the server-side "last 30 days" default. If it is ever
+// blanked, an interval-less run silently returns a month of data.
+func TestHistoryFloorIsSet(t *testing.T) {
+	if strings.TrimSpace(historyFloor) == "" {
+		t.Fatal("historyFloor is empty; an omitted startDate makes SatisMeter default to 30 days ago")
+	}
+}


### PR DESCRIPTION
## What

Adds [SatisMeter](https://www.satismeter.com/) as a source — an NPS, CSAT and in-app
survey platform. Reads campaigns, responses and projects through the v3 REST API.

## Changes

- **`pkg/source/satismeter/`** — source, `register.go`, tests.
- **`internal/server/connectors.go`** — catalog entry.
- **`docs/supported-sources/satismeter.md`**, **`docs/.vitepress/config.mjs`**,
  **`docs/supported-sources/platforms.md`** — docs page and both indexes.

### One API behaviour worth reviewer attention

**An omitted `startDate` is rewritten server-side to "30 days ago"** rather than meaning
"all history". A pull without an explicit lower bound therefore returns a recent slice
that looks complete — no error, plausible row count, a fraction of the data. We measured
31 rows from an unbounded probe against 25,905 from a bounded backfill on the same
account.

The source always sends an explicit floor so that "no interval" means everything.

## How to test

```bash
ingestr ingest \
  --source-uri 'satismeter://?api_key=<key>&project_id=<id>' \
  --source-table responses \
  --dest-uri duckdb:///satismeter.duckdb \
  --dest-table main.responses
```

`go test ./pkg/source/satismeter/` covers the pure logic without network access.

## Risk & rollback

- **Risk:** low. Purely additive — one new package, one catalog line, three docs files.
  No existing source, destination or shared code path is touched.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format-ci`, `make lint` — 0 issues)
- [x] Integration tests pass if affected — not affected; no shared code path is touched
- [x] No unrelated changes included
- [x] Tested locally against a live account

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities — no new dependencies at all
- [x] Security implications considered

## Related issues

None found.

---

### Where this comes from

We've been running this nightly in our own production warehouse since mid-August. That's
why it's arriving now rather than the day it was written — we wanted it to settle first,
and every API quirk called out above is something it actually hit in practice rather than
something we read in the docs.

**No pressure at all if you'd rather not take it.** We're keeping these in our fork
either way and they cost us nothing to maintain there; we're only sending them because
they seemed like they might be useful to someone else. Equally happy to change anything
to taste, or to close it — just say.
