### PR TITLE
feat(source): add streaming HTTP file source

### DIFF
--- a/docs/supported-sources/http.md
+++ b/docs/supported-sources/http.md
@@ -99,6 +99,12 @@ HTTP 408, 429, and 5xx responses and transport failures are retried with bounded
 
 `retries` accepts values from 0 through 10. Waiting and active requests stop promptly when ingestion is cancelled.
 
+A read stalls if the server sends response headers and then stops sending body bytes without closing the connection. `read_timeout` bounds the time allowed between successive reads (not the total download time, so slow but progressing streams are unaffected). It defaults to `2m`; set `0` to disable it:
+
+```sh
+--source-uri 'https://example.com/data.csv#ingestr:read_timeout=5m'
+```
+
 If a response is interrupted after bytes have been decoded, ingestr resumes only when it can preserve file identity:
 
 - the initial response supplied a strong `ETag` or `Last-Modified` validator;

--- a/docs/supported-sources/http.md
+++ b/docs/supported-sources/http.md
@@ -1,123 +1,151 @@
 # HTTP
 
-ingestr supports reading CSV, JSON, and Parquet files from public HTTP/HTTPS URLs. This allows you to ingest data from publicly accessible file URLs directly into your databases.
+ingestr can read CSV, JSON, JSONL, and Parquet files directly from HTTP and HTTPS URLs.
 
 ## URI format
 
-The URI format for HTTP sources is as follows:
+Use the file URL as `--source-uri`. Query parameters remain part of the request URL, so signed download URLs work unchanged.
 
-```plaintext
-http://example.com/path/to/file.csv
-https://example.com/path/to/file.json
-https://example.com/path/to/file.parquet
-```
-
-## Supported file formats
-
-The HTTP source supports the following file formats:
-
-- **CSV** (`.csv`) - Comma-separated values files with headers
-- **CSV Headless** - CSV files without headers (use `#csv_headless` suffix)
-- **JSON** (`.json`, `.jsonl`) - JSON objects and JSON Lines format
-- **Parquet** (`.parquet`) - Apache Parquet columnar format
-
-The file format is automatically inferred from the URL extension. You can also explicitly specify the format using the `#format` suffix in the `--source-table` parameter.
-
-## Usage
-
-### Basic example
-
-```bash
+```sh
 ingestr ingest \
-    --source-uri "https://example.com/data.csv" \
-    --source-table "data" \
-    --dest-uri "duckdb:///local.duckdb" \
-    --dest-table "my_table"
+  --source-uri 'https://example.com/exports/companies.csv' \
+  --source-table 'companies' \
+  --dest-uri 'duckdb:///local.duckdb' \
+  --dest-table 'main.companies'
 ```
 
-### Specifying file format explicitly
+HTTP source options use an `#ingestr:` fragment. URL fragments are not sent to the server, which keeps source configuration separate from the file URL's query parameters:
 
-If the URL doesn't have a recognizable extension (e.g., an API endpoint), you can specify the format using the `#format` suffix in `--source-table`:
-
-```bash
-ingestr ingest \
-    --source-uri "https://example.com/api/export" \
-    --source-table "data#csv" \
-    --dest-uri "duckdb:///local.duckdb" \
-    --dest-table "my_table"
+```text
+https://example.com/data.csv?signature=server-value#ingestr:retries=5
 ```
 
-### CSV without headers
+Percent-encode option values that contain `&`, `=`, `#`, spaces, or other URL-reserved characters.
 
-For CSV files that don't have a header row, use `#csv_headless`. You can optionally provide column names using the `--columns` flag:
+## Format selection
 
-```bash
-# With custom column names
-ingestr ingest \
-    --source-uri "https://example.com/data.csv" \
-    --source-table "data#csv_headless" \
-    --columns "id:bigint,name:text,value:double" \
-    --dest-uri "duckdb:///local.duckdb" \
-    --dest-table "my_table"
+The source selects the decoder in this order:
+
+1. An explicit format hint on `--source-table`.
+2. The final URL suffix after redirects.
+3. The response `Content-Type`.
+
+| Source-table hint | URL suffixes | Content types |
+|---|---|---|
+| `#csv` | `.csv`, `.csv.gz` | `text/csv`, `application/csv` |
+| `#csv_headless` | — | — |
+| `#json` | `.json`, `.json.gz` | `application/json` |
+| `#jsonl` | `.jsonl`, `.ndjson`, and gzipped variants | `application/jsonl`, `application/x-ndjson`, `application/ndjson`, `application/x-jsonlines` |
+| `#parquet` | `.parquet`, `.parquet.gz` | `application/vnd.apache.parquet`, `application/x-parquet` |
+
+Use a hint when the URL and content type are ambiguous:
+
+```sh
+--source-uri 'https://example.com/export?id=42' \
+--source-table 'companies#jsonl'
 ```
 
-If no column names are provided, columns will be automatically named `unknown_col_0`, `unknown_col_1`, etc.:
+CSV encoding hints match blobstore sources and can be combined in either order:
 
-```bash
-# Without column names (auto-generated)
-ingestr ingest \
-    --source-uri "https://example.com/data.csv" \
-    --source-table "data#csv_headless" \
-    --dest-uri "duckdb:///local.duckdb" \
-    --dest-table "my_table"
+```sh
+--source-table 'companies#csv,encoding=windows-1252'
 ```
 
-### Example with JSON file
+For a CSV without a header, use `#csv_headless`. Define names and optional types with `--columns`; otherwise columns are named `unknown_col_0`, `unknown_col_1`, and so on.
 
-```bash
-ingestr ingest \
-    --source-uri "https://api.example.com/export/data.json" \
-    --source-table "data" \
-    --dest-uri "snowflake://user:pass@account/database/schema" \
-    --dest-table "json_data"
+## Authentication and headers
+
+### Bearer authentication
+
+```sh
+--source-uri 'https://example.com/data.csv#ingestr:bearer_token=TOKEN'
 ```
 
-### Example with Parquet file
+### Basic authentication
 
-```bash
-ingestr ingest \
-    --source-uri "https://storage.example.com/data.parquet" \
-    --source-table "data" \
-    --dest-uri "bigquery://project/dataset" \
-    --dest-table "parquet_data"
+Basic credentials can use URL user information:
+
+```sh
+--source-uri 'https://username:password@example.com/data.csv'
 ```
 
-## Supported format suffixes
+or source options:
 
-You can use these suffixes with `--source-table` to explicitly specify the file format:
+```sh
+--source-uri 'https://example.com/data.csv#ingestr:basic_user=username&basic_password=password'
+```
 
-| Suffix | Format |
-|--------|--------|
-| `#csv` | CSV with headers |
-| `#csv_headless` | CSV without headers |
-| `#json` | JSON |
-| `#jsonl` | JSON Lines |
-| `#parquet` | Parquet |
+### Custom headers
 
-## Notes
+Prefix each header name with `header.`. Repeat a key to send multiple values:
 
-- The `--source-table` parameter is required; use it to specify the format suffix if needed (e.g., `data#csv_headless`)
-- The HTTP source downloads the entire file before processing, so ensure you have sufficient memory for large files
-- Authentication is not currently supported; only publicly accessible URLs can be used
-- The file must be accessible without requiring cookies, headers, or other authentication mechanisms
-- For very large files, consider using a dedicated file storage source (e.g., S3, GCS)
-- Data is processed in chunks internally:
-  - CSV: 10,000 rows per chunk
-  - JSON: 1,000 objects per chunk
-  - Parquet: 10,000 rows per chunk
+```sh
+--source-uri 'https://example.com/data.jsonl#ingestr:header.X-API-Key=TOKEN&header.X-Tenant=acme'
+```
 
-## Limitations
+Credentials, option fragments, header values, and query values are redacted from debug logs. On a redirect, configured authentication and custom headers are retained only when the scheme and host are unchanged. They are stripped before following a cross-origin redirect. The source follows at most 10 redirects.
 
-- Only supports public URLs (no authentication)
-- The entire file is downloaded into memory before processing
-- No support for incremental loading
+## Retries, streaming, and resume
+
+CSV, JSON, and JSONL responses are decoded as they arrive. Batches can reach the destination before the download completes, and memory is bounded by the configured batch size. Gzip responses and files ending in `.gz` are decompressed as streams.
+
+Parquet requires random access. The HTTP response is therefore streamed to a temporary file and decoded with the existing Parquet file reader. This bounds heap usage at the cost of temporary disk space; the temporary file is removed after the read.
+
+HTTP 408, 429, and 5xx responses and transport failures are retried with bounded exponential backoff. `Retry-After` is honored. There are three retries after the initial request by default:
+
+```sh
+--source-uri 'https://example.com/data.csv#ingestr:retries=5'
+```
+
+`retries` accepts values from 0 through 10. Waiting and active requests stop promptly when ingestion is cancelled.
+
+If a response is interrupted after bytes have been decoded, ingestr resumes only when it can preserve file identity:
+
+- the initial response supplied a strong `ETag` or `Last-Modified` validator;
+- the server accepts a `Range` request and returns `206 Partial Content`;
+- `Content-Range`, total length, and validators remain consistent.
+
+The resume request uses `If-Range`. If any condition is not met, ingestion fails rather than restarting the file and emitting duplicate rows. Resume state is limited to the current ingestion process; it is not persisted between runs.
+
+## Validation and conditional requests
+
+When the server supplies `Content-Length`, ingestr verifies that the complete response has that length, including across resumed requests.
+
+An optional SHA-256 checksum validates the exact response bytes before file-level gzip decompression:
+
+```sh
+--source-uri 'https://example.com/data.csv#ingestr:checksum=sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+```
+
+Conditional validators can be supplied explicitly:
+
+```sh
+--source-uri 'https://example.com/data.csv#ingestr:if_none_match=%22version-7%22'
+--source-uri 'https://example.com/data.csv#ingestr:if_modified_since=Wed%2C+21+Oct+2015+07%3A28%3A00+GMT'
+```
+
+A `304 Not Modified` response returns `ErrNotModified` and stops ingestion before the destination is changed. ingestr does not persist validators automatically, because doing so without a destination-aware state contract could incorrectly skip or replace data.
+
+## Response metadata
+
+After a response starts, `HTTPSource.Metadata()` exposes:
+
+- the final URL after redirects;
+- `ETag`;
+- `Last-Modified`;
+- content length (`-1` when unknown);
+- content type.
+
+The same non-secret values are shown with `--debug`; URLs in logs have user information, fragments, and query values redacted.
+
+## Source options
+
+| Option | Description |
+|---|---|
+| `bearer_token` | Bearer token; cannot be combined with Basic authentication. |
+| `basic_user` / `basic_password` | HTTP Basic credentials. |
+| `header.<Name>` | Custom request header. Transport-managed headers such as `Range`, `Content-Length`, and `Accept-Encoding` cannot be overridden. |
+| `retries` | Retries after the initial request, from 0 to 10. Default: 3. |
+| `checksum` | Expected checksum in `sha256:<64 hex characters>` form. |
+| `if_none_match` | Value for `If-None-Match`. |
+| `if_modified_since` | Value for `If-Modified-Since`. |

--- a/hack/lint-changed.sh
+++ b/hack/lint-changed.sh
@@ -62,7 +62,7 @@ else
   packages=("${unique_packages[@]}")
 fi
 
-args=(run --timeout "$timeout" --concurrency "$concurrency")
+args=(run --timeout "$timeout" --concurrency "$concurrency" --build-tags integration)
 
 if [[ -n "$parallel_flags" ]]; then
   read -r -a parsed_parallel_flags <<< "$parallel_flags"

