### PR TITLE
feat(sftp): support host key verification

### DIFF
--- a/docs/supported-sources/sftp.md
+++ b/docs/supported-sources/sftp.md
@@ -6,38 +6,70 @@ SFTP (SSH File Transfer Protocol) is a secure file transfer protocol that runs o
 
 ## URI Format
 
-The URI for connecting to an SFTP server is structured as follows:
+For password authentication, use:
 
 ```plaintext
 sftp://<username>:<password>@<host>:<port>
 ```
 
-## URI Components:
+For private-key authentication, omit the password and provide `key_file`:
+
+```plaintext
+sftp://<username>@<host>:<port>?key_file=/path/to/private_key
+```
+
+## URI components
+
 - `username`: The username for the SFTP server.
-- `password`: The password for the SFTP server.
+- `password`: The password for the SFTP server. Either `password` or `key_file` is required.
 - `host`: The hostname or IP address of the SFTP server.
 - `port`: The port number of the SFTP server (defaults to 22 if not specified).
 
-## Setting up an SFTP Integration
+The following query parameters are supported:
 
-To integrate `ingestr` with an SFTP server, you need the server's hostname, port, a valid username, and a password.
+- `key_file`: Path to an OpenSSH private key.
+- `key_passphrase`: Passphrase for an encrypted private key.
+- `known_hosts_file`: Path to an OpenSSH `known_hosts` file, commonly `~/.ssh/known_hosts`.
+- `host_key_fingerprint`: An OpenSSH SHA256 host-key fingerprint, such as `SHA256:...`. Repeat this parameter or provide a comma-separated value to allow multiple keys. When set, these fingerprints are used instead of `known_hosts_file`.
+- `insecure_skip_host_key_check`: Set to `true` only as a temporary compatibility escape hatch. This disables server identity verification and prints a warning.
 
-Once you have your credentials, you can load data to desired destaination.
+For `known_hosts_file`, paths beginning with `~/` are expanded relative to the current user's home directory. URL-encode query parameter values when they contain reserved URI characters.
 
-### Example: Loading data from SFTP TO DUCKDB
+## Host-key verification
+
+Configure `known_hosts_file` or `host_key_fingerprint` to verify the SFTP server's identity. An unknown key or a key that differs from the trusted key stops the connection with an error.
+
+For backwards compatibility, an existing SFTP URI without either option continues without host-key verification and prints a warning. New and updated integrations should always configure one of the verification options. Set `insecure_skip_host_key_check=true` only when the insecure behavior is an explicit, temporary choice.
+
+Before adding a new key, verify it or its SHA256 fingerprint with the server administrator through a trusted channel. You can then add it to an OpenSSH `known_hosts` file or pin the verified fingerprint in the source URI.
+
+## Setting up an SFTP integration
+
+To integrate `ingestr` with an SFTP server, you need the server's hostname, port, a valid username, password or private key, and a trusted host key.
+
+Once you have your credentials, you can load data to the desired destination.
+
+### Example: loading data from SFTP to DuckDB
 
 ```sh
 ingestr ingest \
     --source-uri 'sftp://myuser:MySecretPassword123@sftp.example.com' \
     --source-table 'user.csv' \
     --dest-uri duckdb:///sftp_data.duckdb \
-    --dest-table 'dest.users_deatils'
+    --dest-table 'dest.users_details'
+```
+
+To pin the server key directly:
+
+```sh
+ingestr ingest \
+    --source-uri 'sftp://myuser:MySecretPassword123@sftp.example.com?host_key_fingerprint=SHA256%3A<verified-base64-fingerprint>' \
+    --source-table 'user.csv' \
+    --dest-uri duckdb:///sftp_data.duckdb \
+    --dest-table 'dest.users_details'
 ```
 
 <img alt="sftp" src="../media/sftp.png"/>
 
 
-The `--source-table` specifies `/path/to/directory` The base directory on the server where `ingestr` should start looking for files.
-
-
-
+`--source-table` specifies the file path or glob on the server that `ingestr` should read.

