### PR TITLE
feat(source): add Twenty CRM source

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -278,6 +278,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "SurveyMonkey", link: "/supported-sources/surveymonkey.md" },
               { text: "TikTok Ads", link: "/supported-sources/tiktok-ads.md" },
               { text: "Trello", link: "/supported-sources/trello.md" },
+              { text: "Twenty CRM", link: "/supported-sources/twenty.md" },
               { text: "Twilio", link: "/supported-sources/twilio.md" },
               { text: "2Checkout", link: "/supported-sources/twocheckout.md" },
               { text: "Typeform", link: "/supported-sources/typeform.md" },

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -44,6 +44,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Pipedrive](/supported-sources/pipedrive.md)
 - [Plus Vibe AI](/supported-sources/plusvibeai.md)
 - [Salesforce](/supported-sources/salesforce.md)
+- [Twenty CRM](/supported-sources/twenty.md)
 - [Zendesk](/supported-sources/zendesk.md)
 
 ## Commerce, payments, billing, and finance

--- a/docs/supported-sources/twenty.md
+++ b/docs/supported-sources/twenty.md
@@ -37,23 +37,30 @@ ingestr ingest \
 
 ## Tables
 
-The table name is an object's **plural API name** — `people`, `companies`,
-`opportunities`, `notes`, `tasks`, `leads`, `workspaceMembers`, and any custom
-object your workspace defines.
+Twenty supports the following tables:
 
-There is no fixed table list, because Twenty has no fixed object list. Every
-object, standard or custom, publishes its fields and types under
-`/rest/metadata/objects`, and ingestr reads that to build the table's schema. Two
-workspaces of the same Twenty version can therefore expose different tables and
-very different columns, and both are handled by the same connector.
+| Table | PK | Inc Key | Inc Strategy | Details |
+|-------|----|---------|--------------|---------|
+| `companies` | id | updatedAt | merge | Companies in the workspace. |
+| `notes` | id | updatedAt | merge | Notes attached to workspace records. |
+| `opportunities` | id | updatedAt | merge | Sales opportunities. |
+| `people` | id | updatedAt | merge | People in the workspace. |
+| `tasks` | id | updatedAt | merge | Tasks attached to workspace records. |
+| `workspaceMembers` | id | updatedAt | merge | Members of the workspace. |
+| `custom:<object_name>` | id | updatedAt | merge | A custom object, using its plural API name. |
 
-Passing a singular name is caught and corrected:
+Twenty exposes custom objects through the same REST API as standard objects. To
+ingest one, prefix its plural API name with `custom:`, for example
+`custom:leads`. The connector reads the object's metadata at runtime, so custom
+fields are included automatically.
 
+```sh
+ingestr ingest \
+  --source-uri 'twenty://api.twenty.com?api_key=eyJ...' \
+  --source-table 'custom:leads' \
+  --dest-uri $DEST \
+  --dest-table 'main.leads'
 ```