--- a/pkg/source/csv/csv.go
+++ b/pkg/source/csv/csv.go
@@ -149,119 +149,125 @@ func (s *CSVSource) read(ctx context.Context, opts source.ReadOptions) (<-chan s
 	go func() {
 		defer close(results)
 		defer func() { _ = f.Close() }()
-
-		csvReader := csv.NewReader(decoded)
-		csvReader.FieldsPerRecord = -1
-		csvReader.ReuseRecord = true
-
-		headers, err := csvReader.Read()
-		if err != nil {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to read CSV headers: %w", err)}
+		totalRows, batchNum, err := Read(ctx, decoded, opts, results)
+		if err != nil && ctx.Err() == nil {
+			results <- source.RecordBatchResult{Err: err}
 			return
 		}
-
-		if len(headers) == 0 {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to extract headers from the CSV, are you sure the given file contains a header row?")}
-			return
-		}
-		headers = append([]string(nil), headers...)
-
-		incrementalKey := opts.IncrementalKey
-		if incrementalKey != "" && !containsHeader(headers, incrementalKey) {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("incremental_key '%s' not found in the CSV file", incrementalKey)}
-			return
-		}
-
-		var startTime *time.Time
-		if opts.IntervalStart != nil {
-			t := *opts.IntervalStart
-			startTime = &t
-		}
-
-		builder := newBatchBuilder(headers, opts.ExcludeColumns, opts.Schema)
-		defer builder.rb.Release()
-		incIdx := headerIndexes(headers, incrementalKey)
-
-		batchNum := 0
-		totalRows := 0
-		lineNum := 1
-		var accBytes int64
-
-		flush := func() bool {
-			rec := builder.finish()
-			batchNum++
-			totalRows += int(rec.NumRows())
-			config.Debug("[CSV] Batch %d: %d rows (total: %d)", batchNum, rec.NumRows(), totalRows)
-
-			select {
-			case results <- source.RecordBatchResult{Batch: rec}:
-				return true
-			case <-ctx.Done():
-				rec.Release()
-				return false
-			}
-		}
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			record, err := csvReader.Read()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to read CSV row %d: %w", lineNum+1, err)}
-				return
-			}
-			lineNum++
-
-			if isAllEmpty(record) {
-				continue
-			}
-
-			if incrementalKey != "" && startTime != nil {
-				incValue, ok := lastNonEmptyValue(record, incIdx)
-				if !ok {
-					output.Warnf("[CSV] Row %d: skipping row with empty incremental key '%s'\n", lineNum, incrementalKey)
-					continue
-				}
-				incTime, err := dateparse.ParseAny(incValue)
-				if err != nil {
-					output.Warnf("[CSV] Row %d: skipping row with unparseable incremental key value '%s'\n", lineNum, incValue)
-					continue
-				}
-				if incTime.Before(*startTime) {
-					continue
-				}
-			}
-
-			builder.appendRow(record)
-			if opts.MaxBatchBytes > 0 {
-				accBytes += arrowconv.CellsBytes(record)
-			}
-
-			if builder.rows >= batchSize || (opts.MaxBatchBytes > 0 && accBytes >= opts.MaxBatchBytes) {
-				if !flush() {
-					return
-				}
-				accBytes = 0
-			}
-		}
-
-		if builder.rows > 0 {
-			if !flush() {
-				return
-			}
-		}
-
 		config.Debug("[CSV] Total: %d rows in %d batches, read time: %v", totalRows, batchNum, time.Since(startTotal))
 	}()
 
 	return results, nil
+}
+
+// Read decodes a CSV stream with the same batching and schema behavior as CSVSource.
+func Read(ctx context.Context, reader io.Reader, opts source.ReadOptions, results chan<- source.RecordBatchResult) (int, int, error) {
+	csvReader := csv.NewReader(reader)
+	csvReader.FieldsPerRecord = -1
+	csvReader.ReuseRecord = true
+
+	headers, err := csvReader.Read()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read CSV headers: %w", err)
+	}
+
+	if len(headers) == 0 {
+		return 0, 0, fmt.Errorf("failed to extract headers from the CSV, are you sure the given file contains a header row?")
+	}
+	headers = append([]string(nil), headers...)
+
+	incrementalKey := opts.IncrementalKey
+	if incrementalKey != "" && !containsHeader(headers, incrementalKey) {
+		return 0, 0, fmt.Errorf("incremental_key '%s' not found in the CSV file", incrementalKey)
+	}
+
+	var startTime *time.Time
+	if opts.IntervalStart != nil {
+		t := *opts.IntervalStart
+		startTime = &t
+	}
+
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+	builder := newBatchBuilder(headers, opts.ExcludeColumns, opts.Schema)
+	defer builder.rb.Release()
+	incIdx := headerIndexes(headers, incrementalKey)
+
+	batchNum := 0
+	totalRows := 0
+	lineNum := 1
+	var accBytes int64
+
+	flush := func() bool {
+		rec := builder.finish()
+		batchNum++
+		totalRows += int(rec.NumRows())
+		config.Debug("[CSV] Batch %d: %d rows (total: %d)", batchNum, rec.NumRows(), totalRows)
+
+		select {
+		case results <- source.RecordBatchResult{Batch: rec}:
+			return true
+		case <-ctx.Done():
+			rec.Release()
+			return false
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return totalRows, batchNum, ctx.Err()
+		default:
+		}
+
+		record, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return totalRows, batchNum, fmt.Errorf("failed to read CSV row %d: %w", lineNum+1, err)
+		}
+		lineNum++
+
+		if isAllEmpty(record) {
+			continue
+		}
+
+		if incrementalKey != "" && startTime != nil {
+			incValue, ok := lastNonEmptyValue(record, incIdx)
+			if !ok {
+				output.Warnf("[CSV] Row %d: skipping row with empty incremental key '%s'\n", lineNum, incrementalKey)
+				continue
+			}
+			incTime, err := dateparse.ParseAny(incValue)
+			if err != nil {
+				output.Warnf("[CSV] Row %d: skipping row with unparseable incremental key value '%s'\n", lineNum, incValue)
+				continue
+			}
+			if incTime.Before(*startTime) {
+				continue
+			}
+		}
+
+		builder.appendRow(record)
+		if opts.MaxBatchBytes > 0 {
+			accBytes += arrowconv.CellsBytes(record)
+		}
+
+		if builder.rows >= batchSize || (opts.MaxBatchBytes > 0 && accBytes >= opts.MaxBatchBytes) {
+			if !flush() {
+				return totalRows, batchNum, ctx.Err()
+			}
+			accBytes = 0
+		}
+	}
+
+	if builder.rows > 0 && !flush() {
+		return totalRows, batchNum, ctx.Err()
+	}
+	return totalRows, batchNum, nil
 }
 
 // batchBuilder builds record batches directly from CSV records, bypassing

--- a/pkg/source/http/http.go
+++ b/pkg/source/http/http.go
@@ -1,28 +1,29 @@
 package http
 
 import (
-	"bufio"
-	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"io"
+	stdhttp "net/http"
+	"net/url"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
-	"github.com/apache/arrow-go/v18/arrow/array"
-	"github.com/apache/arrow-go/v18/arrow/memory"
-	"github.com/apache/arrow-go/v18/parquet/file"
-	"github.com/apache/arrow-go/v18/parquet/pqarrow"
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/arrowconv"
-	httpclient "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
+	csvsource "github.com/bruin-data/ingestr/pkg/source/csv"
+	jsonlsource "github.com/bruin-data/ingestr/pkg/source/jsonl"
+	parquetsource "github.com/bruin-data/ingestr/pkg/source/parquet"
 )
 
 const defaultBatchSize = 10000