--- a/docs/supported-sources/sftp.md
+++ b/docs/supported-sources/sftp.md
@@ -12,23 +12,28 @@ For password authentication, use:
 sftp://<username>:<password>@<host>:<port>
 ```
 
-For private-key authentication, omit the password and provide `key_file`:
+For private-key authentication, provide `key_file`. Omit the password for an unencrypted key:
 
 ```plaintext
 sftp://<username>@<host>:<port>?key_file=/path/to/private_key
 ```
 
+For an encrypted private key, use the URI password as its passphrase:
+
+```plaintext
+sftp://<username>:<key-passphrase>@<host>:<port>?key_file=/path/to/private_key
+```
+
 ## URI components
 
 - `username`: The username for the SFTP server.
-- `password`: The password for the SFTP server. Either `password` or `key_file` is required.
+- `password`: The SFTP account password when `key_file` is absent, or the private-key passphrase when `key_file` is present. Either `password` or `key_file` is required.
 - `host`: The hostname or IP address of the SFTP server.
 - `port`: The port number of the SFTP server (defaults to 22 if not specified).
 
 The following query parameters are supported:
 
 - `key_file`: Path to an OpenSSH private key.
-- `key_passphrase`: Passphrase for an encrypted private key.
 - `known_hosts_file`: Path to an OpenSSH `known_hosts` file, commonly `~/.ssh/known_hosts`.
 - `host_key_fingerprint`: An OpenSSH SHA256 host-key fingerprint, such as `SHA256:...`. Repeat this parameter or provide a comma-separated value to allow multiple keys. When set, these fingerprints are used instead of `known_hosts_file`.
 - `insecure_skip_host_key_check`: Set to `true` only as a temporary compatibility escape hatch. This disables server identity verification and prints a warning.

--- a/pkg/source/blobstore/blobstore.go
+++ b/pkg/source/blobstore/blobstore.go
@@ -5,12 +5,16 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,12 +37,14 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/bruin-data/ingestr/internal/adlsutil"
 	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	csvsource "github.com/bruin-data/ingestr/pkg/source/csv"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -278,10 +284,14 @@ func createSFTPClient(parsed *parsedBlobstoreURI) (*ssh.Client, *sftp.Client, er
 	}
 
 	addr := fmt.Sprintf("%s:%s", parsed.sftpHost, parsed.sftpPort)
+	hostKeyCallback, err := createSFTPHostKeyCallback(parsed)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	sshConfig := &ssh.ClientConfig{
 		User:            parsed.sftpUsername,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // SFTP sources connect to user-specified hosts
+		HostKeyCallback: hostKeyCallback,
 	}
 
 	if parsed.sftpPassword != "" {
@@ -319,6 +329,67 @@ func createSFTPClient(parsed *parsedBlobstoreURI) (*ssh.Client, *sftp.Client, er
 	}
 
 	return sshConn, sftpConn, nil
+}
+
+func createSFTPHostKeyCallback(parsed *parsedBlobstoreURI) (ssh.HostKeyCallback, error) {
+	if parsed.sftpInsecureSkipHostKeyCheck {
+		output.Warnf("Warning: SFTP host key verification is disabled; this connection is vulnerable to man-in-the-middle attacks\n")
+		return ssh.InsecureIgnoreHostKey(), nil //nolint:gosec // Explicit compatibility option requested by the user.
+	}
+
+	if len(parsed.sftpHostKeyFingerprints) > 0 {
+		for _, fingerprint := range parsed.sftpHostKeyFingerprints {
+			encoded, ok := strings.CutPrefix(fingerprint, "SHA256:")
+			decoded, err := base64.RawStdEncoding.DecodeString(encoded)
+			if !ok || err != nil || len(decoded) != 32 {
+				return nil, fmt.Errorf("invalid SFTP host_key_fingerprint %q: expected an OpenSSH SHA256 fingerprint", fingerprint)
+			}
+		}
+
+		return func(hostname string, _ net.Addr, key ssh.PublicKey) error {
+			actual := ssh.FingerprintSHA256(key)
+			for _, expected := range parsed.sftpHostKeyFingerprints {
+				if actual == expected {
+					return nil
+				}
+			}
+			return fmt.Errorf("SFTP host key mismatch for %s: got %s, expected one of %s", hostname, actual, strings.Join(parsed.sftpHostKeyFingerprints, ", "))
+		}, nil
+	}
+
+	knownHostsFile := parsed.sftpKnownHostsFile
+	if knownHostsFile == "" {
+		output.Warnf("Warning: SFTP host key verification is not configured; continuing without verification for backwards compatibility. Configure known_hosts_file or host_key_fingerprint to verify the server.\n")
+		return ssh.InsecureIgnoreHostKey(), nil //nolint:gosec // Preserves existing SFTP URIs while warning users to configure verification.
+	}
+	if knownHostsFile == "~" || strings.HasPrefix(knownHostsFile, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("failed to expand SFTP known_hosts_file %q: %w", knownHostsFile, err)
+		}
+		knownHostsFile = filepath.Join(home, strings.TrimPrefix(knownHostsFile, "~/"))
+	}
+
+	callback, err := knownhosts.New(knownHostsFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load SFTP known_hosts file %q: %w", knownHostsFile, err)
+	}
+
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		err := callback(hostname, remote, key)
+		if err == nil {
+			return nil
+		}
+
+		var keyErr *knownhosts.KeyError
+		if errors.As(err, &keyErr) {
+			if len(keyErr.Want) == 0 {
+				return fmt.Errorf("unknown SFTP host key for %s (%s); add it to %q: %w", hostname, ssh.FingerprintSHA256(key), knownHostsFile, err)
+			}
+			return fmt.Errorf("SFTP host key mismatch for %s (%s); the key in %q differs: %w", hostname, ssh.FingerprintSHA256(key), knownHostsFile, err)
+		}
+		return err
+	}, nil
 }
 
 func (s *BlobstoreSource) Close(ctx context.Context) error {
@@ -1409,6 +1480,9 @@ type parsedBlobstoreURI struct {
 	sftpPassword                  string
 	sftpKeyFile                   string
 	sftpKeyPassphrase             string
+	sftpKnownHostsFile            string
+	sftpHostKeyFingerprints       []string
+	sftpInsecureSkipHostKeyCheck  bool
 }
 
 func parseBlobstoreURI(uri string) (*parsedBlobstoreURI, error) {
@@ -1449,8 +1523,23 @@ func parseBlobstoreURI(uri string) (*parsedBlobstoreURI, error) {
 		}
 		parsed.sftpUsername = u.User.Username()
 		parsed.sftpPassword, _ = u.User.Password()
-		parsed.sftpKeyFile = u.Query().Get("key_file")
-		parsed.sftpKeyPassphrase = u.Query().Get("key_passphrase")
+		query := u.Query()
+		parsed.sftpKeyFile = query.Get("key_file")
+		parsed.sftpKeyPassphrase = query.Get("key_passphrase")
+		parsed.sftpKnownHostsFile = query.Get("known_hosts_file")
+		for _, value := range query["host_key_fingerprint"] {
+			for fingerprint := range strings.SplitSeq(value, ",") {
+				if fingerprint = strings.TrimSpace(fingerprint); fingerprint != "" {
+					parsed.sftpHostKeyFingerprints = append(parsed.sftpHostKeyFingerprints, fingerprint)
+				}
+			}
+		}
+		if raw := query.Get("insecure_skip_host_key_check"); raw != "" {
+			parsed.sftpInsecureSkipHostKeyCheck, err = strconv.ParseBool(raw)
+			if err != nil {
+				return nil, fmt.Errorf("invalid insecure_skip_host_key_check value %q: expected true or false", raw)
+			}
+		}
 	default:
 		return nil, fmt.Errorf("unsupported blobstore scheme: %s", u.Scheme)
 	}

--- a/pkg/source/blobstore/blobstore.go
+++ b/pkg/source/blobstore/blobstore.go
@@ -294,7 +294,7 @@ func createSFTPClient(parsed *parsedBlobstoreURI) (*ssh.Client, *sftp.Client, er
 		HostKeyCallback: hostKeyCallback,
 	}
 
-	if parsed.sftpPassword != "" {
+	if parsed.sftpPassword != "" && parsed.sftpKeyFile == "" {
 		sshConfig.Auth = []ssh.AuthMethod{
 			ssh.Password(parsed.sftpPassword),
 		}
@@ -305,12 +305,11 @@ func createSFTPClient(parsed *parsedBlobstoreURI) (*ssh.Client, *sftp.Client, er
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to read SSH key file: %w", err)
 		}
-		var signer ssh.Signer
-		if parsed.sftpKeyPassphrase != "" {
-			signer, err = ssh.ParsePrivateKeyWithPassphrase(key, []byte(parsed.sftpKeyPassphrase))
-		} else {
-			signer, err = ssh.ParsePrivateKey(key)
+		keyPassword := parsed.sftpPassword
+		if keyPassword == "" {
+			keyPassword = parsed.sftpKeyPassphrase
 		}
+		signer, err := parseSFTPPrivateKey(key, keyPassword)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to parse SSH key: %w", err)
 		}
@@ -329,6 +328,19 @@ func createSFTPClient(parsed *parsedBlobstoreURI) (*ssh.Client, *sftp.Client, er
 	}
 
 	return sshConn, sftpConn, nil
+}
+
+func parseSFTPPrivateKey(key []byte, password string) (ssh.Signer, error) {
+	signer, err := ssh.ParsePrivateKey(key)
+	if err == nil {
+		return signer, nil
+	}
+
+	var passphraseMissing *ssh.PassphraseMissingError
+	if password == "" || !errors.As(err, &passphraseMissing) {
+		return nil, err
+	}
+	return ssh.ParsePrivateKeyWithPassphrase(key, []byte(password))
 }
 
 func createSFTPHostKeyCallback(parsed *parsedBlobstoreURI) (ssh.HostKeyCallback, error) {

--- a/pkg/source/blobstore/blobstore_test.go
+++ b/pkg/source/blobstore/blobstore_test.go
@@ -1,8 +1,12 @@
 package blobstore
 
 import (
+	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,10 +20,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/athena"
 	athenatypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/bruin-data/ingestr/internal/adlsutil"
+	"github.com/bruin-data/ingestr/internal/output"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 type fakeAthenaAPI struct {
@@ -216,6 +223,91 @@ func TestParseBlobstoreURI_GCS(t *testing.T) {
 			assert.Equal(t, tt.want.credentialsFile, got.credentialsFile)
 		})
 	}
+}
+
+func TestParseBlobstoreURI_SFTPHostKeyOptions(t *testing.T) {
+	parsed, err := parseBlobstoreURI("sftp://user:password@example.com?known_hosts_file=~%2F.ssh%2Fcustom_hosts&host_key_fingerprint=SHA256%3Afirst%2CSHA256%3Asecond&host_key_fingerprint=SHA256%3Athird&insecure_skip_host_key_check=true")
+	require.NoError(t, err)
+
+	assert.Equal(t, "~/.ssh/custom_hosts", parsed.sftpKnownHostsFile)
+	assert.Equal(t, []string{"SHA256:first", "SHA256:second", "SHA256:third"}, parsed.sftpHostKeyFingerprints)
+	assert.True(t, parsed.sftpInsecureSkipHostKeyCheck)
+
+	_, err = parseBlobstoreURI("sftp://user:password@example.com?insecure_skip_host_key_check=perhaps")
+	require.EqualError(t, err, `invalid insecure_skip_host_key_check value "perhaps": expected true or false`)
+}
+
+func TestSFTPHostKeyCallbackKnownHosts(t *testing.T) {
+	trustedKey := newSSHTestPublicKey(t)
+	otherKey := newSSHTestPublicKey(t)
+	knownHostsFile := filepath.Join(t.TempDir(), "known_hosts")
+	require.NoError(t, os.WriteFile(knownHostsFile, []byte(knownhosts.Line([]string{"sftp.example.com"}, trustedKey)+"\n"), 0o600))
+
+	callback, err := createSFTPHostKeyCallback(&parsedBlobstoreURI{sftpKnownHostsFile: knownHostsFile})
+	require.NoError(t, err)
+	remote := &net.TCPAddr{}
+
+	require.NoError(t, callback("sftp.example.com:22", remote, trustedKey))
+
+	err = callback("unknown.example.com:22", remote, trustedKey)
+	require.ErrorContains(t, err, "unknown SFTP host key")
+	require.ErrorContains(t, err, ssh.FingerprintSHA256(trustedKey))
+
+	err = callback("sftp.example.com:22", remote, otherKey)
+	require.ErrorContains(t, err, "SFTP host key mismatch")
+	require.ErrorContains(t, err, ssh.FingerprintSHA256(otherKey))
+}
+
+func TestSFTPHostKeyCallbackFingerprints(t *testing.T) {
+	trustedKey := newSSHTestPublicKey(t)
+	otherKey := newSSHTestPublicKey(t)
+	trustedFingerprint := ssh.FingerprintSHA256(trustedKey)
+
+	callback, err := createSFTPHostKeyCallback(&parsedBlobstoreURI{
+		sftpHostKeyFingerprints: []string{ssh.FingerprintSHA256(otherKey), trustedFingerprint},
+	})
+	require.NoError(t, err)
+	require.NoError(t, callback("sftp.example.com:22", nil, trustedKey))
+
+	err = callback("sftp.example.com:22", nil, newSSHTestPublicKey(t))
+	require.ErrorContains(t, err, "SFTP host key mismatch")
+	require.ErrorContains(t, err, trustedFingerprint)
+
+	_, err = createSFTPHostKeyCallback(&parsedBlobstoreURI{sftpHostKeyFingerprints: []string{"MD5:invalid"}})
+	require.ErrorContains(t, err, "expected an OpenSSH SHA256 fingerprint")
+}
+
+func TestSFTPHostKeyCallbackPreservesUnconfiguredConnections(t *testing.T) {
+	stdout, stderr, mode := output.Current()
+	defer output.Init(stdout, stderr, mode)
+
+	var warning bytes.Buffer
+	output.Init(&warning, &bytes.Buffer{}, output.ModeText)
+	callback, err := createSFTPHostKeyCallback(&parsedBlobstoreURI{})
+	require.NoError(t, err)
+	require.Contains(t, warning.String(), "continuing without verification for backwards compatibility")
+	require.NoError(t, callback("sftp.example.com:22", nil, newSSHTestPublicKey(t)))
+}
+
+func TestSFTPInsecureHostKeyCallbackWarns(t *testing.T) {
+	stdout, stderr, mode := output.Current()
+	defer output.Init(stdout, stderr, mode)
+
+	var warning bytes.Buffer
+	output.Init(&warning, &bytes.Buffer{}, output.ModeText)
+	callback, err := createSFTPHostKeyCallback(&parsedBlobstoreURI{sftpInsecureSkipHostKeyCheck: true})
+	require.NoError(t, err)
+	require.Contains(t, warning.String(), "SFTP host key verification is disabled")
+	require.NoError(t, callback("sftp.example.com:22", nil, newSSHTestPublicKey(t)))
+}
+
+func newSSHTestPublicKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	key, err := ssh.NewPublicKey(publicKey)
+	require.NoError(t, err)
+	return key
 }
 
 func TestParseBlobstoreURI_AzureDatalake(t *testing.T) {

--- a/pkg/source/blobstore/blobstore_test.go
+++ b/pkg/source/blobstore/blobstore_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"encoding/pem"
 	"net"
 	"os"
 	"path/filepath"
@@ -235,6 +236,36 @@ func TestParseBlobstoreURI_SFTPHostKeyOptions(t *testing.T) {
 
 	_, err = parseBlobstoreURI("sftp://user:password@example.com?insecure_skip_host_key_check=perhaps")
 	require.EqualError(t, err, `invalid insecure_skip_host_key_check value "perhaps": expected true or false`)
+}
+
+func TestParseBlobstoreURI_SFTPPreservesLegacyKeyPassphrase(t *testing.T) {
+	parsed, err := parseBlobstoreURI("sftp://user@example.com?key_file=%2Fkey&key_passphrase=legacy-password")
+	require.NoError(t, err)
+	require.Equal(t, "legacy-password", parsed.sftpKeyPassphrase)
+}
+
+func TestParseSFTPPrivateKey(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	unencryptedBlock, err := ssh.MarshalPrivateKey(privateKey, "")
+	require.NoError(t, err)
+	_, err = parseSFTPPrivateKey(pem.EncodeToMemory(unencryptedBlock), "unused-password")
+	require.NoError(t, err)
+
+	encryptedBlock, err := ssh.MarshalPrivateKeyWithPassphrase(privateKey, "", []byte("key-password"))
+	require.NoError(t, err)
+	encryptedKey := pem.EncodeToMemory(encryptedBlock)
+
+	_, err = parseSFTPPrivateKey(encryptedKey, "key-password")
+	require.NoError(t, err)
+
+	_, err = parseSFTPPrivateKey(encryptedKey, "wrong-password")
+	require.Error(t, err)
+
+	_, err = parseSFTPPrivateKey(encryptedKey, "")
+	var passphraseMissing *ssh.PassphraseMissingError
+	require.ErrorAs(t, err, &passphraseMissing)
 }
 
 func TestSFTPHostKeyCallbackKnownHosts(t *testing.T) {


### PR DESCRIPTION
## Summary

- add OpenSSH `known_hosts` verification through `known_hosts_file`
- support one or more pinned SHA256 host-key fingerprints
- preserve existing SFTP loads when verification is unconfigured, with a migration warning
- retain an explicit warned `insecure_skip_host_key_check=true` escape hatch
- document private-key authentication and host-key verification options

## Verification

- `go test ./pkg/source/blobstore -count=1`
- `make format`
- `make lint`
- `make test`

Closes #1137