-twenty: "person" is the singular name; use the plural api name "people" as the table
-```
-
-An unknown object lists what the workspace actually has.
 
 ## Columns
 
@@ -62,7 +69,7 @@ Columns follow Twenty's field names verbatim.
 - **Relations become foreign keys.** A person's `company` relation lands as the
   `companyId` column, matching what the API returns. One-to-many relations
   (a person's `noteTargets`) produce no column — that key lives on the child.
-- **Composite fields land as JSON text** rather than being flattened:
+- **Composite fields use the JSON type** rather than being flattened:
   `name`, `emails`, `phones`, `address`, `domainName`, `linkedinLink`, `amount`,
   `createdBy`, `updatedBy`.
 - **Money is not a float.** Twenty stores currency as

--- a/docs/supported-sources/twenty.md
+++ b/docs/supported-sources/twenty.md
@@ -1,0 +1,109 @@
+# Twenty CRM
+
+[Twenty](https://twenty.com/) is an open-source CRM. It runs both as a hosted
+workspace (`api.twenty.com`) and self-hosted on your own domain; ingestr supports
+both.
+
+ingestr supports Twenty CRM as a source.
+
+## URI format
+
+```
+twenty://<host>?api_key=<api_key>
+```
+
+- `host` — the workspace host. `api.twenty.com` for Twenty Cloud, or your own
+  domain for a self-hosted instance (e.g. `crm.example.com`).
+- `api_key` — created in the workspace under **Settings → API & Webhooks**. The
+  key is shown only once. One key covers one workspace.
+
+Optional parameters:
+
+- `page_size` — rows per request, default and maximum `200`.
+- `rate_limit` — requests per second, default `1.33` (80% of Twenty's documented
+  100 requests/minute).
+- `include_deleted` — default `true`, see below.
+- `base_path` — where the REST API is mounted, default `/rest`.
+
+Example:
+
+```sh
+ingestr ingest \
+  --source-uri 'twenty://api.twenty.com?api_key=eyJ...' \
+  --source-table 'people' \
+  --dest-uri $DEST \
+  --dest-table 'main.people'
+```
+
+## Tables
+
+The table name is an object's **plural API name** — `people`, `companies`,
+`opportunities`, `notes`, `tasks`, `leads`, `workspaceMembers`, and any custom
+object your workspace defines.
+
+There is no fixed table list, because Twenty has no fixed object list. Every
+object, standard or custom, publishes its fields and types under
+`/rest/metadata/objects`, and ingestr reads that to build the table's schema. Two
+workspaces of the same Twenty version can therefore expose different tables and
+very different columns, and both are handled by the same connector.
+
+Passing a singular name is caught and corrected:
+
+```
+twenty: "person" is the singular name; use the plural api name "people" as the table
+```
+
+An unknown object lists what the workspace actually has.
+
+## Columns
+
+Columns follow Twenty's field names verbatim.
+
+- **Relations become foreign keys.** A person's `company` relation lands as the
+  `companyId` column, matching what the API returns. One-to-many relations
+  (a person's `noteTargets`) produce no column — that key lives on the child.
+- **Composite fields land as JSON text** rather than being flattened:
+  `name`, `emails`, `phones`, `address`, `domainName`, `linkedinLink`, `amount`,
+  `createdBy`, `updatedBy`.
+- **Money is not a float.** Twenty stores currency as
+  `{"amountMicros": 1500000, "currencyCode": "CZK"}` — integer micros. The digits
+  are carried through exactly; divide by 1e6 when you model it.
+- `searchVector` is dropped. It is Postgres' full-text index, not data.
+
+## Incremental loading
+
+Every Twenty object carries `updatedAt`, which is used as the incremental key with
+the `merge` strategy, filtered server-side:
+
+```
+filter=updatedAt[gte]:2026-08-01T00:00:00.000Z
+```
+
+Only the start of the interval is applied. An upper bound would make re-running an
+old window silently drop rows edited since, and `merge` is idempotent, so a wider
+window costs requests rather than correctness.
+
+Records are walked with Twenty's cursor pagination in the API's default order,
+which is by `id`. Ordering by `updatedAt` instead would be unstable: a record
+edited mid-run moves in the sort order and can be skipped or read twice across a
+page boundary.
+
+## Deleted records
+
+Twenty soft-deletes: a deleted record keeps its row with `deletedAt` set, and is
+**excluded from every list response by default**. Left at that, a record deleted
+in the CRM would keep its last-known state in your warehouse forever, looking
+live.
+
+So by default ingestr makes a second pass with `deletedAt[is]:NOT_NULL` and
+re-reads exactly those records, whose `deletedAt` then lands populated. Filter on
+`deletedAt IS NULL` downstream to see the live set.
+
+Set `include_deleted=false` to skip that pass — one fewer walk per run, at the
+cost of never learning about a deletion.
+
+## Rate limits
+
+Twenty documents **100 requests per minute**. The default limiter runs at 80% of
+that. With the maximum page size of 200 rows, a 68,000-row object is roughly 340
+requests, or about four minutes.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -410,6 +410,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("trello", "Trello", []string{"trello"}, true, false),
 		genericURIConnector("trino", "Trino", []string{"trino"}, true, true),
 		genericURIConnector("trustpilot", "Trustpilot", []string{"trustpilot"}, true, false),
+		genericURIConnector("twenty", "Twenty CRM", []string{"twenty"}, true, false),
 		genericURIConnector("twilio", "Twilio", []string{"twilio"}, true, false),
 		genericURIConnector("twocheckout", "2Checkout", []string{"twocheckout"}, true, false),
 		genericURIConnector("typeform", "Typeform", []string{"typeform"}, true, false),

--- a/pkg/source/twenty/register.go
+++ b/pkg/source/twenty/register.go
@@ -1,0 +1,10 @@
+package twenty
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"twenty"},
+		func() interface{} { return NewTwentySource() },
+	)
+}

--- a/pkg/source/twenty/schema.go
+++ b/pkg/source/twenty/schema.go
@@ -12,23 +12,6 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
-// ── Twenty's metadata API ────────────────────────────────────────────────────
-//
-//	GET /rest/metadata/objects
-//	{"data":{"objects":[ {nameSingular, namePlural, isActive, fields:[…]} ]},
-//	 "pageInfo":{"endCursor":…,"hasNextPage":false},"totalCount":25}
-//
-// This is what makes one generic reader cover every object, exactly like the
-// sibling `abra` source: Twenty is metadata-driven, so the SAME code serves a
-// stock workspace and a heavily customised one. It also has to — two workspaces
-// of the same product genuinely differ: measured on two live workspaces, one had
-// a `lead` object the other lacked, and their `person` objects carried 79 fields
-// against 32. A hand-written
-// table list would be wrong for one of them on day one.
-
-// relationSettings is the `settings` blob. Twenty overloads this key per field
-// type — relations put relationType/joinColumnName in it, NUMBER puts dataType.
-// Decoding both into one struct is safe because the absent keys stay zero.
 type relationSettings struct {
 	RelationType   string `json:"relationType"`
 	JoinColumnName string `json:"joinColumnName"`
@@ -49,22 +32,12 @@ type objectMeta struct {
 	Fields       []fieldMeta `json:"fields"`
 }
 
-// metadataCache memoises the object list for the lifetime of one ingestr run.
-// GetTable is called once per table, and a multi-table job would otherwise
-// re-read the whole metadata document per table — wasteful against a 100 req/min
-// budget that the actual row reads need.
 type metadataCache struct {
 	once    sync.Once
 	objects []objectMeta
 	err     error
 }
 
-// fetchObjects reads every object metadata definition, following pagination.
-//
-// The live workspaces answer in a single page (25 objects), but the endpoint is
-// cursor-paginated like every other Twenty collection and a workspace that grows
-// past the default page would otherwise lose objects silently — the failure would
-// surface as "unknown object" for a table that plainly exists in the UI.
 func (s *Source) fetchObjects(ctx context.Context) ([]objectMeta, error) {
 	s.meta.once.Do(func() {
 		var all []objectMeta
@@ -105,7 +78,6 @@ func (s *Source) fetchObjects(ctx context.Context) ([]objectMeta, error) {
 	return s.meta.objects, s.meta.err
 }
 
-// decodeObjects unwraps {"data":{"objects":[…]},"pageInfo":{…}}.
 func decodeObjects(body []byte) ([]objectMeta, pageInfo, error) {
 	var env struct {
 		Data struct {
@@ -119,29 +91,16 @@ func decodeObjects(body []byte) ([]objectMeta, pageInfo, error) {
 	return env.Data.Objects, env.PageInfo, nil
 }
 
-// ── Column planning ──────────────────────────────────────────────────────────
-
-// tablePlan is everything the reader needs about one object, derived once from
-// the metadata so neither the declared schema nor the row projection can drift
-// mid-run.
 type tablePlan struct {
-	object   string // namePlural — both the URL path and the response envelope key
-	singular string
-	columns  []schema.Column
-	typeOf   map[string]schema.DataType
-	// dropped are source keys we deliberately do not carry. Tracked so the drift
-	// warning stays meaningful instead of firing on every row for searchVector.
+	object       string
+	singular     string
+	columns      []schema.Column
+	typeOf       map[string]schema.DataType
 	dropped      map[string]struct{}
 	hasUpdatedAt bool
 	hasDeletedAt bool
 }
 
-// sanitizeColumn keeps a Twenty field name usable as a column name.
-//
-// Twenty enforces camelCase API names, so in practice this is a no-op — it exists
-// so a future custom field with an unexpected character fails as a renamed column
-// rather than as unquoted-identifier SQL. Same minimal substitution as `abra`:
-// every character outside [A-Za-z0-9_] becomes '_', casing preserved.
 func sanitizeColumn(name string) string {
 	var b strings.Builder
 	b.Grow(len(name))
@@ -156,29 +115,9 @@ func sanitizeColumn(name string) string {
 	return b.String()
 }
 
-// dataTypeFor maps a Twenty field type onto an ingestr/Arrow type.
-//
-// ⚠️ COMPOSITE FIELDS BECOME STRINGS CARRYING JSON TEXT, NOT schema.TypeJSON.
-// Twenty's composites (EMAILS, PHONES, LINKS, ADDRESS, CURRENCY, FULL_NAME,
-// ACTOR, RICH_TEXT_V2, ARRAY, MULTI_SELECT, RAW_JSON) are small JSON objects.
-// TypeJSON is not handled uniformly across destinations — some have
-// no mapping for it — so declaring it would land us on an untested path. String
-// is what the sibling `abra` source does with the same class of value, and a
-// reads it back with JSONExtractString, a pattern already in use here.
-//
-// ⚠️ CURRENCY IS THEREFORE NOT A DECIMAL, AND THAT IS DELIBERATE. Twenty carries
-// money as {amountMicros, currencyCode} — integer micros, never a float — so the
-// exact value survives as text and a downstream model divides by 1e6 explicitly.
-// That also keeps this source clear of destination decimal handling for tables with
-// a decimal column on its SECOND sync.
-//
-// NUMBER honours settings.dataType: ints stay ints; anything else keeps its exact
-// decimal text rather than being rounded through a float.
 func dataTypeFor(f fieldMeta) (schema.DataType, bool) {
 	switch strings.ToUpper(strings.TrimSpace(f.Type)) {
 	case "TS_VECTOR":
-		// searchVector is Postgres' full-text index, echoed by REST as
-		// "'notion':1 'notion.com':2". Bulky, derived, and of no analytical use.
 		return 0, false
 	case "BOOLEAN":
 		return schema.TypeBoolean, true
@@ -187,34 +126,19 @@ func dataTypeFor(f fieldMeta) (schema.DataType, bool) {
 	case "DATE":
 		return schema.TypeDate, true
 	case "POSITION":
-		// Twenty's manual-ordering key. Fractional by design — it bisects to
-		// insert between two rows.
 		return schema.TypeFloat64, true
 	case "NUMBER":
 		if f.Settings != nil && !strings.EqualFold(f.Settings.DataType, "int") && f.Settings.DataType != "" {
 			return schema.TypeString, true
 		}
 		return schema.TypeInt64, true
+	case "EMAILS", "PHONES", "LINKS", "ADDRESS", "CURRENCY", "FULL_NAME", "ACTOR", "RICH_TEXT_V2", "ARRAY", "MULTI_SELECT", "RAW_JSON":
+		return schema.TypeJSON, true
 	default:
-		// UUID, TEXT, RICH_TEXT, SELECT, RATING and every composite above.
 		return schema.TypeString, true
 	}
 }
 
-// buildPlan turns one object's metadata into a column plan.
-//
-// ⚠️ RELATIONS ARE THE WHOLE REASON THIS READS METADATA RATHER THAN GUESSING.
-// At depth=0 Twenty returns the FOREIGN KEY, not the related object — a person
-// carries `companyId`, never a nested `company`. But the metadata field is named
-// `company`, and the FK name lives in settings.joinColumnName. So:
-//
-//	MANY_TO_ONE  -> declare settings.joinColumnName (companyId, ownerId, …)
-//	ONE_TO_MANY  -> declare NOTHING; the child side owns that key
-//
-// Inferring the schema from a response instead would have worked, but a column
-// that is entirely NULL in the first batch infers as the wrong type and a
-// customised workspace has plenty of those. The join keys are also the single
-// most valuable thing in a CRM extract, so guessing at them is the wrong trade.
 func buildPlan(obj objectMeta) (*tablePlan, error) {
 	p := &tablePlan{
 		object:   obj.NamePlural,
@@ -253,8 +177,6 @@ func buildPlan(obj objectMeta) (*tablePlan, error) {
 				add(f.Settings.JoinColumnName, schema.TypeString, false)
 				continue
 			}
-			// ONE_TO_MANY (and any relation without a join column): no column on
-			// this side of the edge. Recorded so it is not reported as drift.
 			p.dropped[f.Name] = struct{}{}
 			continue
 		}
@@ -267,7 +189,6 @@ func buildPlan(obj objectMeta) (*tablePlan, error) {
 		switch f.Name {
 		case "id":
 			hasID = true
-			// Twenty ids are UUIDs and are never null.
 			add("id", schema.TypeString, true)
 			continue
 		case updatedAtField:
@@ -278,21 +199,13 @@ func buildPlan(obj objectMeta) (*tablePlan, error) {
 		add(f.Name, dt, false)
 	}
 
-	// ⚠️ FAIL CLOSED ON A MISSING PRIMARY KEY. Without `id` there is nothing to
-	// deduplicate on, and under an append-style incremental strategy every
-	// run would append the full object forever. `count() FINAL` could not see it.
 	if !hasID {
 		return nil, fmt.Errorf("twenty: object %q exposes no `id` field and cannot be ingested safely", obj.NamePlural)
 	}
 
-	// ⚠️ DO NOT ADD A LOAD-TIMESTAMP COLUMN. ingestr's strategy layer sets
-	// `_ingestr_loaded_at` itself, and the promote script uses exactly that column
-	// as the ReplicatedReplacingMergeTree version.
-
 	return p, nil
 }
 
-// sortedKeys returns map keys in a stable order for log lines.
 func sortedKeys(m map[string]struct{}) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/pkg/source/twenty/schema.go
+++ b/pkg/source/twenty/schema.go
@@ -1,0 +1,310 @@
+package twenty
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+// ── Twenty's metadata API ────────────────────────────────────────────────────
+//
+//	GET /rest/metadata/objects
+//	{"data":{"objects":[ {nameSingular, namePlural, isActive, fields:[…]} ]},
+//	 "pageInfo":{"endCursor":…,"hasNextPage":false},"totalCount":25}
+//
+// This is what makes one generic reader cover every object, exactly like the
+// sibling `abra` source: Twenty is metadata-driven, so the SAME code serves a
+// stock workspace and a heavily customised one. It also has to — two workspaces
+// of the same product genuinely differ: measured on two live workspaces, one had
+// a `lead` object the other lacked, and their `person` objects carried 79 fields
+// against 32. A hand-written
+// table list would be wrong for one of them on day one.
+
+// relationSettings is the `settings` blob. Twenty overloads this key per field
+// type — relations put relationType/joinColumnName in it, NUMBER puts dataType.
+// Decoding both into one struct is safe because the absent keys stay zero.
+type relationSettings struct {
+	RelationType   string `json:"relationType"`
+	JoinColumnName string `json:"joinColumnName"`
+	DataType       string `json:"dataType"`
+}
+
+type fieldMeta struct {
+	Name     string            `json:"name"`
+	Type     string            `json:"type"`
+	IsActive bool              `json:"isActive"`
+	Settings *relationSettings `json:"settings"`
+}
+
+type objectMeta struct {
+	NameSingular string      `json:"nameSingular"`
+	NamePlural   string      `json:"namePlural"`
+	IsActive     bool        `json:"isActive"`
+	Fields       []fieldMeta `json:"fields"`
+}
+
+// metadataCache memoises the object list for the lifetime of one ingestr run.
+// GetTable is called once per table, and a multi-table job would otherwise
+// re-read the whole metadata document per table — wasteful against a 100 req/min
+// budget that the actual row reads need.
+type metadataCache struct {
+	once    sync.Once
+	objects []objectMeta
+	err     error
+}
+
+// fetchObjects reads every object metadata definition, following pagination.
+//
+// The live workspaces answer in a single page (25 objects), but the endpoint is
+// cursor-paginated like every other Twenty collection and a workspace that grows
+// past the default page would otherwise lose objects silently — the failure would
+// surface as "unknown object" for a table that plainly exists in the UI.
+func (s *Source) fetchObjects(ctx context.Context) ([]objectMeta, error) {
+	s.meta.once.Do(func() {
+		var all []objectMeta
+		cursor := ""
+		for page := 0; page < maxMetadataPages; page++ {
+			req := s.client.R(ctx).SetQueryParam("limit", strconv.Itoa(metadataPageSize))
+			if cursor != "" {
+				req = req.SetQueryParam("starting_after", cursor)
+			}
+			resp, err := req.Get("/metadata/objects")
+			if err != nil {
+				s.meta.err = fmt.Errorf("twenty: failed to fetch object metadata: %w", err)
+				return
+			}
+			if !resp.IsSuccess() {
+				s.meta.err = fmt.Errorf("twenty: object metadata request returned HTTP %d: %s",
+					resp.StatusCode(), truncate(resp.String(), 300))
+				return
+			}
+			objs, info, err := decodeObjects([]byte(resp.String()))
+			if err != nil {
+				s.meta.err = err
+				return
+			}
+			all = append(all, objs...)
+			if !info.HasNextPage || info.EndCursor == "" || len(objs) == 0 {
+				break
+			}
+			cursor = info.EndCursor
+		}
+		if len(all) == 0 {
+			s.meta.err = fmt.Errorf("twenty: the workspace reported no objects at all — " +
+				"this is an auth or endpoint problem, not an empty workspace")
+			return
+		}
+		s.meta.objects = all
+	})
+	return s.meta.objects, s.meta.err
+}
+
+// decodeObjects unwraps {"data":{"objects":[…]},"pageInfo":{…}}.
+func decodeObjects(body []byte) ([]objectMeta, pageInfo, error) {
+	var env struct {
+		Data struct {
+			Objects []objectMeta `json:"objects"`
+		} `json:"data"`
+		PageInfo pageInfo `json:"pageInfo"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, pageInfo{}, fmt.Errorf("twenty: failed to parse object metadata: %w", err)
+	}
+	return env.Data.Objects, env.PageInfo, nil
+}
+
+// ── Column planning ──────────────────────────────────────────────────────────
+
+// tablePlan is everything the reader needs about one object, derived once from
+// the metadata so neither the declared schema nor the row projection can drift
+// mid-run.
+type tablePlan struct {
+	object   string // namePlural — both the URL path and the response envelope key
+	singular string
+	columns  []schema.Column
+	typeOf   map[string]schema.DataType
+	// dropped are source keys we deliberately do not carry. Tracked so the drift
+	// warning stays meaningful instead of firing on every row for searchVector.
+	dropped      map[string]struct{}
+	hasUpdatedAt bool
+	hasDeletedAt bool
+}
+
+// sanitizeColumn keeps a Twenty field name usable as a column name.
+//
+// Twenty enforces camelCase API names, so in practice this is a no-op — it exists
+// so a future custom field with an unexpected character fails as a renamed column
+// rather than as unquoted-identifier SQL. Same minimal substitution as `abra`:
+// every character outside [A-Za-z0-9_] becomes '_', casing preserved.
+func sanitizeColumn(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// dataTypeFor maps a Twenty field type onto an ingestr/Arrow type.
+//
+// ⚠️ COMPOSITE FIELDS BECOME STRINGS CARRYING JSON TEXT, NOT schema.TypeJSON.
+// Twenty's composites (EMAILS, PHONES, LINKS, ADDRESS, CURRENCY, FULL_NAME,
+// ACTOR, RICH_TEXT_V2, ARRAY, MULTI_SELECT, RAW_JSON) are small JSON objects.
+// TypeJSON is not handled uniformly across destinations — some have
+// no mapping for it — so declaring it would land us on an untested path. String
+// is what the sibling `abra` source does with the same class of value, and a
+// reads it back with JSONExtractString, a pattern already in use here.
+//
+// ⚠️ CURRENCY IS THEREFORE NOT A DECIMAL, AND THAT IS DELIBERATE. Twenty carries
+// money as {amountMicros, currencyCode} — integer micros, never a float — so the
+// exact value survives as text and a downstream model divides by 1e6 explicitly.
+// That also keeps this source clear of destination decimal handling for tables with
+// a decimal column on its SECOND sync.
+//
+// NUMBER honours settings.dataType: ints stay ints; anything else keeps its exact
+// decimal text rather than being rounded through a float.
+func dataTypeFor(f fieldMeta) (schema.DataType, bool) {
+	switch strings.ToUpper(strings.TrimSpace(f.Type)) {
+	case "TS_VECTOR":
+		// searchVector is Postgres' full-text index, echoed by REST as
+		// "'notion':1 'notion.com':2". Bulky, derived, and of no analytical use.
+		return 0, false
+	case "BOOLEAN":
+		return schema.TypeBoolean, true
+	case "DATE_TIME":
+		return schema.TypeTimestamp, true
+	case "DATE":
+		return schema.TypeDate, true
+	case "POSITION":
+		// Twenty's manual-ordering key. Fractional by design — it bisects to
+		// insert between two rows.
+		return schema.TypeFloat64, true
+	case "NUMBER":
+		if f.Settings != nil && !strings.EqualFold(f.Settings.DataType, "int") && f.Settings.DataType != "" {
+			return schema.TypeString, true
+		}
+		return schema.TypeInt64, true
+	default:
+		// UUID, TEXT, RICH_TEXT, SELECT, RATING and every composite above.
+		return schema.TypeString, true
+	}
+}
+
+// buildPlan turns one object's metadata into a column plan.
+//
+// ⚠️ RELATIONS ARE THE WHOLE REASON THIS READS METADATA RATHER THAN GUESSING.
+// At depth=0 Twenty returns the FOREIGN KEY, not the related object — a person
+// carries `companyId`, never a nested `company`. But the metadata field is named
+// `company`, and the FK name lives in settings.joinColumnName. So:
+//
+//	MANY_TO_ONE  -> declare settings.joinColumnName (companyId, ownerId, …)
+//	ONE_TO_MANY  -> declare NOTHING; the child side owns that key
+//
+// Inferring the schema from a response instead would have worked, but a column
+// that is entirely NULL in the first batch infers as the wrong type and a
+// customised workspace has plenty of those. The join keys are also the single
+// most valuable thing in a CRM extract, so guessing at them is the wrong trade.
+func buildPlan(obj objectMeta) (*tablePlan, error) {
+	p := &tablePlan{
+		object:   obj.NamePlural,
+		singular: obj.NameSingular,
+		typeOf:   map[string]schema.DataType{},
+		dropped:  map[string]struct{}{},
+	}
+
+	seen := map[string]struct{}{}
+	add := func(sourceKey string, dt schema.DataType, isPK bool) {
+		dest := sanitizeColumn(sourceKey)
+		if dest == "" {
+			return
+		}
+		if _, dup := seen[dest]; dup {
+			return
+		}
+		seen[dest] = struct{}{}
+		p.typeOf[dest] = dt
+		p.columns = append(p.columns, schema.Column{
+			Name:         dest,
+			DataType:     dt,
+			Nullable:     !isPK,
+			IsPrimaryKey: isPK,
+		})
+	}
+
+	hasID := false
+	for _, f := range obj.Fields {
+		if f.Name == "" || !f.IsActive {
+			continue
+		}
+		if strings.EqualFold(f.Type, "RELATION") {
+			if f.Settings != nil && strings.EqualFold(f.Settings.RelationType, "MANY_TO_ONE") &&
+				f.Settings.JoinColumnName != "" {
+				add(f.Settings.JoinColumnName, schema.TypeString, false)
+				continue
+			}
+			// ONE_TO_MANY (and any relation without a join column): no column on
+			// this side of the edge. Recorded so it is not reported as drift.
+			p.dropped[f.Name] = struct{}{}
+			continue
+		}
+
+		dt, keep := dataTypeFor(f)
+		if !keep {
+			p.dropped[f.Name] = struct{}{}
+			continue
+		}
+		switch f.Name {
+		case "id":
+			hasID = true
+			// Twenty ids are UUIDs and are never null.
+			add("id", schema.TypeString, true)
+			continue
+		case updatedAtField:
+			p.hasUpdatedAt = true
+		case deletedAtField:
+			p.hasDeletedAt = true
+		}
+		add(f.Name, dt, false)
+	}
+
+	// ⚠️ FAIL CLOSED ON A MISSING PRIMARY KEY. Without `id` there is nothing to
+	// deduplicate on, and under an append-style incremental strategy every
+	// run would append the full object forever. `count() FINAL` could not see it.
+	if !hasID {
+		return nil, fmt.Errorf("twenty: object %q exposes no `id` field and cannot be ingested safely", obj.NamePlural)
+	}
+
+	// ⚠️ DO NOT ADD A LOAD-TIMESTAMP COLUMN. ingestr's strategy layer sets
+	// `_ingestr_loaded_at` itself, and the promote script uses exactly that column
+	// as the ReplicatedReplacingMergeTree version.
+
+	return p, nil
+}
+
+// sortedKeys returns map keys in a stable order for log lines.
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/pkg/source/twenty/twenty.go
+++ b/pkg/source/twenty/twenty.go
@@ -1,60 +1,4 @@
-// Package twenty implements an ingestr source for Twenty CRM — the open-source
-// an open-source CRM, for sales and lifecycle data.
-//
-// Docs:  https://docs.twenty.com/developers/extend/api
-// Base:  https://<host>/rest/<objectPlural>          (core records)
-//
-//	https://<host>/rest/metadata/objects         (schema)
-//
-// Auth:  Authorization: Bearer <API key>, one key per workspace.
-//
-// Works against both deployment shapes we run: Twenty Cloud
-// (api.twenty.com) and self-hosted (any host running the REST API).
-//
-// ── Why this is a generic engine rather than a hand-written table list ───────
-//
-// Twenty is metadata-driven: every object, standard or custom, publishes its
-// fields with types at /rest/metadata/objects. One reader therefore covers every
-// object, and adding a table to a CronJob is a string, not a code change. That
-// is not just convenience — two workspaces of the same product genuinely diverge.
-// Measured across two live workspaces: one had a `lead` object the other lacked,
-// and their `person` objects carried 79 fields against 32.
-// A static table/column list would have been wrong for one of them immediately.
-//
-// ── The traps, all verified against the live API ─────────────────────────────
-//
-// ⚠️ depth=0 IS ALWAYS SENT. Twenty's default depth embeds related records, so a
-// person arrives carrying its whole company object. That inflates every page,
-// and worse, it makes the row shape depend on a server-side default we do not
-// control. depth=0 returns the flat record plus foreign keys, which is exactly
-// the raw layer's job. See readPass.
-//
-// ⚠️ THE CURSOR IS OPAQUE BASE64, NOT AN ID. pageInfo.endCursor decodes to
-// {"id":"…"} today, but it is a cursor and is passed back verbatim. Never
-// synthesise one from a record id.
-//
-// ⚠️ PAGING IS ORDERED BY id, NOT BY THE CURSOR FIELD, and order_by is
-// deliberately NOT sent. The default order is what endCursor is built against;
-// ordering by updatedAt while walking a cursor would be unstable, because any
-// row edited mid-run moves in the sort order and can be skipped or repeated
-// across a page boundary. id is immutable, so the walk is stable even while
-// sales is editing records underneath it.
-//
-// ⚠️ SOFT DELETES ARE INVISIBLE BY DEFAULT. Twenty excludes deletedAt IS NOT NULL
-// from every list response. Under merge that means a deleted record keeps its
-// last-known state in the warehouse FOREVER, looking live. So a second pass runs
-// with deletedAt[is]:NOT_NULL and re-reads exactly those rows, whose deletedAt
-// then lands populated for downstream to filter on. Disable with
-// include_deleted=false; do not disable it casually.
-//
-// ⚠️ MONEY IS {amountMicros, currencyCode} AND STAYS TEXT. See dataTypeFor —
-// this also keeps the source clear of destination decimal handling on any
-// table with a decimal column on its SECOND sync.
-//
-// ⚠️ ONE KEY PER WORKSPACE, AND THE WORKSPACE IS ONLY IN THE HOST. Pointing the
-// one workspace's key at another workspace's host (or either at the wrong destination)
-// produces no error, just the wrong company's CRM in the wrong table. Same shape
-// that bit the fakturoid and abra ports.
+// Package twenty implements a source for Twenty CRM.
 package twenty
 
 import (
@@ -74,57 +18,34 @@ import (
 )
 
 const (
-	// updatedAtField is Twenty's row-modification timestamp, present on every
-	// object. It is server-side filterable, which is what makes incremental
-	// loading real rather than a full re-read every night.
-	updatedAtField = "updatedAt"
-
-	// deletedAtField drives the soft-delete pass — see the package doc.
-	deletedAtField = "deletedAt"
-
-	// defaultPageSize is Twenty's documented maximum. At 100 requests/minute the
-	// page size is the only lever on wall-clock, so it is pinned to the ceiling:
-	// a 68k-person workspace is ~342 requests here, and 6,828 at the API default of
-	// 20 — over an hour of pure rate-limit wait.
-	defaultPageSize = 200
-
-	// maxPageSize is the API's hard cap; a larger value is rejected upstream.
-	maxPageSize = 200
-
-	// maxPages bounds the cursor walk. At the default page size this allows 40M
-	// rows per object — a runaway guard against a cursor that never advances,
-	// not a limit on real data.
-	maxPages = 200000
-
-	// metadataPageSize / maxMetadataPages bound the schema read. Workspaces have
-	// tens of objects, not thousands.
-	metadataPageSize = 200
-	maxMetadataPages = 50
-
-	// defaultRateLimit is 80% of Twenty's documented 100 requests/minute,
-	// expressed per second: (100 * 0.8) / 60. With burst 5 the first minute
-	// issues at most 5 + ~80 = 85 requests, inside the cap.
-	defaultRateLimit = 1.3333
-
-	// defaultRateLimitBurst per the add-source guidance.
+	updatedAtField        = "updatedAt"
+	deletedAtField        = "deletedAt"
+	defaultPageSize       = 200
+	maxPageSize           = 200
+	maxPages              = 200000
+	metadataPageSize      = 200
+	maxMetadataPages      = 50
+	defaultRateLimit      = 1.3333
 	defaultRateLimitBurst = 5
-
-	// twentyTimeLayout is what Twenty both emits and accepts in filters:
-	// 2026-08-15T01:44:03.057Z — always UTC, always milliseconds.
-	twentyTimeLayout = "2006-01-02T15:04:05.000Z"
-
-	// defaultBasePath is where both Cloud and self-hosted serve the REST API.
-	defaultBasePath = "/rest"
+	twentyTimeLayout      = "2006-01-02T15:04:05.000Z"
+	defaultBasePath       = "/rest"
 )
 
-// pageInfo is Twenty's cursor envelope, shared by core and metadata responses.
+var standardTables = map[string]struct{}{
+	"companies":        {},
+	"notes":            {},
+	"opportunities":    {},
+	"people":           {},
+	"tasks":            {},
+	"workspaceMembers": {},
+}
+
 type pageInfo struct {
 	StartCursor string `json:"startCursor"`
 	EndCursor   string `json:"endCursor"`
 	HasNextPage bool   `json:"hasNextPage"`
 }
 
-// Source is one authenticated view into ONE Twenty workspace.
 type Source struct {
 	client         *httpclient.Client
 	pageSize       int
@@ -137,9 +58,6 @@ func NewTwentySource() *Source { return &Source{} }
 
 func (s *Source) Schemes() []string { return []string{"twenty"} }
 
-// HandlesIncrementality is false: this source pushes `updatedAt[gte]:…` down to
-// Twenty as a read filter, but the destination still performs the merge. It
-// keeps no state of its own.
 func (s *Source) HandlesIncrementality() bool { return false }
 
 type uriConfig struct {
@@ -151,13 +69,6 @@ type uriConfig struct {
 	includeDeleted bool
 }
 
-// parseURI accepts:
-//
-//	twenty://api.twenty.com?api_key=…
-//	twenty://crm.example.com?api_key=…
-//
-// Optional: page_size, rate_limit, base_path, include_deleted, scheme (http for
-// tests).
 func parseURI(uri string) (uriConfig, error) {
 	var cfg uriConfig
 
@@ -174,9 +85,6 @@ func parseURI(uri string) (uriConfig, error) {
 	cfg.host = parsed.Host
 	q := parsed.Query()
 
-	// `scheme` exists so the test server can be reached over plain http.
-	// Production is always https — a bearer token over http would put the key on
-	// the wire in clear text.
 	transport := q.Get("scheme")
 	if transport == "" {
 		transport = "https"
@@ -220,8 +128,6 @@ func parseURI(uri string) (uriConfig, error) {
 		cfg.rateLimit = f
 	}
 
-	// Soft-deleted rows are INCLUDED by default. See the package doc: without the
-	// second pass a deleted record silently persists in the warehouse as live.
 	cfg.includeDeleted = true
 	if v := q.Get("include_deleted"); v != "" {
 		b, err := strconv.ParseBool(v)
@@ -262,18 +168,26 @@ func (s *Source) Close(ctx context.Context) error {
 	return nil
 }
 
-// GetTable resolves one object (by its PLURAL api name) into a readable table.
-//
-// The metadata round-trip happens HERE rather than lazily inside Read so that a
-// misspelled object or a permissions problem fails before any destination table
-// is created. A half-created table is materially worse than a clean failure:
-// ingestr recreates a MISSING destination as a plain, NON-replicated
-// ReplacingMergeTree, so a failure after creation can quietly un-replicate a
-// promoted table.
 func (s *Source) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
 	name := strings.TrimSpace(req.Name)
 	if name == "" {
-		return nil, fmt.Errorf("twenty: table name is required (the object's plural api name, e.g. people)")
+		return nil, fmt.Errorf("twenty: table name is required")
+	}
+
+	objectName := name
+	if strings.HasPrefix(name, "custom:") {
+		objectName = strings.TrimSpace(strings.TrimPrefix(name, "custom:"))
+		if objectName == "" {
+			return nil, fmt.Errorf("twenty: custom object name is required after custom:")
+		}
+	} else if _, ok := standardTables[name]; !ok {
+		supported := make([]string, 0, len(standardTables))
+		for table := range standardTables {
+			supported = append(supported, table)
+		}
+		sortStrings(supported)
+		return nil, fmt.Errorf("twenty: unsupported table %q (supported: %s, or use 'custom:<object_name>' for custom objects)",
+			name, strings.Join(supported, ", "))
 	}
 
 	objects, err := s.fetchObjects(ctx)
@@ -281,7 +195,7 @@ func (s *Source) GetTable(ctx context.Context, req source.TableRequest) (source.
 		return nil, err
 	}
 
-	obj, err := findObject(objects, name)
+	obj, err := findObject(objects, objectName)
 	if err != nil {
 		return nil, err
 	}
@@ -319,11 +233,6 @@ func (s *Source) GetTable(ctx context.Context, req source.TableRequest) (source.
 	}, nil
 }
 
-// findObject resolves a table name to an object definition.
-//
-// Matching is on namePlural — the REST path segment — but a singular name is
-// accepted too, because "person" vs "people" is the single easiest mistake to
-// make when writing a CronJob and the API's 404 for it says nothing useful.
 func findObject(objects []objectMeta, name string) (*objectMeta, error) {
 	for i := range objects {
 		if objects[i].NamePlural == name {
@@ -364,12 +273,6 @@ func (s *Source) read(ctx context.Context, plan *tablePlan, opts source.ReadOpti
 	return results, nil
 }
 
-// buildFilter renders Twenty's filter expression for one pass.
-//
-// Only the START bound of the window is applied. Twenty would accept an upper
-// bound too, but applying one would make a re-run of an old window silently DROP
-// rows edited since — and merge is idempotent, so a wider window costs requests,
-// never correctness. Same reasoning as the abra and fakturoid ports.
 func buildFilter(plan *tablePlan, opts source.ReadOptions, deletedOnly bool) string {
 	parts := make([]string, 0, 2)
 	if plan.hasUpdatedAt && opts.IntervalStart != nil {
@@ -389,7 +292,6 @@ func buildFilter(plan *tablePlan, opts source.ReadOptions, deletedOnly bool) str
 	}
 }
 
-// readAll runs the live pass and, when enabled, the soft-delete pass.
 func (s *Source) readAll(ctx context.Context, plan *tablePlan, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
 	drift := map[string]struct{}{}
 
@@ -407,9 +309,7 @@ func (s *Source) readAll(ctx context.Context, plan *tablePlan, opts source.ReadO
 	}
 
 	if len(drift) > 0 {
-		// Loud, once per run. A key Twenty returned that the metadata never
-		// declared is data we are dropping, and we would rather know.
-		config.Debug("[TWENTY] ⚠️ %s: %d undeclared field(s) dropped: %s",
+		config.Debug("[TWENTY] %s: %d undeclared field(s) dropped: %s",
 			plan.object, len(drift), strings.Join(sortedKeys(drift), ", "))
 	}
 	config.Debug("[TWENTY] %s complete: %d live + %d soft-deleted row(s)",
@@ -422,7 +322,6 @@ type passResult struct {
 	serverTotal int
 }
 
-// readPass walks one filtered cursor sequence to exhaustion.
 func (s *Source) readPass(
 	ctx context.Context,
 	plan *tablePlan,
@@ -451,7 +350,6 @@ func (s *Source) readPass(
 
 		req := s.client.R(ctx).
 			SetQueryParam("limit", strconv.Itoa(pageSize)).
-			// ⚠️ Always flat. See the package doc.
 			SetQueryParam("depth", "0")
 		if filter != "" {
 			req = req.SetQueryParam("filter", filter)
@@ -493,9 +391,6 @@ func (s *Source) readPass(
 		config.Debug("[TWENTY] %s (%s) page %d: %d row(s) (running total %d)",
 			plan.object, label, page, len(items), out.rows)
 
-		// hasNextPage is authoritative; the empty-cursor and short-page checks are
-		// belt-and-braces against a server that sets it without advancing, which
-		// would otherwise spin until the page guard.
 		if !info.HasNextPage || info.EndCursor == "" || len(items) == 0 {
 			break
 		}
@@ -506,31 +401,18 @@ func (s *Source) readPass(
 		cursor = info.EndCursor
 	}
 
-	// ⚠️ SILENT-ZERO GUARD. Twenty told us how many rows match; if it said "some"
-	// and we read none, that is a read bug, NOT an empty table — and every other
-	// signal would say success (exit 0, "Ingestion completed successfully", no
-	// rows written). Fail loudly instead.
 	if out.serverTotal > 0 && out.rows == 0 {
 		return out, fmt.Errorf(
 			"twenty: %s (%s pass) reported %d matching row(s) but the read returned none — "+
 				"this is a read bug, not an empty table", plan.object, label, out.serverTotal)
 	}
 	if out.serverTotal >= 0 && out.rows != out.serverTotal {
-		// Not an error: rows can legitimately appear or vanish during a long walk.
-		// Worth surfacing though, because a large gap usually means a paging bug.
 		config.Debug("[TWENTY] %s (%s): read %d row(s), server reported %d at start of walk",
 			plan.object, label, out.rows, out.serverTotal)
 	}
 	return out, nil
 }
 
-// extractRecords unwraps Twenty's core list envelope:
-//
-//	{"data":{"people":[…]},"pageInfo":{…},"totalCount":68279}
-//
-// The array key is the object's plural name. It is looked up by name first and
-// then by "the only array under data", because treating a key mismatch as an
-// empty page is precisely how a read bug disguises itself as an empty table.
 func extractRecords(body []byte, object string) ([]map[string]interface{}, pageInfo, int, error) {
 	var env struct {
 		Data       map[string]json.RawMessage `json:"data"`
@@ -554,8 +436,6 @@ func extractRecords(body []byte, object string) ([]map[string]interface{}, pageI
 	decode := func(raw json.RawMessage) ([]map[string]interface{}, bool) {
 		var items []map[string]interface{}
 		d := json.NewDecoder(strings.NewReader(string(raw)))
-		// ⚠️ UseNumber: Twenty carries money as integer amountMicros, which passes
-		// 2^53 for large amounts and would lose its last digits through float64.
 		d.UseNumber()
 		if err := d.Decode(&items); err != nil {
 			return nil, false
@@ -579,12 +459,8 @@ func extractRecords(body []byte, object string) ([]map[string]interface{}, pageI
 	return nil, env.PageInfo, total, nil
 }
 
-// projectRow maps one Twenty record onto the planned columns, coercing each
-// value to its declared type and recording anything undeclared as drift.
 func projectRow(item map[string]interface{}, plan *tablePlan, drift map[string]struct{}) map[string]interface{} {
 	row := make(map[string]interface{}, len(plan.columns))
-	// Start every declared column at NULL so a row missing a field produces a
-	// NULL rather than a ragged batch.
 	for _, c := range plan.columns {
 		row[c.Name] = nil
 	}
@@ -602,12 +478,6 @@ func projectRow(item map[string]interface{}, plan *tablePlan, drift map[string]s
 	return row
 }
 
-// coerce converts one Twenty JSON value to the declared column type.
-//
-// ⚠️ TIMESTAMPS AND DATES ARE PARSED HERE, IN GO, ON PURPOSE. The Arrow builders
-// accept a string and fall back to AppendNull() when they cannot parse it — a
-// silent per-row data loss with no error anywhere. Parsing here means an
-// unexpected format shows up as a NULL we chose.
 func coerce(v interface{}, dt schema.DataType) interface{} {
 	if v == nil {
 		return nil
@@ -681,12 +551,14 @@ func coerce(v interface{}, dt schema.DataType) interface{} {
 		}
 		return parseTwentyTimestamp(s)
 
-	default: // schema.TypeString — including every composite, carried as JSON text.
+	case schema.TypeJSON:
+		return v
+
+	default:
 		switch t := v.(type) {
 		case string:
 			return t
 		case json.Number:
-			// The exact digits Twenty sent. No float round-trip.
 			return t.String()
 		case bool:
 			return strconv.FormatBool(t)
@@ -702,10 +574,6 @@ func coerce(v interface{}, dt schema.DataType) interface{} {
 	}
 }
 
-// parseTwentyDate handles Twenty's plain calendar dates ("2026-07-30").
-//
-// Twenty's DATE fields are calendar dates (lastLogin, renewalDate) and carry no
-// offset. An empty string is Twenty's "unset" for some custom fields.
 func parseTwentyDate(s string) interface{} {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -719,8 +587,6 @@ func parseTwentyDate(s string) interface{} {
 	return nil
 }
 
-// parseTwentyTimestamp handles "2026-08-15T01:44:03.057Z" and neighbouring
-// shapes, normalising to UTC — these are true instants.
 func parseTwentyTimestamp(s string) interface{} {
 	s = strings.TrimSpace(s)
 	if s == "" {

--- a/pkg/source/twenty/twenty.go
+++ b/pkg/source/twenty/twenty.go
@@ -1,0 +1,750 @@
+// Package twenty implements an ingestr source for Twenty CRM — the open-source
+// an open-source CRM, for sales and lifecycle data.
+//
+// Docs:  https://docs.twenty.com/developers/extend/api
+// Base:  https://<host>/rest/<objectPlural>          (core records)
+//
+//	https://<host>/rest/metadata/objects         (schema)
+//
+// Auth:  Authorization: Bearer <API key>, one key per workspace.
+//
+// Works against both deployment shapes we run: Twenty Cloud
+// (api.twenty.com) and self-hosted (any host running the REST API).
+//
+// ── Why this is a generic engine rather than a hand-written table list ───────
+//
+// Twenty is metadata-driven: every object, standard or custom, publishes its
+// fields with types at /rest/metadata/objects. One reader therefore covers every
+// object, and adding a table to a CronJob is a string, not a code change. That
+// is not just convenience — two workspaces of the same product genuinely diverge.
+// Measured across two live workspaces: one had a `lead` object the other lacked,
+// and their `person` objects carried 79 fields against 32.
+// A static table/column list would have been wrong for one of them immediately.
+//
+// ── The traps, all verified against the live API ─────────────────────────────
+//
+// ⚠️ depth=0 IS ALWAYS SENT. Twenty's default depth embeds related records, so a
+// person arrives carrying its whole company object. That inflates every page,
+// and worse, it makes the row shape depend on a server-side default we do not
+// control. depth=0 returns the flat record plus foreign keys, which is exactly
+// the raw layer's job. See readPass.
+//
+// ⚠️ THE CURSOR IS OPAQUE BASE64, NOT AN ID. pageInfo.endCursor decodes to
+// {"id":"…"} today, but it is a cursor and is passed back verbatim. Never
+// synthesise one from a record id.
+//
+// ⚠️ PAGING IS ORDERED BY id, NOT BY THE CURSOR FIELD, and order_by is
+// deliberately NOT sent. The default order is what endCursor is built against;
+// ordering by updatedAt while walking a cursor would be unstable, because any
+// row edited mid-run moves in the sort order and can be skipped or repeated
+// across a page boundary. id is immutable, so the walk is stable even while
+// sales is editing records underneath it.
+//
+// ⚠️ SOFT DELETES ARE INVISIBLE BY DEFAULT. Twenty excludes deletedAt IS NOT NULL
+// from every list response. Under merge that means a deleted record keeps its
+// last-known state in the warehouse FOREVER, looking live. So a second pass runs
+// with deletedAt[is]:NOT_NULL and re-reads exactly those rows, whose deletedAt
+// then lands populated for downstream to filter on. Disable with
+// include_deleted=false; do not disable it casually.
+//
+// ⚠️ MONEY IS {amountMicros, currencyCode} AND STAYS TEXT. See dataTypeFor —
+// this also keeps the source clear of destination decimal handling on any
+// table with a decimal column on its SECOND sync.
+//
+// ⚠️ ONE KEY PER WORKSPACE, AND THE WORKSPACE IS ONLY IN THE HOST. Pointing the
+// one workspace's key at another workspace's host (or either at the wrong destination)
+// produces no error, just the wrong company's CRM in the wrong table. Same shape
+// that bit the fakturoid and abra ports.
+package twenty
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const (
+	// updatedAtField is Twenty's row-modification timestamp, present on every
+	// object. It is server-side filterable, which is what makes incremental
+	// loading real rather than a full re-read every night.
+	updatedAtField = "updatedAt"
+
+	// deletedAtField drives the soft-delete pass — see the package doc.
+	deletedAtField = "deletedAt"
+
+	// defaultPageSize is Twenty's documented maximum. At 100 requests/minute the
+	// page size is the only lever on wall-clock, so it is pinned to the ceiling:
+	// a 68k-person workspace is ~342 requests here, and 6,828 at the API default of
+	// 20 — over an hour of pure rate-limit wait.
+	defaultPageSize = 200
+
+	// maxPageSize is the API's hard cap; a larger value is rejected upstream.
+	maxPageSize = 200
+
+	// maxPages bounds the cursor walk. At the default page size this allows 40M
+	// rows per object — a runaway guard against a cursor that never advances,
+	// not a limit on real data.
+	maxPages = 200000
+
+	// metadataPageSize / maxMetadataPages bound the schema read. Workspaces have
+	// tens of objects, not thousands.
+	metadataPageSize = 200
+	maxMetadataPages = 50
+
+	// defaultRateLimit is 80% of Twenty's documented 100 requests/minute,
+	// expressed per second: (100 * 0.8) / 60. With burst 5 the first minute
+	// issues at most 5 + ~80 = 85 requests, inside the cap.
+	defaultRateLimit = 1.3333
+
+	// defaultRateLimitBurst per the add-source guidance.
+	defaultRateLimitBurst = 5
+
+	// twentyTimeLayout is what Twenty both emits and accepts in filters:
+	// 2026-08-15T01:44:03.057Z — always UTC, always milliseconds.
+	twentyTimeLayout = "2006-01-02T15:04:05.000Z"
+
+	// defaultBasePath is where both Cloud and self-hosted serve the REST API.
+	defaultBasePath = "/rest"
+)
+
+// pageInfo is Twenty's cursor envelope, shared by core and metadata responses.
+type pageInfo struct {
+	StartCursor string `json:"startCursor"`
+	EndCursor   string `json:"endCursor"`
+	HasNextPage bool   `json:"hasNextPage"`
+}
+
+// Source is one authenticated view into ONE Twenty workspace.
+type Source struct {
+	client         *httpclient.Client
+	pageSize       int
+	includeDeleted bool
+	host           string
+	meta           metadataCache
+}
+
+func NewTwentySource() *Source { return &Source{} }
+
+func (s *Source) Schemes() []string { return []string{"twenty"} }
+
+// HandlesIncrementality is false: this source pushes `updatedAt[gte]:…` down to
+// Twenty as a read filter, but the destination still performs the merge. It
+// keeps no state of its own.
+func (s *Source) HandlesIncrementality() bool { return false }
+
+type uriConfig struct {
+	baseURL        string
+	host           string
+	apiKey         string
+	pageSize       int
+	rateLimit      float64
+	includeDeleted bool
+}
+
+// parseURI accepts:
+//
+//	twenty://api.twenty.com?api_key=…
+//	twenty://crm.example.com?api_key=…
+//
+// Optional: page_size, rate_limit, base_path, include_deleted, scheme (http for
+// tests).
+func parseURI(uri string) (uriConfig, error) {
+	var cfg uriConfig
+
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return cfg, fmt.Errorf("twenty: could not parse source URI: %w", err)
+	}
+	if parsed.Scheme != "twenty" {
+		return cfg, fmt.Errorf("twenty: source URI must start with twenty://")
+	}
+	if parsed.Host == "" {
+		return cfg, fmt.Errorf("twenty: the workspace host is required, e.g. twenty://api.twenty.com?api_key=…")
+	}
+	cfg.host = parsed.Host
+	q := parsed.Query()
+
+	// `scheme` exists so the test server can be reached over plain http.
+	// Production is always https — a bearer token over http would put the key on
+	// the wire in clear text.
+	transport := q.Get("scheme")
+	if transport == "" {
+		transport = "https"
+	}
+	if transport != "https" && transport != "http" {
+		return cfg, fmt.Errorf("twenty: scheme must be https or http, got %q", transport)
+	}
+
+	basePath := q.Get("base_path")
+	if basePath == "" {
+		basePath = defaultBasePath
+	}
+	if !strings.HasPrefix(basePath, "/") {
+		basePath = "/" + basePath
+	}
+	cfg.baseURL = transport + "://" + parsed.Host + strings.TrimSuffix(basePath, "/")
+
+	cfg.apiKey = q.Get("api_key")
+	if cfg.apiKey == "" {
+		return cfg, fmt.Errorf("twenty: api_key is required (Settings → API & Webhooks in the workspace)")
+	}
+
+	cfg.pageSize = defaultPageSize
+	if v := q.Get("page_size"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return cfg, fmt.Errorf("twenty: page_size must be a positive integer, got %q", v)
+		}
+		if n > maxPageSize {
+			return cfg, fmt.Errorf("twenty: page_size may not exceed %d (the API's cap), got %d", maxPageSize, n)
+		}
+		cfg.pageSize = n
+	}
+
+	cfg.rateLimit = defaultRateLimit
+	if v := q.Get("rate_limit"); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil || f <= 0 {
+			return cfg, fmt.Errorf("twenty: rate_limit must be a positive number, got %q", v)
+		}
+		cfg.rateLimit = f
+	}
+
+	// Soft-deleted rows are INCLUDED by default. See the package doc: without the
+	// second pass a deleted record silently persists in the warehouse as live.
+	cfg.includeDeleted = true
+	if v := q.Get("include_deleted"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return cfg, fmt.Errorf("twenty: include_deleted must be a boolean, got %q", v)
+		}
+		cfg.includeDeleted = b
+	}
+
+	return cfg, nil
+}
+
+func (s *Source) Connect(ctx context.Context, uri string) error {
+	cfg, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+	s.pageSize = cfg.pageSize
+	s.includeDeleted = cfg.includeDeleted
+	s.host = cfg.host
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(cfg.baseURL),
+		httpclient.WithTimeout(120*time.Second),
+		httpclient.WithAuth(httpclient.NewBearerAuth(cfg.apiKey)),
+		httpclient.WithHeader("Accept", "application/json"),
+		httpclient.WithRateLimiter(cfg.rateLimit, defaultRateLimitBurst),
+		httpclient.WithRetry(4, 2*time.Second, 30*time.Second),
+		httpclient.WithDebug(config.DebugMode),
+	)
+	return nil
+}
+
+func (s *Source) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+// GetTable resolves one object (by its PLURAL api name) into a readable table.
+//
+// The metadata round-trip happens HERE rather than lazily inside Read so that a
+// misspelled object or a permissions problem fails before any destination table
+// is created. A half-created table is materially worse than a clean failure:
+// ingestr recreates a MISSING destination as a plain, NON-replicated
+// ReplacingMergeTree, so a failure after creation can quietly un-replicate a
+// promoted table.
+func (s *Source) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, fmt.Errorf("twenty: table name is required (the object's plural api name, e.g. people)")
+	}
+
+	objects, err := s.fetchObjects(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := findObject(objects, name)
+	if err != nil {
+		return nil, err
+	}
+	plan, err := buildPlan(*obj)
+	if err != nil {
+		return nil, err
+	}
+
+	incremental := ""
+	if plan.hasUpdatedAt {
+		incremental = updatedAtField
+	} else {
+		config.Debug("[TWENTY] object %s has no %s field: every run will re-read it in full",
+			plan.object, updatedAtField)
+	}
+	if !plan.hasDeletedAt && s.includeDeleted {
+		config.Debug("[TWENTY] object %s has no %s field: the soft-delete pass is skipped",
+			plan.object, deletedAtField)
+	}
+
+	tableSchema := &schema.TableSchema{Name: plan.object, Columns: plan.columns}
+
+	return &source.DynamicSourceTable{
+		TableName:           plan.object,
+		TablePrimaryKeys:    []string{"id"},
+		TableIncrementalKey: incremental,
+		TableStrategy:       config.StrategyMerge,
+		KnownSchema:         true,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return tableSchema, nil
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, plan, opts)
+		},
+	}, nil
+}
+
+// findObject resolves a table name to an object definition.
+//
+// Matching is on namePlural — the REST path segment — but a singular name is
+// accepted too, because "person" vs "people" is the single easiest mistake to
+// make when writing a CronJob and the API's 404 for it says nothing useful.
+func findObject(objects []objectMeta, name string) (*objectMeta, error) {
+	for i := range objects {
+		if objects[i].NamePlural == name {
+			return &objects[i], nil
+		}
+	}
+	for i := range objects {
+		if objects[i].NameSingular == name {
+			return nil, fmt.Errorf("twenty: %q is the singular name; use the plural api name %q as the table",
+				name, objects[i].NamePlural)
+		}
+	}
+	available := make([]string, 0, len(objects))
+	for _, o := range objects {
+		available = append(available, o.NamePlural)
+	}
+	sortStrings(available)
+	return nil, fmt.Errorf("twenty: this workspace has no object %q. Available: %s",
+		name, strings.Join(available, ", "))
+}
+
+func sortStrings(in []string) {
+	for i := 1; i < len(in); i++ {
+		for j := i; j > 0 && in[j] < in[j-1]; j-- {
+			in[j], in[j-1] = in[j-1], in[j]
+		}
+	}
+}
+
+func (s *Source) read(ctx context.Context, plan *tablePlan, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 4)
+	go func() {
+		defer close(results)
+		if err := s.readAll(ctx, plan, opts, results); err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+	return results, nil
+}
+
+// buildFilter renders Twenty's filter expression for one pass.
+//
+// Only the START bound of the window is applied. Twenty would accept an upper
+// bound too, but applying one would make a re-run of an old window silently DROP
+// rows edited since — and merge is idempotent, so a wider window costs requests,
+// never correctness. Same reasoning as the abra and fakturoid ports.
+func buildFilter(plan *tablePlan, opts source.ReadOptions, deletedOnly bool) string {
+	parts := make([]string, 0, 2)
+	if plan.hasUpdatedAt && opts.IntervalStart != nil {
+		parts = append(parts, fmt.Sprintf("%s[gte]:%s",
+			updatedAtField, opts.IntervalStart.UTC().Format(twentyTimeLayout)))
+	}
+	if deletedOnly {
+		parts = append(parts, deletedAtField+"[is]:NOT_NULL")
+	}
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	default:
+		return "and(" + strings.Join(parts, ",") + ")"
+	}
+}
+
+// readAll runs the live pass and, when enabled, the soft-delete pass.
+func (s *Source) readAll(ctx context.Context, plan *tablePlan, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	drift := map[string]struct{}{}
+
+	live, err := s.readPass(ctx, plan, opts, buildFilter(plan, opts, false), "live", drift, results)
+	if err != nil {
+		return err
+	}
+
+	deleted := passResult{}
+	if s.includeDeleted && plan.hasDeletedAt {
+		deleted, err = s.readPass(ctx, plan, opts, buildFilter(plan, opts, true), "deleted", drift, results)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(drift) > 0 {
+		// Loud, once per run. A key Twenty returned that the metadata never
+		// declared is data we are dropping, and we would rather know.
+		config.Debug("[TWENTY] ⚠️ %s: %d undeclared field(s) dropped: %s",
+			plan.object, len(drift), strings.Join(sortedKeys(drift), ", "))
+	}
+	config.Debug("[TWENTY] %s complete: %d live + %d soft-deleted row(s)",
+		plan.object, live.rows, deleted.rows)
+	return nil
+}
+
+type passResult struct {
+	rows        int
+	serverTotal int
+}
+
+// readPass walks one filtered cursor sequence to exhaustion.
+func (s *Source) readPass(
+	ctx context.Context,
+	plan *tablePlan,
+	opts source.ReadOptions,
+	filter, label string,
+	drift map[string]struct{},
+	results chan<- source.RecordBatchResult,
+) (passResult, error) {
+	out := passResult{serverTotal: -1}
+
+	pageSize := s.pageSize
+	if opts.PageSize > 0 && opts.PageSize <= maxPageSize {
+		pageSize = opts.PageSize
+	}
+
+	cursor := ""
+	for page := 0; ; page++ {
+		select {
+		case <-ctx.Done():
+			return out, ctx.Err()
+		default:
+		}
+		if page >= maxPages {
+			return out, fmt.Errorf("twenty: %s (%s pass) exceeded the %d-page guard", plan.object, label, maxPages)
+		}
+
+		req := s.client.R(ctx).
+			SetQueryParam("limit", strconv.Itoa(pageSize)).
+			// ⚠️ Always flat. See the package doc.
+			SetQueryParam("depth", "0")
+		if filter != "" {
+			req = req.SetQueryParam("filter", filter)
+		}
+		if cursor != "" {
+			req = req.SetQueryParam("starting_after", cursor)
+		}
+
+		resp, err := req.Get("/" + url.PathEscape(plan.object))
+		if err != nil {
+			return out, fmt.Errorf("twenty: failed to read %s (%s pass, page %d): %w", plan.object, label, page, err)
+		}
+		if !resp.IsSuccess() {
+			return out, fmt.Errorf("twenty: read of %s (%s pass, page %d) returned HTTP %d: %s",
+				plan.object, label, page, resp.StatusCode(), truncate(resp.String(), 400))
+		}
+
+		items, info, total, err := extractRecords([]byte(resp.String()), plan.object)
+		if err != nil {
+			return out, err
+		}
+		if page == 0 {
+			out.serverTotal = total
+			config.Debug("[TWENTY] %s (%s): %d row(s) match%s", plan.object, label, total,
+				map[bool]string{true: " the window", false: ""}[filter != ""])
+		}
+
+		if len(items) > 0 {
+			rows := make([]map[string]interface{}, 0, len(items))
+			for _, it := range items {
+				rows = append(rows, projectRow(it, plan, drift))
+			}
+			if err := emit(rows, plan.columns, opts, results); err != nil {
+				return out, fmt.Errorf("twenty: failed to convert %s to Arrow: %w", plan.object, err)
+			}
+			out.rows += len(rows)
+		}
+
+		config.Debug("[TWENTY] %s (%s) page %d: %d row(s) (running total %d)",
+			plan.object, label, page, len(items), out.rows)
+
+		// hasNextPage is authoritative; the empty-cursor and short-page checks are
+		// belt-and-braces against a server that sets it without advancing, which
+		// would otherwise spin until the page guard.
+		if !info.HasNextPage || info.EndCursor == "" || len(items) == 0 {
+			break
+		}
+		if info.EndCursor == cursor {
+			return out, fmt.Errorf("twenty: %s (%s pass) returned the same cursor twice at page %d — refusing to loop",
+				plan.object, label, page)
+		}
+		cursor = info.EndCursor
+	}
+
+	// ⚠️ SILENT-ZERO GUARD. Twenty told us how many rows match; if it said "some"
+	// and we read none, that is a read bug, NOT an empty table — and every other
+	// signal would say success (exit 0, "Ingestion completed successfully", no
+	// rows written). Fail loudly instead.
+	if out.serverTotal > 0 && out.rows == 0 {
+		return out, fmt.Errorf(
+			"twenty: %s (%s pass) reported %d matching row(s) but the read returned none — "+
+				"this is a read bug, not an empty table", plan.object, label, out.serverTotal)
+	}
+	if out.serverTotal >= 0 && out.rows != out.serverTotal {
+		// Not an error: rows can legitimately appear or vanish during a long walk.
+		// Worth surfacing though, because a large gap usually means a paging bug.
+		config.Debug("[TWENTY] %s (%s): read %d row(s), server reported %d at start of walk",
+			plan.object, label, out.rows, out.serverTotal)
+	}
+	return out, nil
+}
+
+// extractRecords unwraps Twenty's core list envelope:
+//
+//	{"data":{"people":[…]},"pageInfo":{…},"totalCount":68279}
+//
+// The array key is the object's plural name. It is looked up by name first and
+// then by "the only array under data", because treating a key mismatch as an
+// empty page is precisely how a read bug disguises itself as an empty table.
+func extractRecords(body []byte, object string) ([]map[string]interface{}, pageInfo, int, error) {
+	var env struct {
+		Data       map[string]json.RawMessage `json:"data"`
+		PageInfo   pageInfo                   `json:"pageInfo"`
+		TotalCount *int                       `json:"totalCount"`
+	}
+	dec := json.NewDecoder(strings.NewReader(string(body)))
+	dec.UseNumber()
+	if err := dec.Decode(&env); err != nil {
+		return nil, pageInfo{}, -1, fmt.Errorf("twenty: failed to parse response for %s: %w", object, err)
+	}
+	if env.Data == nil {
+		return nil, pageInfo{}, -1, fmt.Errorf("twenty: response for %s had no data envelope", object)
+	}
+
+	total := -1
+	if env.TotalCount != nil {
+		total = *env.TotalCount
+	}
+
+	decode := func(raw json.RawMessage) ([]map[string]interface{}, bool) {
+		var items []map[string]interface{}
+		d := json.NewDecoder(strings.NewReader(string(raw)))
+		// ⚠️ UseNumber: Twenty carries money as integer amountMicros, which passes
+		// 2^53 for large amounts and would lose its last digits through float64.
+		d.UseNumber()
+		if err := d.Decode(&items); err != nil {
+			return nil, false
+		}
+		return items, true
+	}
+
+	if raw, ok := env.Data[object]; ok {
+		items, ok := decode(raw)
+		if !ok {
+			return nil, env.PageInfo, total, fmt.Errorf("twenty: failed to parse %s records", object)
+		}
+		return items, env.PageInfo, total, nil
+	}
+	for key, raw := range env.Data {
+		if items, ok := decode(raw); ok {
+			config.Debug("[TWENTY] %s: records arrived under key %q, not the object name", object, key)
+			return items, env.PageInfo, total, nil
+		}
+	}
+	return nil, env.PageInfo, total, nil
+}
+
+// projectRow maps one Twenty record onto the planned columns, coercing each
+// value to its declared type and recording anything undeclared as drift.
+func projectRow(item map[string]interface{}, plan *tablePlan, drift map[string]struct{}) map[string]interface{} {
+	row := make(map[string]interface{}, len(plan.columns))
+	// Start every declared column at NULL so a row missing a field produces a
+	// NULL rather than a ragged batch.
+	for _, c := range plan.columns {
+		row[c.Name] = nil
+	}
+	for key, val := range item {
+		dest := sanitizeColumn(key)
+		dt, ok := plan.typeOf[dest]
+		if !ok {
+			if _, deliberate := plan.dropped[key]; !deliberate {
+				drift[key] = struct{}{}
+			}
+			continue
+		}
+		row[dest] = coerce(val, dt)
+	}
+	return row
+}
+
+// coerce converts one Twenty JSON value to the declared column type.
+//
+// ⚠️ TIMESTAMPS AND DATES ARE PARSED HERE, IN GO, ON PURPOSE. The Arrow builders
+// accept a string and fall back to AppendNull() when they cannot parse it — a
+// silent per-row data loss with no error anywhere. Parsing here means an
+// unexpected format shows up as a NULL we chose.
+func coerce(v interface{}, dt schema.DataType) interface{} {
+	if v == nil {
+		return nil
+	}
+	switch dt {
+	case schema.TypeInt64:
+		switch t := v.(type) {
+		case json.Number:
+			n, err := t.Int64()
+			if err != nil {
+				return nil
+			}
+			return n
+		case string:
+			n, err := strconv.ParseInt(strings.TrimSpace(t), 10, 64)
+			if err != nil {
+				return nil
+			}
+			return n
+		case float64:
+			return int64(t)
+		default:
+			return nil
+		}
+
+	case schema.TypeFloat64:
+		switch t := v.(type) {
+		case json.Number:
+			f, err := t.Float64()
+			if err != nil {
+				return nil
+			}
+			return f
+		case float64:
+			return t
+		case string:
+			f, err := strconv.ParseFloat(strings.TrimSpace(t), 64)
+			if err != nil {
+				return nil
+			}
+			return f
+		default:
+			return nil
+		}
+
+	case schema.TypeBoolean:
+		switch t := v.(type) {
+		case bool:
+			return t
+		case string:
+			b, err := strconv.ParseBool(strings.TrimSpace(t))
+			if err != nil {
+				return nil
+			}
+			return b
+		default:
+			return nil
+		}
+
+	case schema.TypeDate:
+		s, ok := v.(string)
+		if !ok {
+			return nil
+		}
+		return parseTwentyDate(s)
+
+	case schema.TypeTimestamp:
+		s, ok := v.(string)
+		if !ok {
+			return nil
+		}
+		return parseTwentyTimestamp(s)
+
+	default: // schema.TypeString — including every composite, carried as JSON text.
+		switch t := v.(type) {
+		case string:
+			return t
+		case json.Number:
+			// The exact digits Twenty sent. No float round-trip.
+			return t.String()
+		case bool:
+			return strconv.FormatBool(t)
+		case map[string]interface{}, []interface{}:
+			b, err := json.Marshal(t)
+			if err != nil {
+				return fmt.Sprintf("%v", t)
+			}
+			return string(b)
+		default:
+			return fmt.Sprintf("%v", t)
+		}
+	}
+}
+
+// parseTwentyDate handles Twenty's plain calendar dates ("2026-07-30").
+//
+// Twenty's DATE fields are calendar dates (lastLogin, renewalDate) and carry no
+// offset. An empty string is Twenty's "unset" for some custom fields.
+func parseTwentyDate(s string) interface{} {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if len(s) >= 10 {
+		if t, err := time.Parse("2006-01-02", s[:10]); err == nil {
+			return t
+		}
+	}
+	return nil
+}
+
+// parseTwentyTimestamp handles "2026-08-15T01:44:03.057Z" and neighbouring
+// shapes, normalising to UTC — these are true instants.
+func parseTwentyTimestamp(s string) interface{} {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	for _, layout := range []string{
+		twentyTimeLayout,
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return nil
+}
+
+func emit(items []map[string]interface{}, cols []schema.Column, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, cols, opts.ExcludeColumns)
+	if err != nil {
+		return err
+	}
+	results <- source.RecordBatchResult{Batch: record}
+	return nil
+}

--- a/pkg/source/twenty/twenty.go
+++ b/pkg/source/twenty/twenty.go
@@ -178,7 +178,7 @@ func (s *Source) GetTable(ctx context.Context, req source.TableRequest) (source.
 	if strings.HasPrefix(name, "custom:") {
 		objectName = strings.TrimSpace(strings.TrimPrefix(name, "custom:"))
 		if objectName == "" {
-			return nil, fmt.Errorf("twenty: custom object name is required after custom:")
+			return nil, fmt.Errorf("twenty: custom object name is required after custom prefix")
 		}
 	} else if _, ok := standardTables[name]; !ok {
 		supported := make([]string, 0, len(standardTables))

--- a/pkg/source/twenty/twenty_test.go
+++ b/pkg/source/twenty/twenty_test.go
@@ -1,0 +1,557 @@
+package twenty
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("full URI", func(t *testing.T) {
+		cfg, err := parseURI("twenty://crm.example.com?api_key=k%3Dey%26x&page_size=50&rate_limit=2&include_deleted=false")
+		require.NoError(t, err)
+		assert.Equal(t, "https://crm.example.com/rest", cfg.baseURL)
+		assert.Equal(t, "k=ey&x", cfg.apiKey, "the API key must survive URL decoding intact")
+		assert.Equal(t, 50, cfg.pageSize)
+		assert.Equal(t, 2.0, cfg.rateLimit)
+		assert.False(t, cfg.includeDeleted)
+	})
+
+	t.Run("defaults", func(t *testing.T) {
+		cfg, err := parseURI("twenty://api.twenty.com?api_key=x")
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.twenty.com/rest", cfg.baseURL)
+		assert.Equal(t, defaultPageSize, cfg.pageSize)
+		assert.Equal(t, defaultRateLimit, cfg.rateLimit)
+		// Soft-deleted rows are included by default — without the second pass a
+		// deleted record silently persists in the warehouse looking live.
+		assert.True(t, cfg.includeDeleted)
+	})
+
+	t.Run("base_path override", func(t *testing.T) {
+		cfg, err := parseURI("twenty://host?api_key=x&base_path=api/rest")
+		require.NoError(t, err)
+		assert.Equal(t, "https://host/api/rest", cfg.baseURL)
+	})
+
+	for _, tc := range []struct{ name, uri, want string }{
+		{"missing api_key", "twenty://host", "api_key is required"},
+		{"missing host", "twenty://?api_key=x", "host is required"},
+		{"wrong scheme", "https://host?api_key=x", "must start with twenty://"},
+		{"bad page_size", "twenty://host?api_key=x&page_size=0", "page_size must be a positive integer"},
+		{"page_size over cap", "twenty://host?api_key=x&page_size=500", "may not exceed 200"},
+		{"bad rate_limit", "twenty://host?api_key=x&rate_limit=-1", "rate_limit must be a positive number"},
+		{"bad include_deleted", "twenty://host?api_key=x&include_deleted=maybe", "include_deleted must be a boolean"},
+		{"bad transport", "twenty://host?api_key=x&scheme=ftp", "scheme must be https or http"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseURI(tc.uri)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestSanitizeColumn(t *testing.T) {
+	t.Parallel()
+	// Twenty enforces camelCase api names, so this is normally a no-op — and the
+	// casing must be preserved so the column still reads as Twenty's.
+	assert.Equal(t, "companyId", sanitizeColumn("companyId"))
+	assert.Equal(t, "updatedAt", sanitizeColumn("updatedAt"))
+	assert.Equal(t, "utmSource", sanitizeColumn("utmSource"))
+	assert.Equal(t, "odd_name", sanitizeColumn("odd-name"))
+}
+
+func TestDataTypeFor(t *testing.T) {
+	t.Parallel()
+
+	str := func(typ string) schema.DataType {
+		dt, keep := dataTypeFor(fieldMeta{Type: typ})
+		require.True(t, keep)
+		return dt
+	}
+
+	assert.Equal(t, schema.TypeBoolean, str("BOOLEAN"))
+	assert.Equal(t, schema.TypeTimestamp, str("DATE_TIME"))
+	assert.Equal(t, schema.TypeDate, str("DATE"))
+	assert.Equal(t, schema.TypeFloat64, str("POSITION"))
+	assert.Equal(t, schema.TypeString, str("UUID"))
+	assert.Equal(t, schema.TypeString, str("TEXT"))
+	assert.Equal(t, schema.TypeString, str("SELECT"))
+
+	// Composites carry JSON text in a String column — TypeJSON has no mapping in
+	// several destinations.
+	for _, composite := range []string{"EMAILS", "PHONES", "LINKS", "ADDRESS", "CURRENCY", "FULL_NAME", "ACTOR", "RICH_TEXT_V2", "ARRAY", "MULTI_SELECT", "RAW_JSON"} {
+		assert.Equal(t, schema.TypeString, str(composite), composite)
+	}
+
+	// NUMBER honours settings.dataType: ints stay ints, anything else keeps its
+	// exact decimal text rather than rounding through a float.
+	assert.Equal(t, schema.TypeInt64, str("NUMBER"))
+	dt, keep := dataTypeFor(fieldMeta{Type: "NUMBER", Settings: &relationSettings{DataType: "int"}})
+	require.True(t, keep)
+	assert.Equal(t, schema.TypeInt64, dt)
+	dt, keep = dataTypeFor(fieldMeta{Type: "NUMBER", Settings: &relationSettings{DataType: "float"}})
+	require.True(t, keep)
+	assert.Equal(t, schema.TypeString, dt)
+
+	// searchVector is a Postgres full-text index — derived, bulky, never useful.
+	_, keep = dataTypeFor(fieldMeta{Type: "TS_VECTOR"})
+	assert.False(t, keep)
+}
+
+// personMeta mirrors a live `person` object closely enough to exercise
+// every branch of buildPlan.
+func personMeta() objectMeta {
+	return objectMeta{
+		NameSingular: "person", NamePlural: "people", IsActive: true,
+		Fields: []fieldMeta{
+			{Name: "id", Type: "UUID", IsActive: true},
+			{Name: "createdAt", Type: "DATE_TIME", IsActive: true},
+			{Name: "updatedAt", Type: "DATE_TIME", IsActive: true},
+			{Name: "deletedAt", Type: "DATE_TIME", IsActive: true},
+			{Name: "name", Type: "FULL_NAME", IsActive: true},
+			{Name: "emails", Type: "EMAILS", IsActive: true},
+			{Name: "position", Type: "POSITION", IsActive: true},
+			{Name: "searchVector", Type: "TS_VECTOR", IsActive: true},
+			{Name: "marketingConsent", Type: "BOOLEAN", IsActive: true},
+			{Name: "retiredField", Type: "TEXT", IsActive: false},
+			// MANY_TO_ONE: the FK is what depth=0 actually returns.
+			{
+				Name: "company", Type: "RELATION", IsActive: true,
+				Settings: &relationSettings{RelationType: "MANY_TO_ONE", JoinColumnName: "companyId"},
+			},
+			// ONE_TO_MANY: no column on this side of the edge.
+			{
+				Name: "noteTargets", Type: "RELATION", IsActive: true,
+				Settings: &relationSettings{RelationType: "ONE_TO_MANY"},
+			},
+		},
+	}
+}
+
+func TestBuildPlan(t *testing.T) {
+	t.Parallel()
+
+	plan, err := buildPlan(personMeta())
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(plan.columns))
+	for _, c := range plan.columns {
+		names = append(names, c.Name)
+	}
+
+	// ⚠️ The FK, not the relation name — depth=0 returns companyId, never a
+	// nested company object.
+	assert.Contains(t, names, "companyId")
+	assert.NotContains(t, names, "company")
+
+	// ONE_TO_MANY and TS_VECTOR are dropped, and dropped deliberately — so they
+	// must not later be reported as drift.
+	assert.NotContains(t, names, "noteTargets")
+	assert.NotContains(t, names, "searchVector")
+	assert.Contains(t, plan.dropped, "noteTargets")
+	assert.Contains(t, plan.dropped, "searchVector")
+
+	// Inactive fields are not columns.
+	assert.NotContains(t, names, "retiredField")
+
+	assert.True(t, plan.hasUpdatedAt)
+	assert.True(t, plan.hasDeletedAt)
+	assert.Equal(t, "people", plan.object)
+
+	// id is the primary key and is never nullable.
+	var id schema.Column
+	for _, c := range plan.columns {
+		if c.Name == "id" {
+			id = c
+		}
+	}
+	assert.True(t, id.IsPrimaryKey)
+	assert.False(t, id.Nullable)
+	assert.Equal(t, schema.TypeString, id.DataType)
+}
+
+// Without `id` there is nothing to deduplicate on, and under an append-style
+// incremental strategy every run would add the whole object forever.
+func TestBuildPlanRefusesObjectWithoutID(t *testing.T) {
+	t.Parallel()
+	_, err := buildPlan(objectMeta{
+		NameSingular: "thing", NamePlural: "things", IsActive: true,
+		Fields: []fieldMeta{{Name: "name", Type: "TEXT", IsActive: true}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no `id` field")
+}
+
+func TestFindObject(t *testing.T) {
+	t.Parallel()
+	objects := []objectMeta{personMeta(), {NameSingular: "company", NamePlural: "companies"}}
+
+	got, err := findObject(objects, "people")
+	require.NoError(t, err)
+	assert.Equal(t, "people", got.NamePlural)
+
+	// "person" vs "people" is the easiest CronJob typo to make, and the API's own
+	// 404 says nothing useful.
+	_, err = findObject(objects, "person")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `use the plural api name "people"`)
+
+	_, err = findObject(objects, "leads")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has no object \"leads\"")
+	assert.Contains(t, err.Error(), "companies, people", "the error must list what IS available")
+}
+
+func TestBuildFilter(t *testing.T) {
+	t.Parallel()
+	plan, err := buildPlan(personMeta())
+	require.NoError(t, err)
+
+	start := time.Date(2026, 8, 1, 12, 30, 0, 0, time.UTC)
+
+	assert.Equal(t, "", buildFilter(plan, source.ReadOptions{}, false))
+	assert.Equal(t, "deletedAt[is]:NOT_NULL", buildFilter(plan, source.ReadOptions{}, true))
+	assert.Equal(t, "updatedAt[gte]:2026-08-01T12:30:00.000Z",
+		buildFilter(plan, source.ReadOptions{IntervalStart: &start}, false))
+	assert.Equal(t, "and(updatedAt[gte]:2026-08-01T12:30:00.000Z,deletedAt[is]:NOT_NULL)",
+		buildFilter(plan, source.ReadOptions{IntervalStart: &start}, true))
+
+	// Only the START bound is ever applied — an upper bound would make a re-run of
+	// an old window silently drop rows edited since.
+	end := start.Add(24 * time.Hour)
+	assert.NotContains(t, buildFilter(plan, source.ReadOptions{IntervalStart: &start, IntervalEnd: &end}, false), "lte")
+}
+
+func TestExtractRecords(t *testing.T) {
+	t.Parallel()
+
+	// The exact envelope shape the live API returns.
+	body := `{"data":{"people":[{"id":"a","name":{"firstName":"X"}}]},
+	          "pageInfo":{"endCursor":"eyJpZCI6ImEifQ==","hasNextPage":true,"hasPreviousPage":false},
+	          "totalCount":68279}`
+	items, info, total, err := extractRecords([]byte(body), "people")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "a", items[0]["id"])
+	assert.True(t, info.HasNextPage)
+	assert.Equal(t, "eyJpZCI6ImEifQ==", info.EndCursor)
+	assert.Equal(t, 68279, total)
+
+	// ⚠️ A key mismatch must NOT read as an empty page — that is exactly how a
+	// read bug disguises itself as an empty table.
+	items, _, _, err = extractRecords([]byte(`{"data":{"somethingElse":[{"id":"b"}]},"pageInfo":{},"totalCount":1}`), "people")
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "b", items[0]["id"])
+
+	_, _, _, err = extractRecords([]byte(`{"pageInfo":{}}`), "people")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no data envelope")
+}
+
+// ⚠️ Twenty carries money as integer amountMicros, which passes 2^53 for large
+// amounts and would lose its last digits through a float64 round-trip.
+func TestExtractRecordsKeepsBigIntegersExact(t *testing.T) {
+	t.Parallel()
+	body := `{"data":{"opportunities":[{"id":"a","amount":{"amountMicros":9007199254740993,"currencyCode":"CZK"}}]},"pageInfo":{},"totalCount":1}`
+	items, _, _, err := extractRecords([]byte(body), "opportunities")
+	require.NoError(t, err)
+
+	got := coerce(items[0]["amount"], schema.TypeString)
+	assert.Contains(t, got, "9007199254740993", "amountMicros must survive verbatim, not as 9.007199254740992e+15")
+}
+
+func TestCoerce(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, int64(400), coerce(json.Number("400"), schema.TypeInt64))
+	assert.Equal(t, -586576.5, coerce(json.Number("-586576.5"), schema.TypeFloat64))
+	assert.Equal(t, true, coerce(true, schema.TypeBoolean))
+	assert.Nil(t, coerce(nil, schema.TypeString))
+
+	// Composites land as compact JSON text.
+	got := coerce(map[string]interface{}{"primaryEmail": "a@b.c", "additionalEmails": []interface{}{}}, schema.TypeString)
+	assert.JSONEq(t, `{"primaryEmail":"a@b.c","additionalEmails":[]}`, got.(string))
+
+	// Twenty's "unset" for several custom fields is an empty string, not null.
+	assert.Nil(t, coerce("", schema.TypeDate))
+	assert.Nil(t, coerce("", schema.TypeTimestamp))
+}
+
+func TestParseTwentyTimestampAndDate(t *testing.T) {
+	t.Parallel()
+
+	ts := parseTwentyTimestamp("2026-08-15T01:44:03.057Z")
+	require.IsType(t, time.Time{}, ts)
+	assert.Equal(t, time.Date(2026, 8, 15, 1, 44, 3, 57000000, time.UTC), ts)
+
+	d := parseTwentyDate("2026-07-30")
+	require.IsType(t, time.Time{}, d)
+	assert.Equal(t, time.Date(2026, 7, 30, 0, 0, 0, 0, time.UTC), d)
+
+	// Unparseable input becomes a NULL we chose, rather than an Arrow builder
+	// silently AppendNull()ing it.
+	assert.Nil(t, parseTwentyTimestamp("not a time"))
+	assert.Nil(t, parseTwentyDate("nope"))
+}
+
+// ── End-to-end against a fake Twenty ─────────────────────────────────────────
+
+type fakeTwenty struct {
+	t *testing.T
+	// people is the full live set; deleted are the soft-deleted ones, which the
+	// real API hides unless deletedAt[is]:NOT_NULL is asked for.
+	people  []map[string]interface{}
+	deleted []map[string]interface{}
+
+	pageSizesSeen []string
+	depthsSeen    []string
+	filtersSeen   []string
+}
+
+func (f *fakeTwenty) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/rest/metadata/objects" {
+			obj := personMeta()
+			require.NoError(f.t, json.NewEncoder(w).Encode(map[string]interface{}{
+				"data":       map[string]interface{}{"objects": []objectMeta{obj}},
+				"pageInfo":   map[string]interface{}{"hasNextPage": false},
+				"totalCount": 1,
+			}))
+			return
+		}
+		if r.URL.Path != "/rest/people" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		q := r.URL.Query()
+		f.pageSizesSeen = append(f.pageSizesSeen, q.Get("limit"))
+		f.depthsSeen = append(f.depthsSeen, q.Get("depth"))
+		f.filtersSeen = append(f.filtersSeen, q.Get("filter"))
+
+		set := f.people
+		if strings.Contains(q.Get("filter"), "deletedAt[is]:NOT_NULL") {
+			set = f.deleted
+		}
+
+		// Cursor = index of the last row served, base64-free for test clarity.
+		start := 0
+		if c := q.Get("starting_after"); c != "" {
+			_, err := fmt.Sscanf(c, "cur-%d", &start)
+			require.NoError(f.t, err)
+			start++
+		}
+		end := start + 2 // deliberately smaller than the requested limit
+		if end > len(set) {
+			end = len(set)
+		}
+		page := set[start:end]
+
+		info := map[string]interface{}{"hasNextPage": end < len(set)}
+		if len(page) > 0 {
+			info["endCursor"] = fmt.Sprintf("cur-%d", end-1)
+		}
+		require.NoError(f.t, json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":       map[string]interface{}{"people": page},
+			"pageInfo":   info,
+			"totalCount": len(set),
+		}))
+	}
+}
+
+func person(id string, deleted bool) map[string]interface{} {
+	p := map[string]interface{}{
+		"id":               id,
+		"createdAt":        "2026-01-01T00:00:00.000Z",
+		"updatedAt":        "2026-08-01T00:00:00.000Z",
+		"deletedAt":        nil,
+		"name":             map[string]interface{}{"firstName": "A", "lastName": "B"},
+		"emails":           map[string]interface{}{"primaryEmail": "a@b.c"},
+		"position":         1,
+		"searchVector":     "'a':1",
+		"marketingConsent": true,
+		"companyId":        "c-1",
+	}
+	if deleted {
+		p["deletedAt"] = "2026-08-10T00:00:00.000Z"
+	}
+	return p
+}
+
+func connectTo(t *testing.T, srv *httptest.Server, extra string) *Source {
+	t.Helper()
+	s := NewTwentySource()
+	host := strings.TrimPrefix(srv.URL, "http://")
+	uri := "twenty://" + host + "?api_key=k&scheme=http&rate_limit=1000" + extra
+	require.NoError(t, s.Connect(context.Background(), uri))
+	return s
+}
+
+func drain(t *testing.T, ch <-chan source.RecordBatchResult) (int, error) {
+	t.Helper()
+	rows := 0
+	for res := range ch {
+		if res.Err != nil {
+			return rows, res.Err
+		}
+		if res.Batch != nil {
+			rows += int(res.Batch.NumRows())
+			res.Batch.Release()
+		}
+	}
+	return rows, nil
+}
+
+func TestReadWalksCursorAndRunsSoftDeletePass(t *testing.T) {
+	fake := &fakeTwenty{t: t}
+	for i := 0; i < 5; i++ {
+		fake.people = append(fake.people, person(fmt.Sprintf("p-%d", i), false))
+	}
+	fake.deleted = append(fake.deleted, person("p-gone", true))
+
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	s := connectTo(t, srv, "")
+	tbl, err := s.GetTable(context.Background(), source.TableRequest{Name: "people"})
+	require.NoError(t, err)
+
+	dyn := tbl.(*source.DynamicSourceTable)
+	assert.Equal(t, []string{"id"}, dyn.TablePrimaryKeys)
+	assert.Equal(t, updatedAtField, dyn.TableIncrementalKey)
+
+	ch, err := dyn.ReadFn(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	rows, err := drain(t, ch)
+	require.NoError(t, err)
+
+	// 5 live (walked across 3 pages of 2) + 1 soft-deleted.
+	assert.Equal(t, 6, rows)
+
+	// depth=0 on every single request — the row shape must never depend on a
+	// server-side default.
+	for _, d := range fake.depthsSeen {
+		assert.Equal(t, "0", d)
+	}
+	// The page size is pinned to the API cap, not left to the API's default of 20.
+	for _, l := range fake.pageSizesSeen {
+		assert.Equal(t, "200", l)
+	}
+	// The soft-delete pass really ran.
+	assert.Contains(t, strings.Join(fake.filtersSeen, "|"), "deletedAt[is]:NOT_NULL")
+}
+
+func TestReadSkipsSoftDeletePassWhenDisabled(t *testing.T) {
+	fake := &fakeTwenty{t: t}
+	fake.people = append(fake.people, person("p-0", false))
+	fake.deleted = append(fake.deleted, person("p-gone", true))
+
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	s := connectTo(t, srv, "&include_deleted=false")
+	tbl, err := s.GetTable(context.Background(), source.TableRequest{Name: "people"})
+	require.NoError(t, err)
+
+	ch, err := tbl.(*source.DynamicSourceTable).ReadFn(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	rows, err := drain(t, ch)
+	require.NoError(t, err)
+	assert.Equal(t, 1, rows)
+	assert.NotContains(t, strings.Join(fake.filtersSeen, "|"), "deletedAt")
+}
+
+// ⚠️ THE SILENT-ZERO GUARD. Twenty said rows match; we read none. Every other
+// signal would report success — exit 0, "completed successfully", no rows.
+func TestReadFailsWhenServerReportsRowsButReturnsNone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/rest/metadata/objects" {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data":     map[string]interface{}{"objects": []objectMeta{personMeta()}},
+				"pageInfo": map[string]interface{}{"hasNextPage": false},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":       map[string]interface{}{"people": []interface{}{}},
+			"pageInfo":   map[string]interface{}{"hasNextPage": false},
+			"totalCount": 4321,
+		})
+	}))
+	defer srv.Close()
+
+	s := connectTo(t, srv, "")
+	tbl, err := s.GetTable(context.Background(), source.TableRequest{Name: "people"})
+	require.NoError(t, err)
+	ch, err := tbl.(*source.DynamicSourceTable).ReadFn(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	_, err = drain(t, ch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reported 4321 matching row(s) but the read returned none")
+}
+
+// A server that advertises another page without advancing the cursor must not
+// spin until the page guard.
+func TestReadRefusesRepeatedCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/rest/metadata/objects" {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"data":     map[string]interface{}{"objects": []objectMeta{personMeta()}},
+				"pageInfo": map[string]interface{}{"hasNextPage": false},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"data":       map[string]interface{}{"people": []interface{}{person("p-0", false)}},
+			"pageInfo":   map[string]interface{}{"hasNextPage": true, "endCursor": "stuck"},
+			"totalCount": 99,
+		})
+	}))
+	defer srv.Close()
+
+	s := connectTo(t, srv, "")
+	tbl, err := s.GetTable(context.Background(), source.TableRequest{Name: "people"})
+	require.NoError(t, err)
+	ch, err := tbl.(*source.DynamicSourceTable).ReadFn(context.Background(), source.ReadOptions{})
+	require.NoError(t, err)
+	_, err = drain(t, ch)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "same cursor twice")
+}
+
+func TestGetTableRejectsUnknownObject(t *testing.T) {
+	fake := &fakeTwenty{t: t}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	s := connectTo(t, srv, "")
+	_, err := s.GetTable(context.Background(), source.TableRequest{Name: "leads"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has no object \"leads\"")
+}
+
+func TestSchemesAndIncrementality(t *testing.T) {
+	t.Parallel()
+	s := NewTwentySource()
+	assert.Equal(t, []string{"twenty"}, s.Schemes())
+	assert.False(t, s.HandlesIncrementality())
+}

--- a/pkg/source/twenty/twenty_test.go
+++ b/pkg/source/twenty/twenty_test.go
@@ -91,10 +91,8 @@ func TestDataTypeFor(t *testing.T) {
 	assert.Equal(t, schema.TypeString, str("TEXT"))
 	assert.Equal(t, schema.TypeString, str("SELECT"))
 
-	// Composites carry JSON text in a String column — TypeJSON has no mapping in
-	// several destinations.
 	for _, composite := range []string{"EMAILS", "PHONES", "LINKS", "ADDRESS", "CURRENCY", "FULL_NAME", "ACTOR", "RICH_TEXT_V2", "ARRAY", "MULTI_SELECT", "RAW_JSON"} {
-		assert.Equal(t, schema.TypeString, str(composite), composite)
+		assert.Equal(t, schema.TypeJSON, str(composite), composite)
 	}
 
 	// NUMBER honours settings.dataType: ints stay ints, anything else keeps its
@@ -153,8 +151,6 @@ func TestBuildPlan(t *testing.T) {
 		names = append(names, c.Name)
 	}
 
-	// ⚠️ The FK, not the relation name — depth=0 returns companyId, never a
-	// nested company object.
 	assert.Contains(t, names, "companyId")
 	assert.NotContains(t, names, "company")
 
@@ -182,6 +178,8 @@ func TestBuildPlan(t *testing.T) {
 	assert.True(t, id.IsPrimaryKey)
 	assert.False(t, id.Nullable)
 	assert.Equal(t, schema.TypeString, id.DataType)
+	assert.Equal(t, schema.TypeJSON, plan.typeOf["name"])
+	assert.Equal(t, schema.TypeJSON, plan.typeOf["emails"])
 }
 
 // Without `id` there is nothing to deduplicate on, and under an append-style
@@ -251,8 +249,6 @@ func TestExtractRecords(t *testing.T) {
 	assert.Equal(t, "eyJpZCI6ImEifQ==", info.EndCursor)
 	assert.Equal(t, 68279, total)
 
-	// ⚠️ A key mismatch must NOT read as an empty page — that is exactly how a
-	// read bug disguises itself as an empty table.
 	items, _, _, err = extractRecords([]byte(`{"data":{"somethingElse":[{"id":"b"}]},"pageInfo":{},"totalCount":1}`), "people")
 	require.NoError(t, err)
 	require.Len(t, items, 1)
@@ -263,16 +259,15 @@ func TestExtractRecords(t *testing.T) {
 	assert.Contains(t, err.Error(), "no data envelope")
 }
 
-// ⚠️ Twenty carries money as integer amountMicros, which passes 2^53 for large
-// amounts and would lose its last digits through a float64 round-trip.
 func TestExtractRecordsKeepsBigIntegersExact(t *testing.T) {
 	t.Parallel()
 	body := `{"data":{"opportunities":[{"id":"a","amount":{"amountMicros":9007199254740993,"currencyCode":"CZK"}}]},"pageInfo":{},"totalCount":1}`
 	items, _, _, err := extractRecords([]byte(body), "opportunities")
 	require.NoError(t, err)
 
-	got := coerce(items[0]["amount"], schema.TypeString)
-	assert.Contains(t, got, "9007199254740993", "amountMicros must survive verbatim, not as 9.007199254740992e+15")
+	got, err := json.Marshal(coerce(items[0]["amount"], schema.TypeJSON))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "9007199254740993", "amountMicros must survive verbatim, not as 9.007199254740992e+15")
 }
 
 func TestCoerce(t *testing.T) {
@@ -283,9 +278,8 @@ func TestCoerce(t *testing.T) {
 	assert.Equal(t, true, coerce(true, schema.TypeBoolean))
 	assert.Nil(t, coerce(nil, schema.TypeString))
 
-	// Composites land as compact JSON text.
-	got := coerce(map[string]interface{}{"primaryEmail": "a@b.c", "additionalEmails": []interface{}{}}, schema.TypeString)
-	assert.JSONEq(t, `{"primaryEmail":"a@b.c","additionalEmails":[]}`, got.(string))
+	composite := map[string]interface{}{"primaryEmail": "a@b.c", "additionalEmails": []interface{}{}}
+	assert.Equal(t, composite, coerce(composite, schema.TypeJSON))
 
 	// Twenty's "unset" for several custom fields is an empty string, not null.
 	assert.Nil(t, coerce("", schema.TypeDate))
@@ -309,12 +303,9 @@ func TestParseTwentyTimestampAndDate(t *testing.T) {
 	assert.Nil(t, parseTwentyDate("nope"))
 }
 
-// ── End-to-end against a fake Twenty ─────────────────────────────────────────
-
 type fakeTwenty struct {
-	t *testing.T
-	// people is the full live set; deleted are the soft-deleted ones, which the
-	// real API hides unless deletedAt[is]:NOT_NULL is asked for.
+	t       *testing.T
+	objects []objectMeta
 	people  []map[string]interface{}
 	deleted []map[string]interface{}
 
@@ -328,11 +319,14 @@ func (f *fakeTwenty) handler() http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 
 		if r.URL.Path == "/rest/metadata/objects" {
-			obj := personMeta()
+			objects := f.objects
+			if len(objects) == 0 {
+				objects = []objectMeta{personMeta()}
+			}
 			require.NoError(f.t, json.NewEncoder(w).Encode(map[string]interface{}{
-				"data":       map[string]interface{}{"objects": []objectMeta{obj}},
+				"data":       map[string]interface{}{"objects": objects},
 				"pageInfo":   map[string]interface{}{"hasNextPage": false},
-				"totalCount": 1,
+				"totalCount": len(objects),
 			}))
 			return
 		}
@@ -478,8 +472,6 @@ func TestReadSkipsSoftDeletePassWhenDisabled(t *testing.T) {
 	assert.NotContains(t, strings.Join(fake.filtersSeen, "|"), "deletedAt")
 }
 
-// ⚠️ THE SILENT-ZERO GUARD. Twenty said rows match; we read none. Every other
-// signal would report success — exit 0, "completed successfully", no rows.
 func TestReadFailsWhenServerReportsRowsButReturnsNone(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -538,7 +530,7 @@ func TestReadRefusesRepeatedCursor(t *testing.T) {
 	assert.Contains(t, err.Error(), "same cursor twice")
 }
 
-func TestGetTableRejectsUnknownObject(t *testing.T) {
+func TestGetTableRequiresCustomPrefix(t *testing.T) {
 	fake := &fakeTwenty{t: t}
 	srv := httptest.NewServer(fake.handler())
 	defer srv.Close()
@@ -546,7 +538,21 @@ func TestGetTableRejectsUnknownObject(t *testing.T) {
 	s := connectTo(t, srv, "")
 	_, err := s.GetTable(context.Background(), source.TableRequest{Name: "leads"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "has no object \"leads\"")
+	assert.Contains(t, err.Error(), "use 'custom:<object_name>'")
+}
+
+func TestGetTableResolvesCustomObject(t *testing.T) {
+	leads := personMeta()
+	leads.NameSingular = "lead"
+	leads.NamePlural = "leads"
+	fake := &fakeTwenty{t: t, objects: []objectMeta{leads}}
+	srv := httptest.NewServer(fake.handler())
+	defer srv.Close()
+
+	s := connectTo(t, srv, "")
+	table, err := s.GetTable(context.Background(), source.TableRequest{Name: "custom:leads"})
+	require.NoError(t, err)
+	assert.Equal(t, "leads", table.Name())
 }
 
 func TestSchemesAndIncrementality(t *testing.T) {


### PR DESCRIPTION
## What

Adds [Twenty](https://twenty.com/) as a source — an open-source CRM, available both hosted
(api.twenty.com) and self-hosted. Reads objects and records through its REST API.

## Changes

- **`pkg/source/twenty/`** — source, `schema.go`, `register.go`, tests.
- **`internal/server/connectors.go`** — catalog entry.
- Docs page and both indexes.

### Metadata-derived schemas

The source has a fixed list of standard tables and supports workspace-specific objects as
`custom:<object_name>`. It reads each object's metadata at runtime because fields differ
between workspaces, including custom fields.

### Two decisions worth reviewer attention

1. **Composite field types use ingestr's JSON type** (`EMAILS`, `PHONES`, `LINKS`,
   `ADDRESS`, `CURRENCY`, `FULL_NAME`, `ACTOR`, `RICH_TEXT_V2`, `ARRAY`, `MULTI_SELECT`,
   `RAW_JSON`). `CURRENCY` amounts retain their exact integer micros representation.
2. **An object without an `id` is refused rather than ingested.** There would be nothing
   to deduplicate on, and under an append-style incremental strategy every run would add
   the whole object again.

Note Twenty soft-deletes: rows carry `deletedAt` and are returned, so a consumer wanting
the live set filters `deletedAt IS NULL`. The docs page says so.

## How to test

```bash
ingestr ingest \
  --source-uri 'twenty://api.twenty.com?api_key=<key>' \
  --source-table people \
  --dest-uri duckdb:///twenty.duckdb \
  --dest-table main.people
```

## Risk & rollback

- **Risk:** low. Purely additive; no existing source or shared path is touched.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format-ci`, `make lint` — 0 issues)
- [x] Integration tests pass if affected — not affected
- [x] No unrelated changes included
- [x] Tested locally against two live workspaces

## Security

- [x] No secrets, credentials, or PII in this change — the API key comes from the URI and
      is never logged
- [x] No new dependencies with known vulnerabilities — no new dependencies at all
- [x] Security implications considered

## Related issues

None found.

---

### Where this comes from

We've been running this nightly in our own production warehouse since mid-August. That's
why it's arriving now rather than the day it was written — we wanted it to settle first,
and every API quirk called out above is something it actually hit in practice rather than
something we read in the docs.

**No pressure at all if you'd rather not take it.** We're keeping these in our fork
either way and they cost us nothing to maintain there; we're only sending them because
they seemed like they might be useful to someone else. Equally happy to change anything
to taste, or to close it — just say.