@@ -39,8 +40,11 @@ const (
 )
 
 type HTTPSource struct {
-	url    string
-	client *httpclient.Client
+	target   *url.URL
+	options  requestOptions
+	client   *stdhttp.Client
+	metadata Metadata
+	mu       sync.RWMutex
 }
 
 func NewHTTPSource() *HTTPSource {
@@ -56,21 +60,38 @@ func (s *HTTPSource) Connect(ctx context.Context, uri string) error {
 		return fmt.Errorf("HTTP source URI cannot be empty")
 	}
 
-	s.url = uri
-	s.client = httpclient.New(
-		httpclient.WithTimeout(120*time.Second),
-		httpclient.WithDebug(config.DebugMode),
-	)
+	target, options, err := parseSourceURI(uri)
+	if err != nil {
+		return err
+	}
+	s.target = target
+	s.options = options
+	s.client = newHTTPClient(options.headers)
 
-	config.Debug("[HTTP] Connected to URL: %s", s.url)
+	config.Debug("[HTTP] Connected to URL: %s", displayURL(s.target))
 	return nil
 }
 
 func (s *HTTPSource) Close(ctx context.Context) error {
 	if s.client != nil {
-		return s.client.Close()
+		if transport, ok := s.client.Transport.(*stdhttp.Transport); ok {
+			transport.CloseIdleConnections()
+		}
 	}
 	return nil
+}
+
+// Metadata returns response metadata from the most recently started read.
+func (s *HTTPSource) Metadata() Metadata {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.metadata
+}
+
+func (s *HTTPSource) setMetadata(metadata Metadata) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.metadata = metadata
 }
 
 func (s *HTTPSource) HandlesIncrementality() bool {
@@ -100,14 +121,7 @@ func (s *HTTPSource) GetTable(ctx context.Context, req source.TableRequest) (sou
 
 func (s *HTTPSource) read(ctx context.Context, table string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	startTotal := time.Now()
-	config.Debug("[HTTP] Starting read from URL: %s", s.url)
-
-	format := detectFormat(s.url, table)
-	if format == formatUnknown {
-		return nil, fmt.Errorf("cannot detect file format from URL or table name; use #csv, #csv_headless, #json, #jsonl, or #parquet suffix on --source-table")
-	}
-
-	config.Debug("[HTTP] Detected format: %s", format)
+	config.Debug("[HTTP] Starting read from URL: %s", displayURL(s.target))
 
 	batchSize := opts.PageSize
 	if batchSize <= 0 {
@@ -119,38 +133,78 @@ func (s *HTTPSource) read(ctx context.Context, table string, opts source.ReadOpt
 	go func() {
 		defer close(results)
 
-		resp, err := s.client.R(ctx).Get(s.url)
+		stream, err := s.openStream(ctx)
 		if err != nil {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to fetch URL: %w", err)}
+			sendError(ctx, results, fmt.Errorf("failed to fetch HTTP source: %w", err))
 			return
 		}
+		defer func() { _ = stream.Close() }()
 
-		if !resp.IsSuccess() {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode(), resp.String())}
+		metadata := s.Metadata()
+		format, encoding := detectFormat(metadata.FinalURL, table, metadata.ContentType)
+		if format == formatUnknown {
+			sendError(ctx, results, fmt.Errorf("cannot detect file format from URL, Content-Type, or table name; use #csv, #csv_headless, #json, #jsonl, or #parquet on --source-table"))
 			return
 		}
+		config.Debug("[HTTP] Detected format: %s", format)
 
-		data := resp.Body()
-		config.Debug("[HTTP] Downloaded %d bytes", len(data))
+		var reader io.Reader = stream
+		contentEncoding := strings.ToLower(strings.TrimSpace(stream.encoding))
+		if contentEncoding != "" && contentEncoding != "identity" && contentEncoding != "gzip" && contentEncoding != "x-gzip" {
+			sendError(ctx, results, fmt.Errorf("unsupported HTTP Content-Encoding %q", stream.encoding))
+			return
+		}
+		if isGzipped(metadata.FinalURL) || contentEncoding == "gzip" || contentEncoding == "x-gzip" {
+			gzReader, err := gzip.NewReader(stream)
+			if err != nil {
+				sendError(ctx, results, fmt.Errorf("failed to open gzip stream: %w", err))
+				return
+			}
+			defer func() { _ = gzReader.Close() }()
+			reader = gzReader
+		}
 
 		var totalRows int64
 		var batchNum int
 
 		switch format {
 		case formatCSV:
-			err = readCSV(ctx, bytes.NewReader(data), results, &totalRows, &batchNum, batchSize, opts, true)
+			decoded, decodeErr := csvsource.Decode(reader, encoding)
+			if decodeErr != nil {
+				err = fmt.Errorf("failed to set up CSV decoder: %w", decodeErr)
+				break
+			}
+			rows, batches, readErr := csvsource.Read(ctx, decoded, opts, results)
+			totalRows += int64(rows)
+			batchNum += batches
+			err = readErr
 		case formatCSVHeadless:
-			err = readCSV(ctx, bytes.NewReader(data), results, &totalRows, &batchNum, batchSize, opts, false)
+			decoded, decodeErr := csvsource.Decode(reader, encoding)
+			if decodeErr != nil {
+				err = fmt.Errorf("failed to set up CSV decoder: %w", decodeErr)
+				break
+			}
+			err = readCSV(ctx, decoded, results, &totalRows, &batchNum, batchSize, opts, false)
 		case formatJSON:
-			err = readJSON(ctx, data, results, &totalRows, &batchNum, batchSize, opts)
+			err = readJSON(ctx, reader, results, &totalRows, &batchNum, batchSize, opts)
 		case formatJSONL:
-			err = readJSONL(ctx, bytes.NewReader(data), results, &totalRows, &batchNum, batchSize, opts)
+			rows, batches, readErr := jsonlsource.Read(ctx, reader, opts, results)
+			totalRows += int64(rows)
+			batchNum += batches
+			err = readErr
 		case formatParquet:
-			err = readParquet(ctx, data, results, &totalRows, &batchNum, opts)
+			err = readParquetStream(ctx, reader, results, &totalRows, &batchNum, opts)
 		}
 
 		if err != nil {
-			results <- source.RecordBatchResult{Err: err}
+			sendError(ctx, results, err)
+			return
+		}
+		if len(s.options.checksum) > 0 {
+			if _, err := io.Copy(io.Discard, reader); err != nil {
+				sendError(ctx, results, fmt.Errorf("failed to validate HTTP source: %w", err))
+				return
+			}
 		}
 
 		config.Debug("[HTTP] Total: %d rows in %d batches, read time: %v", totalRows, batchNum, time.Since(startTotal))
@@ -159,41 +213,70 @@ func (s *HTTPSource) read(ctx context.Context, table string, opts source.ReadOpt
 	return results, nil
 }
 
-func detectFormat(url, table string) fileFormat {
+func detectFormat(sourceURL, table, contentType string) (fileFormat, string) {
+	encoding := ""
+	hintedFormat := formatUnknown
 	if idx := strings.Index(table, "#"); idx != -1 {
-		hint := strings.ToLower(table[idx+1:])
-		switch hint {
-		case "csv":
-			return formatCSV
-		case "csv_headless":
-			return formatCSVHeadless
-		case "json":
-			return formatJSON
-		case "jsonl", "ndjson":
-			return formatJSONL
-		case "parquet":
-			return formatParquet
+		for _, rawHint := range strings.Split(table[idx+1:], ",") {
+			hint := strings.TrimSpace(strings.ToLower(rawHint))
+			if strings.HasPrefix(hint, "encoding=") {
+				encoding = strings.TrimSpace(rawHint[len("encoding="):])
+				continue
+			}
+			switch hint {
+			case "csv":
+				hintedFormat = formatCSV
+			case "csv_headless":
+				hintedFormat = formatCSVHeadless
+			case "json":
+				hintedFormat = formatJSON
+			case "jsonl", "ndjson":
+				hintedFormat = formatJSONL
+			case "parquet":
+				hintedFormat = formatParquet
+			}
 		}
 	}
+	if hintedFormat != formatUnknown {
+		return hintedFormat, encoding
+	}
 
-	lower := strings.ToLower(url)
+	lower := strings.ToLower(sourceURL)
 	qIdx := strings.Index(lower, "?")
 	if qIdx != -1 {
 		lower = lower[:qIdx]
 	}
+	lower = strings.TrimSuffix(lower, ".gz")
 
 	switch {
 	case strings.HasSuffix(lower, ".csv"):
-		return formatCSV
+		return formatCSV, encoding
 	case strings.HasSuffix(lower, ".json"):
-		return formatJSON
+		return formatJSON, encoding
 	case strings.HasSuffix(lower, ".jsonl") || strings.HasSuffix(lower, ".ndjson"):
-		return formatJSONL
+		return formatJSONL, encoding
 	case strings.HasSuffix(lower, ".parquet"):
-		return formatParquet
-	default:
-		return formatUnknown
+		return formatParquet, encoding
 	}
+
+	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	switch mediaType {
+	case "text/csv", "application/csv":
+		return formatCSV, encoding
+	case "application/json":
+		return formatJSON, encoding
+	case "application/jsonl", "application/x-jsonlines", "application/x-ndjson", "application/ndjson":
+		return formatJSONL, encoding
+	case "application/vnd.apache.parquet", "application/x-parquet":
+		return formatParquet, encoding
+	default:
+		return formatUnknown, encoding
+	}
+}
+
+func isGzipped(sourceURL string) bool {
+	parsed, err := url.Parse(sourceURL)
+	return err == nil && strings.HasSuffix(strings.ToLower(parsed.Path), ".gz")
 }
 
 func cleanTableName(table string) string {
@@ -203,7 +286,7 @@ func cleanTableName(table string) string {
 	return table
 }
 
-func readCSV(_ context.Context, reader io.Reader, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions, hasHeader bool) error {
+func readCSV(ctx context.Context, reader io.Reader, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions, hasHeader bool) error {
 	csvReader := csv.NewReader(reader)
 	csvReader.FieldsPerRecord = -1
 
@@ -242,7 +325,9 @@ func readCSV(_ context.Context, reader io.Reader, results chan<- source.RecordBa
 		*totalRows += int64(len(rows))
 		config.Debug("[HTTP] CSV batch %d: %d rows (total: %d)", *batchNum, len(rows), *totalRows)
 
-		results <- source.RecordBatchResult{Batch: rec}
+		if !sendBatch(ctx, results, rec) {
+			return ctx.Err()
+		}
 		rows = make([]map[string]interface{}, 0, batchSize)
 		accBytes = 0
 		return nil
@@ -355,8 +440,8 @@ func overrideEntryReadName(pair string) string {
 	return strings.TrimSpace(parts[0])
 }
 
-func readJSON(_ context.Context, data []byte, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
+func readJSON(ctx context.Context, reader io.Reader, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions) error {
+	decoder := json.NewDecoder(reader)
 	decoder.UseNumber()
 
 	token, err := decoder.Token()
@@ -366,15 +451,15 @@ func readJSON(_ context.Context, data []byte, results chan<- source.RecordBatchR
 
 	switch token {
 	case json.Delim('['):
-		return readJSONArray(decoder, results, totalRows, batchNum, batchSize, opts)
+		return readJSONArray(ctx, decoder, results, totalRows, batchNum, batchSize, opts)
 	case json.Delim('{'):
-		return readJSONObject(data, results, totalRows, batchNum, opts)
+		return readJSONObject(ctx, decoder, results, totalRows, batchNum, opts)
 	default:
 		return fmt.Errorf("unexpected JSON token: %v; expected array or object", token)
 	}
 }
 
-func readJSONArray(decoder *json.Decoder, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions) error {
+func readJSONArray(ctx context.Context, decoder *json.Decoder, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions) error {
 	items := make([]map[string]interface{}, 0, batchSize)
 	var accBytes int64
 
@@ -391,7 +476,9 @@ func readJSONArray(decoder *json.Decoder, results chan<- source.RecordBatchResul
 		*totalRows += int64(len(items))
 		config.Debug("[HTTP] JSON batch %d: %d items (total: %d)", *batchNum, len(items), *totalRows)
 
-		results <- source.RecordBatchResult{Batch: rec}
+		if !sendBatch(ctx, results, rec) {
+			return ctx.Err()
+		}
 		items = make([]map[string]interface{}, 0, batchSize)
 		accBytes = 0
 		return nil
@@ -428,13 +515,21 @@ func readJSONArray(decoder *json.Decoder, results chan<- source.RecordBatchResul
 	return nil
 }
 
-func readJSONObject(data []byte, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, opts source.ReadOptions) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-
-	var item map[string]interface{}
-	if err := decoder.Decode(&item); err != nil {
-		return fmt.Errorf("failed to decode JSON object: %w", err)
+func readJSONObject(ctx context.Context, decoder *json.Decoder, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, opts source.ReadOptions) error {
+	item := make(map[string]interface{})
+	for decoder.More() {
+		key, err := decoder.Token()
+		if err != nil {
+			return fmt.Errorf("failed to decode JSON object key: %w", err)
+		}
+		var value interface{}
+		if err := decoder.Decode(&value); err != nil {
+			return fmt.Errorf("failed to decode JSON object value: %w", err)
+		}
+		item[key.(string)] = value
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fmt.Errorf("failed to finish JSON object: %w", err)
 	}
 
 	rec, err := arrowconv.ItemsToArrowRecordWithSchema([]map[string]interface{}{item}, nil, opts.ExcludeColumns)
@@ -446,152 +541,54 @@ func readJSONObject(data []byte, results chan<- source.RecordBatchResult, totalR
 	*totalRows++
 	config.Debug("[HTTP] JSON batch %d: 1 item (total: %d)", *batchNum, *totalRows)
 
-	results <- source.RecordBatchResult{Batch: rec}
+	if !sendBatch(ctx, results, rec) {
+		return ctx.Err()
+	}
 	return nil
 }
 
-func readJSONL(_ context.Context, reader io.Reader, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, batchSize int, opts source.ReadOptions) error {
-	scanner := bufio.NewScanner(reader)
-	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+func readParquetStream(ctx context.Context, reader io.Reader, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, opts source.ReadOptions) error {
+	temp, err := os.CreateTemp("", "ingestr-http-*.parquet")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary Parquet file: %w", err)
+	}
+	path := temp.Name()
+	defer func() { _ = os.Remove(path) }()
 
-	items := make([]map[string]interface{}, 0, batchSize)
-	var accBytes int64
-	lineNum := 0
-
-	flush := func() error {
-		if len(items) == 0 {
-			return nil
-		}
-		rec, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
-		if err != nil {
-			return fmt.Errorf("failed to convert JSONL to Arrow: %w", err)
-		}
-
-		*batchNum++
-		*totalRows += int64(len(items))
-		config.Debug("[HTTP] JSONL batch %d: %d items (total: %d)", *batchNum, len(items), *totalRows)
-
-		results <- source.RecordBatchResult{Batch: rec}
-		items = make([]map[string]interface{}, 0, batchSize)
-		accBytes = 0
-		return nil
+	if _, err := io.Copy(temp, reader); err != nil {
+		_ = temp.Close()
+		return fmt.Errorf("failed to stream Parquet source to disk: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary Parquet file: %w", err)
 	}
 
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		lineNum++
-
-		if line == "" {
-			continue
-		}
-
-		var item map[string]interface{}
-		decoder := json.NewDecoder(strings.NewReader(line))
-		decoder.UseNumber()
-		if err := decoder.Decode(&item); err != nil {
-			return fmt.Errorf("failed to parse JSON at line %d: %w", lineNum, err)
-		}
-
-		if opts.MaxBatchBytes > 0 {
-			rowBytes := arrowconv.RowBytes(item)
-			if len(items) > 0 && accBytes+rowBytes > opts.MaxBatchBytes {
-				if err := flush(); err != nil {
-					return err
-				}
-			}
-			accBytes += rowBytes
-		}
-		items = append(items, item)
-
-		if len(items) >= batchSize {
-			if err := flush(); err != nil {
-				return err
-			}
-		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("error reading JSONL data: %w", err)
-	}
-
-	if err := flush(); err != nil {
-		return err
-	}
-
-	return nil
+	rows, batches, err := parquetsource.ReadFile(ctx, path, opts, results)
+	*totalRows += rows
+	*batchNum += batches
+	return err
 }
 
-func readParquet(ctx context.Context, data []byte, results chan<- source.RecordBatchResult, totalRows *int64, batchNum *int, opts source.ReadOptions) error {
-	reader := bytes.NewReader(data)
-	pr, err := file.NewParquetReader(reader)
-	if err != nil {
-		return fmt.Errorf("failed to open parquet reader: %w", err)
+func sendBatch(ctx context.Context, results chan<- source.RecordBatchResult, batch arrow.RecordBatch) bool {
+	select {
+	case results <- source.RecordBatchResult{Batch: batch}:
+		return true
+	case <-ctx.Done():
+		batch.Release()
+		return false
 	}
-
-	fr, err := pqarrow.NewFileReader(pr, pqarrow.ArrowReadProperties{}, memory.DefaultAllocator)
-	if err != nil {
-		return fmt.Errorf("failed to create parquet arrow reader: %w", err)
-	}
-
-	tbl, err := fr.ReadTable(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to read parquet table: %w", err)
-	}
-	defer tbl.Release()
-
-	chunkSize := int64(opts.PageSize)
-	if chunkSize <= 0 {
-		chunkSize = int64(defaultBatchSize)
-	}
-
-	tr := array.NewTableReader(tbl, chunkSize)
-	defer tr.Release()
-
-	excludeSet := make(map[string]struct{}, len(opts.ExcludeColumns))
-	for _, col := range opts.ExcludeColumns {
-		excludeSet[strings.ToLower(col)] = struct{}{}
-	}
-
-	for tr.Next() {
-		rec := tr.RecordBatch()
-
-		if len(excludeSet) > 0 {
-			rec = excludeArrowColumns(rec, excludeSet)
-		} else {
-			rec.Retain()
-		}
-
-		*batchNum++
-		rows := rec.NumRows()
-		*totalRows += rows
-		config.Debug("[HTTP] Parquet batch %d: %d rows (total: %d)", *batchNum, rows, *totalRows)
-
-		results <- source.RecordBatchResult{Batch: rec}
-	}
-
-	return tr.Err()
 }
 
-func excludeArrowColumns(rec arrow.RecordBatch, exclude map[string]struct{}) arrow.RecordBatch {
-	s := rec.Schema()
-	keptCols := make([]arrow.Array, 0, s.NumFields())
-	keptFields := make([]arrow.Field, 0, s.NumFields())
-
-	for i := range int(s.NumFields()) {
-		field := s.Field(i)
-		if _, skip := exclude[strings.ToLower(field.Name)]; skip {
-			continue
-		}
-		keptCols = append(keptCols, rec.Column(i))
-		keptFields = append(keptFields, field)
+func sendError(ctx context.Context, results chan<- source.RecordBatchResult, err error) {
+	select {
+	case results <- source.RecordBatchResult{Err: err}:
+		return
+	default:
 	}
-
-	if len(keptCols) == int(s.NumFields()) {
-		rec.Retain()
-		return rec
+	select {
+	case results <- source.RecordBatchResult{Err: err}:
+	case <-ctx.Done():
 	}
-
-	return array.NewRecordBatch(arrow.NewSchema(keptFields, nil), keptCols, rec.NumRows())
 }
 
 func parseColumnNames(columns string, numCols int) []string {

--- a/pkg/source/http/http.go
+++ b/pkg/source/http/http.go
@@ -218,9 +218,10 @@ func detectFormat(sourceURL, table, contentType string) (fileFormat, string) {
 	hintedFormat := formatUnknown
 	if idx := strings.Index(table, "#"); idx != -1 {
 		for _, rawHint := range strings.Split(table[idx+1:], ",") {
-			hint := strings.TrimSpace(strings.ToLower(rawHint))
+			trimmed := strings.TrimSpace(rawHint)
+			hint := strings.ToLower(trimmed)
 			if strings.HasPrefix(hint, "encoding=") {
-				encoding = strings.TrimSpace(rawHint[len("encoding="):])
+				encoding = strings.TrimSpace(trimmed[len("encoding="):])
 				continue
 			}
 			switch hint {

--- a/pkg/source/http/http.go
+++ b/pkg/source/http/http.go
@@ -141,7 +141,7 @@ func (s *HTTPSource) read(ctx context.Context, table string, opts source.ReadOpt
 		defer func() { _ = stream.Close() }()
 
 		metadata := s.Metadata()
-		format, encoding := detectFormat(metadata.FinalURL, table, metadata.ContentType)
+		format, encoding, gzipped := detectFormat(metadata.FinalURL, table, metadata.ContentType)
 		if format == formatUnknown {
 			sendError(ctx, results, fmt.Errorf("cannot detect file format from URL, Content-Type, or table name; use #csv, #csv_headless, #json, #jsonl, or #parquet on --source-table"))
 			return
@@ -154,7 +154,7 @@ func (s *HTTPSource) read(ctx context.Context, table string, opts source.ReadOpt
 			sendError(ctx, results, fmt.Errorf("unsupported HTTP Content-Encoding %q", stream.encoding))
 			return
 		}
-		if isGzipped(metadata.FinalURL) || contentEncoding == "gzip" || contentEncoding == "x-gzip" {
+		if gzipped || contentEncoding == "gzip" || contentEncoding == "x-gzip" {
 			gzReader, err := gzip.NewReader(stream)
 			if err != nil {
 				sendError(ctx, results, fmt.Errorf("failed to open gzip stream: %w", err))
@@ -213,7 +213,14 @@ func (s *HTTPSource) read(ctx context.Context, table string, opts source.ReadOpt
 	return results, nil
 }
 
-func detectFormat(sourceURL, table, contentType string) (fileFormat, string) {
+func detectFormat(sourceURL, table, contentType string) (fileFormat, string, bool) {
+	path := strings.ToLower(sourceURL)
+	if parsed, err := url.Parse(sourceURL); err == nil {
+		path = strings.ToLower(parsed.Path)
+	}
+	gzipped := strings.HasSuffix(path, ".gz")
+	base := strings.TrimSuffix(path, ".gz")
+
 	encoding := ""
 	hintedFormat := formatUnknown
 	if idx := strings.Index(table, "#"); idx != -1 {
@@ -239,45 +246,33 @@ func detectFormat(sourceURL, table, contentType string) (fileFormat, string) {
 		}
 	}
 	if hintedFormat != formatUnknown {
-		return hintedFormat, encoding
+		return hintedFormat, encoding, gzipped
 	}
-
-	lower := strings.ToLower(sourceURL)
-	qIdx := strings.Index(lower, "?")
-	if qIdx != -1 {
-		lower = lower[:qIdx]
-	}
-	lower = strings.TrimSuffix(lower, ".gz")
 
 	switch {
-	case strings.HasSuffix(lower, ".csv"):
-		return formatCSV, encoding
-	case strings.HasSuffix(lower, ".json"):
-		return formatJSON, encoding
-	case strings.HasSuffix(lower, ".jsonl") || strings.HasSuffix(lower, ".ndjson"):
-		return formatJSONL, encoding
-	case strings.HasSuffix(lower, ".parquet"):
-		return formatParquet, encoding
+	case strings.HasSuffix(base, ".csv"):
+		return formatCSV, encoding, gzipped
+	case strings.HasSuffix(base, ".json"):
+		return formatJSON, encoding, gzipped
+	case strings.HasSuffix(base, ".jsonl") || strings.HasSuffix(base, ".ndjson"):
+		return formatJSONL, encoding, gzipped
+	case strings.HasSuffix(base, ".parquet"):
+		return formatParquet, encoding, gzipped
 	}
 
 	mediaType := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
 	switch mediaType {
 	case "text/csv", "application/csv":
-		return formatCSV, encoding
+		return formatCSV, encoding, gzipped
 	case "application/json":
-		return formatJSON, encoding
+		return formatJSON, encoding, gzipped
 	case "application/jsonl", "application/x-jsonlines", "application/x-ndjson", "application/ndjson":
-		return formatJSONL, encoding
+		return formatJSONL, encoding, gzipped
 	case "application/vnd.apache.parquet", "application/x-parquet":
-		return formatParquet, encoding
+		return formatParquet, encoding, gzipped
 	default:
-		return formatUnknown, encoding
+		return formatUnknown, encoding, gzipped
 	}
-}
-
-func isGzipped(sourceURL string) bool {
-	parsed, err := url.Parse(sourceURL)
-	return err == nil && strings.HasSuffix(strings.ToLower(parsed.Path), ".gz")
 }
 
 func cleanTableName(table string) string {

--- a/pkg/source/http/http.go
+++ b/pkg/source/http/http.go
@@ -66,7 +66,7 @@ func (s *HTTPSource) Connect(ctx context.Context, uri string) error {
 	}
 	s.target = target
 	s.options = options
-	s.client = newHTTPClient(options.headers)
+	s.client = newHTTPClient(options.headers, options.readTimeout)
 
 	config.Debug("[HTTP] Connected to URL: %s", displayURL(s.target))
 	return nil

--- a/pkg/source/http/http_test.go
+++ b/pkg/source/http/http_test.go
@@ -1,14 +1,22 @@
 package http
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
-	httpclient "github.com/bruin-data/ingestr/pkg/http"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,7 +46,7 @@ func TestDetectFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := detectFormat(tt.url, tt.table)
+			result, _ := detectFormat(tt.url, tt.table, "")
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -150,7 +158,10 @@ func TestHTTPByteCap(t *testing.T) {
 	defer srv.Close()
 
 	run := func(max int64) (int64, int64) {
-		s := &HTTPSource{url: srv.URL, client: httpclient.New()}
+		s := NewHTTPSource()
+		if err := s.Connect(context.Background(), srv.URL); err != nil {
+			t.Fatal(err)
+		}
 		results, err := s.read(context.Background(), "data#json", source.ReadOptions{MaxBatchBytes: max})
 		if err != nil {
 			t.Fatal(err)
@@ -182,4 +193,294 @@ func TestHTTPByteCap(t *testing.T) {
 	if offR != onR || offR != 50 {
 		t.Fatalf("row mismatch off=%d on=%d want 50", offR, onR)
 	}
+}
+
+func TestHTTPSourceStreamsBeforeResponseCompletes(t *testing.T) {
+	firstWritten := make(chan struct{})
+	finish := make(chan struct{})
+	defer func() {
+		select {
+		case <-finish:
+		default:
+			close(finish)
+		}
+	}()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = io.WriteString(w, "id,name\n1,first\n")
+		w.(http.Flusher).Flush()
+		close(firstWritten)
+		<-finish
+		_, _ = io.WriteString(w, "2,second\n")
+	}))
+	defer srv.Close()
+
+	s := connectedSource(t, srv.URL)
+	results, err := s.read(context.Background(), "data", source.ReadOptions{PageSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-firstWritten
+
+	select {
+	case result := <-results:
+		if result.Err != nil {
+			t.Fatal(result.Err)
+		}
+		assert.EqualValues(t, 1, result.Batch.NumRows())
+		result.Batch.Release()
+	case <-time.After(2 * time.Second):
+		t.Fatal("first record batch was not emitted while the response remained open")
+	}
+
+	close(finish)
+	rows, err := collectRows(results)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, rows)
+}
+
+func TestHTTPSourceAuthHeadersRedirectAndMetadata(t *testing.T) {
+	const (
+		token  = "top-secret-token"
+		apiKey = "top-secret-key"
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/start", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/download", http.StatusFound)
+	})
+	mux.HandleFunc("/download", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+token || r.Header.Get("X-API-Key") != apiKey {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.Header().Set("ETag", `"version-1"`)
+		w.Header().Set("Last-Modified", "Wed, 21 Oct 2015 07:28:00 GMT")
+		_, _ = io.WriteString(w, "{\"id\":1}\n")
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	uri := srv.URL + "/start#ingestr:bearer_token=" + url.QueryEscape(token) + "&header.X-API-Key=" + url.QueryEscape(apiKey)
+	s := connectedSource(t, uri)
+	rows, err := readRows(t, s, "data", source.ReadOptions{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, rows)
+
+	metadata := s.Metadata()
+	assert.Equal(t, srv.URL+"/download", metadata.FinalURL)
+	assert.Equal(t, `"version-1"`, metadata.ETag)
+	assert.Equal(t, "Wed, 21 Oct 2015 07:28:00 GMT", metadata.LastModified)
+	assert.Equal(t, "application/x-ndjson", metadata.ContentType)
+	assert.Greater(t, metadata.ContentLength, int64(0))
+	assert.NotContains(t, displayURL(s.target), token)
+	assert.NotContains(t, displayURL(s.target), apiKey)
+}
+
+func TestHTTPSourceStripsConfiguredHeadersOnCrossOriginRedirect(t *testing.T) {
+	var gotAuthorization, gotSecret string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		gotSecret = r.Header.Get("X-Secret")
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = io.WriteString(w, "id\n1\n")
+	}))
+	defer target.Close()
+
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/data.csv", http.StatusFound)
+	}))
+	defer redirect.Close()
+
+	s := connectedSource(t, redirect.URL+"#ingestr:bearer_token=secret&header.X-Secret=secret")
+	_, err := readRows(t, s, "data", source.ReadOptions{})
+	assert.NoError(t, err)
+	assert.Empty(t, gotAuthorization)
+	assert.Empty(t, gotSecret)
+}
+
+func TestHTTPSourceResumesInterruptedResponse(t *testing.T) {
+	data := []byte("id,name\n1,alpha\n2,beta\n3,gamma\n")
+	const cut = 17
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := requests.Add(1)
+		w.Header().Set("ETag", `"stable"`)
+		w.Header().Set("Content-Type", "text/csv")
+		if request == 1 {
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data[:cut])
+			return
+		}
+
+		assert.Equal(t, fmt.Sprintf("bytes=%d-", cut), r.Header.Get("Range"))
+		assert.Equal(t, `"stable"`, r.Header.Get("If-Range"))
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", cut, len(data)-1, len(data)))
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)-cut))
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(data[cut:])
+	}))
+	defer srv.Close()
+
+	s := connectedSource(t, srv.URL+"/data.csv#ingestr:retries=0")
+	rows, err := readRows(t, s, "data", source.ReadOptions{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, rows)
+	assert.EqualValues(t, 2, requests.Load())
+}
+
+func TestHTTPSourceDoesNotFakeResumeWithoutValidator(t *testing.T) {
+	data := []byte("id\n1\n2\n")
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data[:5])
+	}))
+	defer srv.Close()
+
+	s := connectedSource(t, srv.URL+"/data.csv#ingestr:retries=0")
+	_, err := readRows(t, s, "data", source.ReadOptions{})
+	assert.ErrorContains(t, err, "expected")
+	assert.EqualValues(t, 1, requests.Load())
+}
+
+func TestHTTPSourceConditionalRequest(t *testing.T) {
+	const etag = `"current"`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, etag, r.Header.Get("If-None-Match"))
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer srv.Close()
+
+	s := connectedSource(t, srv.URL+"/data.csv#ingestr:if_none_match="+url.QueryEscape(etag)+"&retries=0")
+	_, err := readRows(t, s, "data", source.ReadOptions{})
+	assert.ErrorIs(t, err, ErrNotModified)
+}
+
+func TestHTTPSourceChecksum(t *testing.T) {
+	data := []byte("id\n1\n")
+	digest := sha256.Sum256(data)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	t.Run("valid", func(t *testing.T) {
+		s := connectedSource(t, fmt.Sprintf("%s/data#ingestr:checksum=sha256:%x&retries=0", srv.URL, digest))
+		rows, err := readRows(t, s, "data", source.ReadOptions{})
+		assert.NoError(t, err)
+		assert.EqualValues(t, 1, rows)
+	})
+
+	t.Run("mismatch", func(t *testing.T) {
+		s := connectedSource(t, srv.URL+"/data#ingestr:checksum=sha256:"+strings.Repeat("0", 64)+"&retries=0")
+		_, err := readRows(t, s, "data", source.ReadOptions{})
+		assert.ErrorContains(t, err, "checksum mismatch")
+	})
+}
+
+func TestHTTPSourceRetryCancellation(t *testing.T) {
+	requestReceived := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived <- struct{}{}
+		w.Header().Set("Retry-After", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s := connectedSource(t, srv.URL+"/data.csv#ingestr:retries=3")
+	results, err := s.read(ctx, "data", source.ReadOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-requestReceived
+	cancel()
+	_, err = collectRows(results)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestHTTPSourceRetriesTransientStatus(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = io.WriteString(w, "id\n1\n")
+	}))
+	defer srv.Close()
+
+	s := connectedSource(t, srv.URL+"/data.csv#ingestr:retries=1")
+	rows, err := readRows(t, s, "data", source.ReadOptions{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, rows)
+	assert.EqualValues(t, 2, requests.Load())
+}
+
+func TestHTTPSourceStreamsGzip(t *testing.T) {
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	_, _ = io.WriteString(writer, "id\n1\n2\n")
+	assert.NoError(t, writer.Close())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	defer srv.Close()
+
+	s := connectedSource(t, srv.URL+"/data.csv.gz#ingestr:retries=0")
+	rows, err := readRows(t, s, "data", source.ReadOptions{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 2, rows)
+}
+
+func TestParseSourceURIAuthentication(t *testing.T) {
+	target, opts, err := parseSourceURI("https://user:password@example.com/data.csv?signature=keep#ingestr:header.X-Value=a%26b%23c&retries=0")
+	assert.NoError(t, err)
+	assert.Nil(t, target.User)
+	assert.Equal(t, "signature=keep", target.RawQuery)
+	assert.Equal(t, basicAuth("user", "password"), opts.headers.Get("Authorization"))
+	assert.Equal(t, "a&b#c", opts.headers.Get("X-Value"))
+	assert.Equal(t, 0, opts.retries)
+}
+
+func connectedSource(t *testing.T, uri string) *HTTPSource {
+	t.Helper()
+	s := NewHTTPSource()
+	if err := s.Connect(context.Background(), uri); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close(context.Background()) })
+	return s
+}
+
+func readRows(t *testing.T, s *HTTPSource, table string, opts source.ReadOptions) (int64, error) {
+	t.Helper()
+	results, err := s.read(context.Background(), table, opts)
+	if err != nil {
+		return 0, err
+	}
+	return collectRows(results)
+}
+
+func collectRows(results <-chan source.RecordBatchResult) (int64, error) {
+	var rows int64
+	for result := range results {
+		if result.Err != nil {
+			return rows, result.Err
+		}
+		if result.Batch != nil {
+			rows += result.Batch.NumRows()
+			result.Batch.Release()
+		}
+	}
+	return rows, nil
 }

--- a/pkg/source/http/http_test.go
+++ b/pkg/source/http/http_test.go
@@ -52,6 +52,30 @@ func TestDetectFormat(t *testing.T) {
 	}
 }
 
+func TestDetectFormatEncoding(t *testing.T) {
+	tests := []struct {
+		name             string
+		table            string
+		expectedFormat   fileFormat
+		expectedEncoding string
+	}{
+		{"encoding only", "my_data#encoding=windows-1252", formatUnknown, "windows-1252"},
+		{"format then encoding", "my_data#csv,encoding=windows-1252", formatCSV, "windows-1252"},
+		{"encoding then format", "my_data#encoding=windows-1252,csv", formatCSV, "windows-1252"},
+		{"space after comma", "my_data#csv, encoding=windows-1252", formatCSV, "windows-1252"},
+		{"space before format", "my_data#encoding=windows-1252, csv", formatCSV, "windows-1252"},
+		{"mixed-case encoding value preserved", "my_data#csv,encoding=Windows-1252", formatCSV, "Windows-1252"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, encoding := detectFormat("https://example.com/data", tt.table, "")
+			assert.Equal(t, tt.expectedFormat, format)
+			assert.Equal(t, tt.expectedEncoding, encoding)
+		})
+	}
+}
+
 func TestCleanTableName(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/source/http/http_test.go
+++ b/pkg/source/http/http_test.go
@@ -46,7 +46,7 @@ func TestDetectFormat(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, _ := detectFormat(tt.url, tt.table, "")
+			result, _, _ := detectFormat(tt.url, tt.table, "")
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -69,9 +69,32 @@ func TestDetectFormatEncoding(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			format, encoding := detectFormat("https://example.com/data", tt.table, "")
+			format, encoding, _ := detectFormat("https://example.com/data", tt.table, "")
 			assert.Equal(t, tt.expectedFormat, format)
 			assert.Equal(t, tt.expectedEncoding, encoding)
+		})
+	}
+}
+
+func TestDetectFormatGzip(t *testing.T) {
+	tests := []struct {
+		name           string
+		url            string
+		table          string
+		expectedFormat fileFormat
+		expectedGzip   bool
+	}{
+		{"plain csv", "https://example.com/data.csv", "my_data", formatCSV, false},
+		{"gzipped csv by extension", "https://example.com/data.csv.gz", "my_data", formatCSV, true},
+		{"gzipped csv with query", "https://example.com/data.csv.gz?token=abc", "my_data", formatCSV, true},
+		{"gzipped with format hint", "https://example.com/data.gz", "my_data#csv", formatCSV, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, _, gzipped := detectFormat(tt.url, tt.table, "")
+			assert.Equal(t, tt.expectedFormat, format)
+			assert.Equal(t, tt.expectedGzip, gzipped)
 		})
 	}
 }

--- a/pkg/source/http/http_test.go
+++ b/pkg/source/http/http_test.go
@@ -528,6 +528,37 @@ func TestHTTPSourceRetriesTransientStatus(t *testing.T) {
 	assert.EqualValues(t, 2, requests.Load())
 }
 
+func TestHTTPSourceReadTimeout(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Length", "1000000")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		_, _ = io.WriteString(w, "id\n1\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+		<-release
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	done := make(chan error, 1)
+	go func() {
+		s := connectedSource(t, srv.URL+"/data.csv#ingestr:retries=0&read_timeout=200ms")
+		_, err := readRows(t, s, "data", source.ReadOptions{})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("read hung despite read_timeout")
+	}
+}
+
 func TestHTTPSourceStreamsGzip(t *testing.T) {
 	var compressed bytes.Buffer
 	writer := gzip.NewWriter(&compressed)

--- a/pkg/source/http/http_test.go
+++ b/pkg/source/http/http_test.go
@@ -523,6 +523,34 @@ func TestHTTPSourceStreamsGzip(t *testing.T) {
 	assert.EqualValues(t, 2, rows)
 }
 
+func TestHTTPSourceUserAgent(t *testing.T) {
+	tests := []struct {
+		name     string
+		suffix   string
+		expected string
+	}{
+		{"default user-agent", "", "ingestr/1.0 (https://github.com/bruin-data/ingestr)"},
+		{"custom user-agent", "&header.User-Agent=my-agent", "my-agent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotUA atomic.Value
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotUA.Store(r.Header.Get("User-Agent"))
+				w.Header().Set("Content-Type", "text/csv")
+				_, _ = io.WriteString(w, "id\n1\n")
+			}))
+			defer srv.Close()
+
+			s := connectedSource(t, srv.URL+"/data.csv#ingestr:retries=0"+tt.suffix)
+			_, err := readRows(t, s, "data", source.ReadOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, gotUA.Load())
+		})
+	}
+}
+
 func TestParseSourceURIAuthentication(t *testing.T) {
 	target, opts, err := parseSourceURI("https://user:password@example.com/data.csv?signature=keep#ingestr:header.X-Value=a%26b%23c&retries=0")
 	assert.NoError(t, err)

--- a/pkg/source/http/http_test.go
+++ b/pkg/source/http/http_test.go
@@ -330,6 +330,63 @@ func TestHTTPSourceResumesInterruptedResponse(t *testing.T) {
 	assert.EqualValues(t, 2, requests.Load())
 }
 
+func TestHTTPSourceRejectsChangedOrMissingResumeValidator(t *testing.T) {
+	data := []byte("id,name\n1,alpha\n2,beta\n")
+	const cut = 14
+	tests := []struct {
+		name          string
+		initialHeader http.Header
+		resumeHeader  http.Header
+		errorContains string
+	}{
+		{
+			name:          "missing ETag",
+			initialHeader: http.Header{"ETag": {`"stable"`}},
+			resumeHeader:  http.Header{},
+			errorContains: "ETag was missing or changed",
+		},
+		{
+			name:          "changed Last-Modified",
+			initialHeader: http.Header{"Last-Modified": {"Wed, 21 Oct 2015 07:28:00 GMT"}},
+			resumeHeader:  http.Header{"Last-Modified": {"Thu, 22 Oct 2015 07:28:00 GMT"}},
+			errorContains: "Last-Modified was missing or changed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requests atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				request := requests.Add(1)
+				w.Header().Set("Content-Type", "text/csv")
+				if request == 1 {
+					for name, values := range tt.initialHeader {
+						w.Header()[name] = values
+					}
+					w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write(data[:cut])
+					return
+				}
+
+				for name, values := range tt.resumeHeader {
+					w.Header()[name] = values
+				}
+				w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", cut, len(data)-1, len(data)))
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)-cut))
+				w.WriteHeader(http.StatusPartialContent)
+				_, _ = w.Write(data[cut:])
+			}))
+			defer srv.Close()
+
+			s := connectedSource(t, srv.URL+"/data.csv#ingestr:retries=0")
+			_, err := readRows(t, s, "data", source.ReadOptions{})
+			assert.ErrorContains(t, err, tt.errorContains)
+			assert.EqualValues(t, 2, requests.Load())
+		})
+	}
+}
+
 func TestHTTPSourceDoesNotFakeResumeWithoutValidator(t *testing.T) {
 	data := []byte("id\n1\n2\n")
 	var requests atomic.Int32

--- a/pkg/source/http/transport.go
+++ b/pkg/source/http/transport.go
@@ -172,7 +172,7 @@ type idleConn struct {
 }
 
 func (c *idleConn) Read(b []byte) (int, error) {
-	if err := c.Conn.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+	if err := c.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
 		return 0, err
 	}
 	return c.Conn.Read(b)

--- a/pkg/source/http/transport.go
+++ b/pkg/source/http/transport.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"net"
 	stdhttp "net/http"
 	"net/textproto"
 	"net/url"
@@ -20,8 +21,9 @@ import (
 )
 
 const (
-	defaultRetries = 3
-	maxErrorBody   = 4096
+	defaultRetries     = 3
+	maxErrorBody       = 4096
+	defaultReadTimeout = 2 * time.Minute
 )
 
 // ErrNotModified reports a 304 response to a caller-supplied conditional request.
@@ -42,6 +44,7 @@ type requestOptions struct {
 	ifNoneMatch     string
 	ifModifiedSince string
 	checksum        []byte
+	readTimeout     time.Duration
 }
 
 func parseSourceURI(raw string) (*url.URL, requestOptions, error) {
@@ -50,7 +53,7 @@ func parseSourceURI(raw string) (*url.URL, requestOptions, error) {
 		return nil, requestOptions{}, fmt.Errorf("invalid HTTP source URI")
 	}
 
-	opts := requestOptions{headers: make(stdhttp.Header), retries: defaultRetries}
+	opts := requestOptions{headers: make(stdhttp.Header), retries: defaultRetries, readTimeout: defaultReadTimeout}
 	if parsed.User != nil {
 		password, _ := parsed.User.Password()
 		opts.headers.Set("Authorization", basicAuth(parsed.User.Username(), password))
@@ -113,6 +116,13 @@ func parseSourceURI(raw string) (*url.URL, requestOptions, error) {
 		}
 		opts.retries = retries
 	}
+	if raw := values.Get("read_timeout"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil || d < 0 {
+			return nil, requestOptions{}, fmt.Errorf("HTTP source read_timeout must be a non-negative duration (e.g. 120s); 0 disables it")
+		}
+		opts.readTimeout = d
+	}
 	if checksum := values.Get("checksum"); checksum != "" {
 		algorithm, encoded, ok := strings.Cut(checksum, ":")
 		if !ok || !strings.EqualFold(algorithm, "sha256") {
@@ -127,6 +137,7 @@ func parseSourceURI(raw string) (*url.URL, requestOptions, error) {
 	known := map[string]bool{
 		"basic_user": true, "basic_password": true, "bearer_token": true,
 		"if_none_match": true, "if_modified_since": true, "retries": true, "checksum": true,
+		"read_timeout": true,
 	}
 	for key := range values {
 		if !known[key] && !strings.HasPrefix(strings.ToLower(key), "header.") {
@@ -152,9 +163,34 @@ func isManagedHeader(name string) bool {
 	}
 }
 
-func newHTTPClient(headers stdhttp.Header) *stdhttp.Client {
+// idleConn resets a read deadline before every Read so a stalled body (headers
+// received, then no bytes) fails instead of hanging, without capping the total
+// duration of a slow but progressing stream.
+type idleConn struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func (c *idleConn) Read(b []byte) (int, error) {
+	if err := c.Conn.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+		return 0, err
+	}
+	return c.Conn.Read(b)
+}
+
+func newHTTPClient(headers stdhttp.Header, readTimeout time.Duration) *stdhttp.Client {
 	transport := stdhttp.DefaultTransport.(*stdhttp.Transport).Clone()
 	transport.ResponseHeaderTimeout = 2 * time.Minute
+	if readTimeout > 0 {
+		dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return &idleConn{Conn: conn, timeout: readTimeout}, nil
+		}
+	}
 	return &stdhttp.Client{
 		Transport: transport,
 		CheckRedirect: func(req *stdhttp.Request, via []*stdhttp.Request) error {

--- a/pkg/source/http/transport.go
+++ b/pkg/source/http/transport.go
@@ -1,0 +1,449 @@
+package http
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	stdhttp "net/http"
+	"net/textproto"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+)
+
+const (
+	defaultRetries = 3
+	maxErrorBody   = 4096
+)
+
+// ErrNotModified reports a 304 response to a caller-supplied conditional request.
+var ErrNotModified = errors.New("HTTP source was not modified")
+
+// Metadata describes the HTTP representation selected after redirects.
+type Metadata struct {
+	FinalURL      string
+	ETag          string
+	LastModified  string
+	ContentLength int64
+	ContentType   string
+}
+
+type requestOptions struct {
+	headers         stdhttp.Header
+	retries         int
+	ifNoneMatch     string
+	ifModifiedSince string
+	checksum        []byte
+}
+
+func parseSourceURI(raw string) (*url.URL, requestOptions, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, requestOptions{}, fmt.Errorf("invalid HTTP source URI")
+	}
+
+	opts := requestOptions{headers: make(stdhttp.Header), retries: defaultRetries}
+	if parsed.User != nil {
+		password, _ := parsed.User.Password()
+		opts.headers.Set("Authorization", basicAuth(parsed.User.Username(), password))
+		parsed.User = nil
+	}
+
+	fragment := parsed.EscapedFragment()
+	parsed.Fragment = ""
+	parsed.RawFragment = ""
+	if fragment == "" {
+		return parsed, opts, nil
+	}
+	if !strings.HasPrefix(fragment, "ingestr:") {
+		return nil, requestOptions{}, fmt.Errorf("HTTP source URI fragment must start with ingestr:")
+	}
+
+	values, err := url.ParseQuery(strings.TrimPrefix(fragment, "ingestr:"))
+	if err != nil {
+		return nil, requestOptions{}, fmt.Errorf("invalid HTTP source options")
+	}
+
+	basicUser := values.Get("basic_user")
+	basicPassword := values.Get("basic_password")
+	bearerToken := values.Get("bearer_token")
+	if bearerToken != "" && (basicUser != "" || basicPassword != "" || opts.headers.Get("Authorization") != "") {
+		return nil, requestOptions{}, fmt.Errorf("bearer_token and basic authentication cannot be combined")
+	}
+	if basicUser != "" || basicPassword != "" {
+		if opts.headers.Get("Authorization") != "" {
+			return nil, requestOptions{}, fmt.Errorf("basic authentication cannot be configured in both userinfo and source options")
+		}
+		opts.headers.Set("Authorization", basicAuth(basicUser, basicPassword))
+	}
+	if bearerToken != "" {
+		opts.headers.Set("Authorization", "Bearer "+bearerToken)
+	}
+
+	for key, entries := range values {
+		if !strings.HasPrefix(strings.ToLower(key), "header.") {
+			continue
+		}
+		name := textproto.CanonicalMIMEHeaderKey(key[len("header."):])
+		if name == "" || isManagedHeader(name) {
+			return nil, requestOptions{}, fmt.Errorf("HTTP header %q cannot be configured", name)
+		}
+		if name == "Authorization" && opts.headers.Get(name) != "" {
+			return nil, requestOptions{}, fmt.Errorf("Authorization cannot be configured more than once")
+		}
+		for _, value := range entries {
+			opts.headers.Add(name, value)
+		}
+	}
+
+	opts.ifNoneMatch = values.Get("if_none_match")
+	opts.ifModifiedSince = values.Get("if_modified_since")
+	if rawRetries := values.Get("retries"); rawRetries != "" {
+		retries, err := strconv.Atoi(rawRetries)
+		if err != nil || retries < 0 || retries > 10 {
+			return nil, requestOptions{}, fmt.Errorf("HTTP source retries must be between 0 and 10")
+		}
+		opts.retries = retries
+	}
+	if checksum := values.Get("checksum"); checksum != "" {
+		algorithm, encoded, ok := strings.Cut(checksum, ":")
+		if !ok || !strings.EqualFold(algorithm, "sha256") {
+			return nil, requestOptions{}, fmt.Errorf("HTTP source checksum must use sha256:<hex>")
+		}
+		opts.checksum, err = hex.DecodeString(encoded)
+		if err != nil || len(opts.checksum) != sha256.Size {
+			return nil, requestOptions{}, fmt.Errorf("HTTP source checksum must be a 64-character SHA-256 hex digest")
+		}
+	}
+
+	known := map[string]bool{
+		"basic_user": true, "basic_password": true, "bearer_token": true,
+		"if_none_match": true, "if_modified_since": true, "retries": true, "checksum": true,
+	}
+	for key := range values {
+		if !known[key] && !strings.HasPrefix(strings.ToLower(key), "header.") {
+			return nil, requestOptions{}, fmt.Errorf("unknown HTTP source option %q", key)
+		}
+	}
+
+	return parsed, opts, nil
+}
+
+func basicAuth(username, password string) string {
+	req, _ := stdhttp.NewRequest(stdhttp.MethodGet, "http://localhost", nil)
+	req.SetBasicAuth(username, password)
+	return req.Header.Get("Authorization")
+}
+
+func isManagedHeader(name string) bool {
+	switch strings.ToLower(name) {
+	case "host", "content-length", "transfer-encoding", "connection", "range", "if-range", "accept-encoding":
+		return true
+	default:
+		return false
+	}
+}
+
+func newHTTPClient(headers stdhttp.Header) *stdhttp.Client {
+	transport := stdhttp.DefaultTransport.(*stdhttp.Transport).Clone()
+	transport.ResponseHeaderTimeout = 2 * time.Minute
+	return &stdhttp.Client{
+		Transport: transport,
+		CheckRedirect: func(req *stdhttp.Request, via []*stdhttp.Request) error {
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			if len(via) > 0 && !sameOrigin(via[0].URL, req.URL) {
+				for name := range headers {
+					req.Header.Del(name)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func sameOrigin(a, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) && strings.EqualFold(a.Host, b.Host)
+}
+
+func displayURL(u *url.URL) string {
+	if u == nil {
+		return "HTTP source"
+	}
+	copyURL := *u
+	copyURL.User = nil
+	if copyURL.RawQuery != "" {
+		copyURL.RawQuery = "redacted"
+	}
+	copyURL.Fragment = ""
+	return copyURL.String()
+}
+
+type responseStream struct {
+	source   *HTTPSource
+	ctx      context.Context
+	body     io.ReadCloser
+	encoding string
+	offset   int64
+	total    int64
+	etag     string
+	modified string
+	hash     hash.Hash
+	expected []byte
+}
+
+func (s *HTTPSource) openStream(ctx context.Context) (*responseStream, error) {
+	resp, err := s.doRequest(ctx, 0, "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	total := resp.ContentLength
+	metadata := Metadata{
+		FinalURL:      resp.Request.URL.String(),
+		ETag:          resp.Header.Get("ETag"),
+		LastModified:  resp.Header.Get("Last-Modified"),
+		ContentLength: total,
+		ContentType:   resp.Header.Get("Content-Type"),
+	}
+	s.setMetadata(metadata)
+	config.Debug("[HTTP] Response from %s: content_type=%q, content_length=%d, etag=%q, last_modified=%q",
+		displayURL(resp.Request.URL), metadata.ContentType, metadata.ContentLength, metadata.ETag, metadata.LastModified)
+
+	stream := &responseStream{
+		source: s, ctx: ctx, body: resp.Body, total: total,
+		encoding: resp.Header.Get("Content-Encoding"), etag: metadata.ETag,
+		modified: metadata.LastModified, expected: s.options.checksum,
+	}
+	if len(stream.expected) > 0 {
+		stream.hash = sha256.New()
+	}
+	return stream, nil
+}
+
+func (s *HTTPSource) doRequest(ctx context.Context, offset int64, etag, modified string) (*stdhttp.Response, error) {
+	var lastErr error
+	retryAfterWaited := false
+	for attempt := 0; attempt <= s.options.retries; attempt++ {
+		if attempt > 0 && !retryAfterWaited {
+			wait := time.Second << min(attempt-1, 4)
+			config.Debug("[HTTP] Retrying %s in %s (attempt %d/%d)", displayURL(s.target), wait, attempt+1, s.options.retries+1)
+			if err := sleepContext(ctx, wait); err != nil {
+				return nil, err
+			}
+		}
+		retryAfterWaited = false
+
+		req, err := stdhttp.NewRequestWithContext(ctx, stdhttp.MethodGet, s.target.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP request")
+		}
+		req.Header = s.options.headers.Clone()
+		req.Header.Set("Accept-Encoding", "identity")
+		req.Header.Set("User-Agent", "ingestr/1.0 (https://github.com/bruin-data/ingestr)")
+		if offset > 0 {
+			req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+			if strongETag(etag) {
+				req.Header.Set("If-Range", etag)
+			} else if modified != "" {
+				req.Header.Set("If-Range", modified)
+			}
+		} else {
+			if s.options.ifNoneMatch != "" {
+				req.Header.Set("If-None-Match", s.options.ifNoneMatch)
+			}
+			if s.options.ifModifiedSince != "" {
+				req.Header.Set("If-Modified-Since", s.options.ifModifiedSince)
+			}
+		}
+
+		resp, err := s.client.Do(req)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			lastErr = fmt.Errorf("HTTP request failed")
+			continue
+		}
+		if resp.StatusCode == stdhttp.StatusNotModified && offset == 0 {
+			_ = resp.Body.Close()
+			return nil, ErrNotModified
+		}
+		if retryableStatus(resp.StatusCode) && attempt < s.options.retries {
+			wait := retryAfter(resp.Header.Get("Retry-After"))
+			_, _ = io.CopyN(io.Discard, resp.Body, maxErrorBody)
+			_ = resp.Body.Close()
+			if wait > 0 {
+				if err := sleepContext(ctx, wait); err != nil {
+					return nil, err
+				}
+				retryAfterWaited = true
+			}
+			lastErr = fmt.Errorf("HTTP request returned status %d", resp.StatusCode)
+			continue
+		}
+		if offset == 0 && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return resp, nil
+		}
+		if offset > 0 && resp.StatusCode == stdhttp.StatusPartialContent {
+			start, total, err := parseContentRange(resp.Header.Get("Content-Range"))
+			if err != nil || start != offset {
+				_ = resp.Body.Close()
+				return nil, fmt.Errorf("server returned an invalid Content-Range while resuming at byte %d", offset)
+			}
+			if total >= 0 && resp.ContentLength >= 0 && resp.ContentLength != total-offset {
+				_ = resp.Body.Close()
+				return nil, fmt.Errorf("resumed response Content-Length does not match Content-Range")
+			}
+			return resp, nil
+		}
+
+		_ = resp.Body.Close()
+		if offset > 0 {
+			return nil, fmt.Errorf("server does not support safe resume at byte %d (status %d)", offset, resp.StatusCode)
+		}
+		return nil, fmt.Errorf("HTTP request returned status %d", resp.StatusCode)
+	}
+	return nil, lastErr
+}
+
+func (r *responseStream) Read(p []byte) (int, error) {
+	for {
+		n, err := r.body.Read(p)
+		if n > 0 {
+			r.offset += int64(n)
+			if r.hash != nil {
+				_, _ = r.hash.Write(p[:n])
+			}
+			if err != nil {
+				err = nil
+			}
+			return n, err
+		}
+		if err == nil {
+			continue
+		}
+		if r.ctx.Err() != nil {
+			return 0, r.ctx.Err()
+		}
+		if err == io.EOF && (r.total < 0 || r.offset == r.total) {
+			if verifyErr := r.verify(); verifyErr != nil {
+				return 0, verifyErr
+			}
+			return 0, io.EOF
+		}
+		if !strongETag(r.etag) && !validLastModified(r.modified) {
+			if err == io.EOF && r.total >= 0 {
+				return 0, fmt.Errorf("HTTP response ended after %d bytes, expected %d", r.offset, r.total)
+			}
+			return 0, fmt.Errorf("HTTP response interrupted after %d bytes and cannot be resumed safely: %w", r.offset, err)
+		}
+
+		_ = r.body.Close()
+		resp, resumeErr := r.source.doRequest(r.ctx, r.offset, r.etag, r.modified)
+		if resumeErr != nil {
+			return 0, fmt.Errorf("HTTP response interrupted after %d bytes: %w", r.offset, resumeErr)
+		}
+		if r.etag != "" && resp.Header.Get("ETag") != "" && resp.Header.Get("ETag") != r.etag {
+			_ = resp.Body.Close()
+			return 0, fmt.Errorf("HTTP source ETag changed while resuming")
+		}
+		_, total, _ := parseContentRange(resp.Header.Get("Content-Range"))
+		if r.total >= 0 && total >= 0 && total != r.total {
+			_ = resp.Body.Close()
+			return 0, fmt.Errorf("HTTP source length changed while resuming")
+		}
+		if r.total < 0 {
+			r.total = total
+		}
+		r.body = resp.Body
+		config.Debug("[HTTP] Resumed %s at byte %d", displayURL(resp.Request.URL), r.offset)
+	}
+}
+
+func (r *responseStream) Close() error {
+	return r.body.Close()
+}
+
+func (r *responseStream) verify() error {
+	if len(r.expected) == 0 {
+		return nil
+	}
+	actual := r.hash.Sum(nil)
+	if subtle.ConstantTimeCompare(actual, r.expected) != 1 {
+		return fmt.Errorf("HTTP source SHA-256 checksum mismatch: got %s", hex.EncodeToString(actual))
+	}
+	return nil
+}
+
+func strongETag(etag string) bool {
+	etag = strings.TrimSpace(etag)
+	return len(etag) >= 2 && etag[0] == '"' && etag[len(etag)-1] == '"' && !strings.HasPrefix(etag, "W/")
+}
+
+func validLastModified(value string) bool {
+	_, err := stdhttp.ParseTime(value)
+	return err == nil
+}
+
+func retryableStatus(status int) bool {
+	return status == stdhttp.StatusTooManyRequests || status == stdhttp.StatusRequestTimeout || status >= 500
+}
+
+func retryAfter(value string) time.Duration {
+	if seconds, err := strconv.Atoi(strings.TrimSpace(value)); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if when, err := stdhttp.ParseTime(value); err == nil {
+		if wait := time.Until(when); wait > 0 {
+			return wait
+		}
+	}
+	return 0
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func parseContentRange(value string) (start, total int64, err error) {
+	if !strings.HasPrefix(value, "bytes ") {
+		return 0, -1, fmt.Errorf("invalid Content-Range")
+	}
+	rangePart, totalPart, ok := strings.Cut(strings.TrimPrefix(value, "bytes "), "/")
+	if !ok {
+		return 0, -1, fmt.Errorf("invalid Content-Range")
+	}
+	startPart, _, ok := strings.Cut(rangePart, "-")
+	if !ok {
+		return 0, -1, fmt.Errorf("invalid Content-Range")
+	}
+	start, err = strconv.ParseInt(startPart, 10, 64)
+	if err != nil || start < 0 {
+		return 0, -1, fmt.Errorf("invalid Content-Range")
+	}
+	if totalPart == "*" {
+		return start, -1, nil
+	}
+	total, err = strconv.ParseInt(totalPart, 10, 64)
+	if err != nil || total < start {
+		return 0, -1, fmt.Errorf("invalid Content-Range")
+	}
+	return start, total, nil
+}

--- a/pkg/source/http/transport.go
+++ b/pkg/source/http/transport.go
@@ -249,7 +249,9 @@ func (s *HTTPSource) doRequest(ctx context.Context, offset int64, etag, modified
 		}
 		req.Header = s.options.headers.Clone()
 		req.Header.Set("Accept-Encoding", "identity")
-		req.Header.Set("User-Agent", "ingestr/1.0 (https://github.com/bruin-data/ingestr)")
+		if req.Header.Get("User-Agent") == "" {
+			req.Header.Set("User-Agent", "ingestr/1.0 (https://github.com/bruin-data/ingestr)")
+		}
 		if offset > 0 {
 			req.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
 			if strongETag(etag) {

--- a/pkg/source/http/transport.go
+++ b/pkg/source/http/transport.go
@@ -64,7 +64,7 @@ func parseSourceURI(raw string) (*url.URL, requestOptions, error) {
 		return parsed, opts, nil
 	}
 	if !strings.HasPrefix(fragment, "ingestr:") {
-		return nil, requestOptions{}, fmt.Errorf("HTTP source URI fragment must start with ingestr:")
+		return nil, requestOptions{}, fmt.Errorf("HTTP source URI fragment must use the ingestr: prefix")
 	}
 
 	values, err := url.ParseQuery(strings.TrimPrefix(fragment, "ingestr:"))
@@ -97,7 +97,7 @@ func parseSourceURI(raw string) (*url.URL, requestOptions, error) {
 			return nil, requestOptions{}, fmt.Errorf("HTTP header %q cannot be configured", name)
 		}
 		if name == "Authorization" && opts.headers.Get(name) != "" {
-			return nil, requestOptions{}, fmt.Errorf("Authorization cannot be configured more than once")
+			return nil, requestOptions{}, fmt.Errorf("authorization cannot be configured more than once")
 		}
 		for _, value := range entries {
 			opts.headers.Add(name, value)
@@ -353,9 +353,13 @@ func (r *responseStream) Read(p []byte) (int, error) {
 		if resumeErr != nil {
 			return 0, fmt.Errorf("HTTP response interrupted after %d bytes: %w", r.offset, resumeErr)
 		}
-		if r.etag != "" && resp.Header.Get("ETag") != "" && resp.Header.Get("ETag") != r.etag {
+		if strongETag(r.etag) && resp.Header.Get("ETag") != r.etag {
 			_ = resp.Body.Close()
-			return 0, fmt.Errorf("HTTP source ETag changed while resuming")
+			return 0, fmt.Errorf("HTTP source ETag was missing or changed while resuming")
+		}
+		if !strongETag(r.etag) && resp.Header.Get("Last-Modified") != r.modified {
+			_ = resp.Body.Close()
+			return 0, fmt.Errorf("HTTP source Last-Modified was missing or changed while resuming")
 		}
 		_, total, _ := parseContentRange(resp.Header.Get("Content-Range"))
 		if r.total >= 0 && total >= 0 && total != r.total {

--- a/pkg/source/jsonl/jsonl.go
+++ b/pkg/source/jsonl/jsonl.go
@@ -161,7 +161,15 @@ func Read(ctx context.Context, reader io.Reader, opts source.ReadOptions, result
 		}
 
 		var item map[string]interface{}
-		if err := json.Unmarshal([]byte(line), &item); err != nil {
+		decoder := json.NewDecoder(strings.NewReader(line))
+		decoder.UseNumber()
+		if err := decoder.Decode(&item); err != nil {
+			return totalRows, batchNum, fmt.Errorf("failed to parse JSON at line %d: %w", lineNum, err)
+		}
+		if err := decoder.Decode(&struct{}{}); err != io.EOF {
+			if err == nil {
+				err = fmt.Errorf("multiple JSON values")
+			}
 			return totalRows, batchNum, fmt.Errorf("failed to parse JSON at line %d: %w", lineNum, err)
 		}
 

--- a/pkg/source/jsonl/jsonl.go
+++ b/pkg/source/jsonl/jsonl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -90,11 +91,6 @@ func (s *JSONLSource) read(ctx context.Context, opts source.ReadOptions) (<-chan
 	startTotal := time.Now()
 	config.Debug("[JSONL] Starting read from file: %s", s.filePath)
 
-	batchSize := opts.PageSize
-	if batchSize <= 0 {
-		batchSize = 10000
-	}
-
 	results := make(chan source.RecordBatchResult, 8)
 
 	go func() {
@@ -106,88 +102,105 @@ func (s *JSONLSource) read(ctx context.Context, opts source.ReadOptions) (<-chan
 			return
 		}
 		defer func() { _ = file.Close() }()
-
-		scanner := bufio.NewScanner(file)
-		scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
-
-		batchNum := 0
-		totalRows := 0
-		items := make([]map[string]interface{}, 0, batchSize)
-		var accBytes int64
-		lineNum := 0
-
-		flush := func() error {
-			if len(items) == 0 {
-				return nil
-			}
-			record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
-			if err != nil {
-				return fmt.Errorf("failed to convert to Arrow: %w", err)
-			}
-
-			batchNum++
-			totalRows += len(items)
-			config.Debug("[JSONL] Batch %d: %d items (total: %d)", batchNum, len(items), totalRows)
-
-			results <- source.RecordBatchResult{Batch: record}
-			items = make([]map[string]interface{}, 0, batchSize)
-			accBytes = 0
-			return nil
-		}
-
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-			lineNum++
-
-			if line == "" {
-				continue
-			}
-
-			var item map[string]interface{}
-			if err := json.Unmarshal([]byte(line), &item); err != nil {
-				results <- source.RecordBatchResult{Err: fmt.Errorf("failed to parse JSON at line %d: %w", lineNum, err)}
-				return
-			}
-
-			if opts.MaxBatchBytes > 0 {
-				rowBytes := arrowconv.RowBytes(item)
-				if len(items) > 0 && accBytes+rowBytes > opts.MaxBatchBytes {
-					if err := flush(); err != nil {
-						results <- source.RecordBatchResult{Err: err}
-						return
-					}
-				}
-				accBytes += rowBytes
-			}
-			items = append(items, item)
-
-			if len(items) >= batchSize {
-				if err := flush(); err != nil {
-					results <- source.RecordBatchResult{Err: err}
-					return
-				}
-			}
-
-			if opts.Limit > 0 && totalRows+len(items) >= opts.Limit {
-				items = items[:opts.Limit-totalRows]
-				break
-			}
-		}
-
-		if err := scanner.Err(); err != nil {
-			results <- source.RecordBatchResult{Err: fmt.Errorf("error reading JSONL file: %w", err)}
-			return
-		}
-
-		if err := flush(); err != nil {
+		totalRows, batchNum, err := Read(ctx, file, opts, results)
+		if err != nil && ctx.Err() == nil {
 			results <- source.RecordBatchResult{Err: err}
 			return
 		}
-
 		config.Debug("[JSONL] Total: %d items in %d batches, read time: %v", totalRows, batchNum, time.Since(startTotal))
 	}()
 
 	return results, nil
+}
+
+// Read decodes a JSONL stream with the same batching behavior as JSONLSource.
+func Read(ctx context.Context, reader io.Reader, opts source.ReadOptions, results chan<- source.RecordBatchResult) (int, int, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 1024*1024), 10*1024*1024)
+
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = 10000
+	}
+	batchNum := 0
+	totalRows := 0
+	items := make([]map[string]interface{}, 0, batchSize)
+	var accBytes int64
+	lineNum := 0
+
+	flush := func() error {
+		if len(items) == 0 {
+			return nil
+		}
+		record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+		if err != nil {
+			return fmt.Errorf("failed to convert to Arrow: %w", err)
+		}
+
+		batchNum++
+		totalRows += len(items)
+		config.Debug("[JSONL] Batch %d: %d items (total: %d)", batchNum, len(items), totalRows)
+
+		select {
+		case results <- source.RecordBatchResult{Batch: record}:
+		case <-ctx.Done():
+			record.Release()
+			return ctx.Err()
+		}
+		items = make([]map[string]interface{}, 0, batchSize)
+		accBytes = 0
+		return nil
+	}
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		lineNum++
+
+		if line == "" {
+			continue
+		}
+
+		var item map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &item); err != nil {
+			return totalRows, batchNum, fmt.Errorf("failed to parse JSON at line %d: %w", lineNum, err)
+		}
+
+		if opts.MaxBatchBytes > 0 {
+			rowBytes := arrowconv.RowBytes(item)
+			if len(items) > 0 && accBytes+rowBytes > opts.MaxBatchBytes {
+				if err := flush(); err != nil {
+					return totalRows, batchNum, err
+				}
+			}
+			accBytes += rowBytes
+		}
+		items = append(items, item)
+
+		if len(items) >= batchSize {
+			if err := flush(); err != nil {
+				return totalRows, batchNum, err
+			}
+		}
+
+		if opts.Limit > 0 && totalRows+len(items) >= opts.Limit {
+			items = items[:opts.Limit-totalRows]
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return totalRows, batchNum, ctx.Err()
+		default:
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return totalRows, batchNum, fmt.Errorf("error reading JSONL file: %w", err)
+	}
+
+	if err := flush(); err != nil {
+		return totalRows, batchNum, err
+	}
+	return totalRows, batchNum, nil
 }
 
 var _ source.Source = (*JSONLSource)(nil)

--- a/pkg/source/jsonl/jsonl_test.go
+++ b/pkg/source/jsonl/jsonl_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/require"
 )
@@ -80,4 +82,29 @@ func TestJSONLByteCap(t *testing.T) {
 	batchesOn, rowsOn := drainJSONL(t, resOn)
 	require.Greater(t, batchesOn, 1, "small cap must split into more than one batch")
 	require.Equal(t, int64(recordCount), rowsOn, "byte cap must not drop rows")
+}
+
+func TestReadPreservesLargeIntegers(t *testing.T) {
+	results := make(chan source.RecordBatchResult, 1)
+	rows, batches, err := Read(
+		context.Background(),
+		strings.NewReader("{\"id\":9007199254740993}\n"),
+		source.ReadOptions{},
+		results,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, rows)
+	require.Equal(t, 1, batches)
+
+	result := <-results
+	require.NoError(t, result.Err)
+	require.NotNil(t, result.Batch)
+	defer result.Batch.Release()
+
+	column := result.Batch.Column(0)
+	unknown, ok := column.(*schema.UnknownArray)
+	require.True(t, ok, "expected unknown column, got %T (%s)", column, column.DataType())
+	storage, ok := unknown.Storage().(*array.String)
+	require.True(t, ok)
+	require.Equal(t, "9007199254740993", storage.Value(0))
 }

--- a/pkg/source/parquet/parquet.go
+++ b/pkg/source/parquet/parquet.go
@@ -264,6 +264,25 @@ func readFile(
 	return false, nil
 }
 
+// ReadFile streams one local Parquet file through the same decoder used by
+// ParquetSource. Callers that transport remote files can spool them to disk and
+// reuse this reader without buffering the file in memory.
+func ReadFile(ctx context.Context, filePath string, opts source.ReadOptions, results chan<- source.RecordBatchResult) (int64, int, error) {
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = defaultBatchSize
+	}
+	limit := int64(opts.Limit)
+	if limit < 0 {
+		limit = 0
+	}
+
+	var totalRows int64
+	var batchNum int
+	_, err := readFile(ctx, filePath, buildExcludeSet(opts.ExcludeColumns), int64(batchSize), limit, &totalRows, &batchNum, results)
+	return totalRows, batchNum, err
+}
+
 func readParquetSchema(filePath string) (*arrow.Schema, error) {
 	f, err := os.Open(filePath)
 	if err != nil {

--- a/tests/integration/http_source_test.go
+++ b/tests/integration/http_source_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPSourcePipelineFileFormatsAndAuthentication(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	parquetPath := filepath.Join(t.TempDir(), "users.parquet")
+	writeSeedParquet(t, parquetPath, 2)
+	parquetBody, err := os.ReadFile(parquetPath)
+	require.NoError(t, err)
+
+	type endpoint struct {
+		contentType string
+		body        []byte
+		authorized  func(*http.Request) bool
+	}
+
+	endpoints := map[string]endpoint{
+		"/public/users.csv": {
+			contentType: "text/csv",
+			body:        []byte("id,name\n1,user_1\n2,user_2\n"),
+			authorized: func(r *http.Request) bool {
+				return r.Header.Get("Authorization") == ""
+			},
+		},
+		"/api/json": {
+			contentType: "application/octet-stream",
+			body:        []byte(`[{"id":1,"name":"user_1"},{"id":2,"name":"user_2"}]`),
+			authorized: func(r *http.Request) bool {
+				return r.Header.Get("X-API-Key") == "json-secret"
+			},
+		},
+		"/api/jsonl": {
+			contentType: "application/x-ndjson",
+			body:        []byte("{\"id\":1,\"name\":\"user_1\"}\n{\"id\":2,\"name\":\"user_2\"}\n"),
+			authorized: func(r *http.Request) bool {
+				return r.Header.Get("Authorization") == "Bearer jsonl-token"
+			},
+		},
+		"/private/users.parquet": {
+			contentType: "application/vnd.apache.parquet",
+			body:        parquetBody,
+			authorized: func(r *http.Request) bool {
+				username, password, ok := r.BasicAuth()
+				return ok && username == "parquet-user" && password == "parquet-password"
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		endpoint, ok := endpoints[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		if !endpoint.authorized(r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", endpoint.contentType)
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(endpoint.body)))
+		_, _ = w.Write(endpoint.body)
+	}))
+	t.Cleanup(server.Close)
+
+	tests := []struct {
+		name        string
+		sourceURI   string
+		sourceTable string
+	}{
+		{
+			name:        "CSV without authentication selected by URL extension",
+			sourceURI:   server.URL + "/public/users.csv",
+			sourceTable: "users",
+		},
+		{
+			name:        "JSON with API key header and explicit format hint",
+			sourceURI:   server.URL + "/api/json#ingestr:header.X-API-Key=json-secret",
+			sourceTable: "users#json",
+		},
+		{
+			name:        "JSONL with bearer authentication selected by content type",
+			sourceURI:   server.URL + "/api/jsonl#ingestr:bearer_token=jsonl-token",
+			sourceTable: "users",
+		},
+		{
+			name:        "Parquet with basic authentication selected by URL extension",
+			sourceURI:   server.URL + "/private/users.parquet#ingestr:basic_user=parquet-user&basic_password=parquet-password",
+			sourceTable: "users",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			duckDBPath := filepath.Join(t.TempDir(), "out.duckdb")
+			cfg := &config.IngestConfig{
+				SourceURI:           tt.sourceURI,
+				SourceTable:         tt.sourceTable,
+				DestURI:             fmt.Sprintf("duckdb:///%s", duckDBPath),
+				DestTable:           "main.users",
+				IncrementalStrategy: config.StrategyReplace,
+			}
+
+			require.NoError(t, cfg.Validate())
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			assert.Equal(t, 2, readDuckDBRowCount(t, duckDBPath, "main.users"))
+
+			db := openDuckDBForTest(t, duckDBPath)
+			defer func() { _ = db.Close() }()
+
+			rows, err := db.QueryContext(ctx, "SELECT id, name FROM main.users ORDER BY id")
+			require.NoError(t, err)
+			defer func() { _ = rows.Close() }()
+
+			var actual []string
+			for rows.Next() {
+				var id int64
+				var name string
+				require.NoError(t, rows.Scan(&id, &name))
+				actual = append(actual, fmt.Sprintf("%d:%s", id, name))
+			}
+			require.NoError(t, rows.Err())
+			assert.Equal(t, []string{"1:user_1", "2:user_2"}, actual)
+		})
+	}
+}

--- a/tests/integration/http_source_test.go
+++ b/tests/integration/http_source_test.go
@@ -50,7 +50,7 @@ func TestHTTPSourcePipelineFileFormatsAndAuthentication(t *testing.T) {
 		},
 		"/api/jsonl": {
 			contentType: "application/x-ndjson",
-			body:        []byte("{\"id\":1,\"name\":\"user_1\"}\n{\"id\":2,\"name\":\"user_2\"}\n"),
+			body:        []byte("{\"id\":1,\"name\":\"user_1\"}\n{\"id\":9007199254740993,\"name\":\"large_id\"}\n"),
 			authorized: func(r *http.Request) bool {
 				return r.Header.Get("Authorization") == "Bearer jsonl-token"
 			},
@@ -86,26 +86,31 @@ func TestHTTPSourcePipelineFileFormatsAndAuthentication(t *testing.T) {
 		name        string
 		sourceURI   string
 		sourceTable string
+		expected    []string
 	}{
 		{
 			name:        "CSV without authentication selected by URL extension",
 			sourceURI:   server.URL + "/public/users.csv",
 			sourceTable: "users",
+			expected:    []string{"1:user_1", "2:user_2"},
 		},
 		{
 			name:        "JSON with API key header and explicit format hint",
 			sourceURI:   server.URL + "/api/json#ingestr:header.X-API-Key=json-secret",
 			sourceTable: "users#json",
+			expected:    []string{"1:user_1", "2:user_2"},
 		},
 		{
 			name:        "JSONL with bearer authentication selected by content type",
 			sourceURI:   server.URL + "/api/jsonl#ingestr:bearer_token=jsonl-token",
 			sourceTable: "users",
+			expected:    []string{"1:user_1", "9007199254740993:large_id"},
 		},
 		{
 			name:        "Parquet with basic authentication selected by URL extension",
 			sourceURI:   server.URL + "/private/users.parquet#ingestr:basic_user=parquet-user&basic_password=parquet-password",
 			sourceTable: "users",
+			expected:    []string{"1:user_1", "2:user_2"},
 		},
 	}
 
@@ -140,7 +145,7 @@ func TestHTTPSourcePipelineFileFormatsAndAuthentication(t *testing.T) {
 				actual = append(actual, fmt.Sprintf("%d:%s", id, name))
 			}
 			require.NoError(t, rows.Err())
-			assert.Equal(t, []string{"1:user_1", "2:user_2"}, actual)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- stream HTTP(S) CSV, JSON, JSONL, gzip, and Parquet files through the existing decoders with bounded heap usage
- add safe static authentication/custom headers, redirect handling, retries, cancellation, conditional requests, checksums, metadata, and validated in-process Range resume
- document the URI contract and add focused transport tests plus full-pipeline `httptest` coverage into DuckDB
- make changed-package lint include integration-tagged tests

Resume is deliberately limited to an interrupted read in the current process and requires a strong ETag or valid Last-Modified validator plus a consistent `206 Content-Range` response. Conditional validators are caller-supplied and are not persisted automatically.

## Verification

- `make format`
- `make lint`
- `TEST_CONCURRENCY=2 make test`
- `go test -count=1 -race ./pkg/source/http ./pkg/source/csv ./pkg/source/jsonl ./pkg/source/parquet`
- `INGESTR_QUIET_PROGRESS=1 INTEGRATION_BACKENDS=none go test -tags integration -count=1 -run '^TestHTTPSourcePipeline' ./tests/integration`

Closes #1138