### PR TITLE
add Sumble source

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,12 @@ Pull requests are welcome. However, please open an issue first to discuss what y
         <td>-</td>
     </tr>
     <tr>
+        <td>Sumble</td>
+        <td>✅</td>
+        <td>-</td>
+        <td>-</td>
+    </tr>
+    <tr>
         <td>SurveyMonkey</td>
         <td>✅</td>
         <td>-</td>

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -277,6 +277,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Solidgate", link: "/supported-sources/solidgate.md" },
               { text: "Square", link: "/supported-sources/square.md" },
               { text: "Stripe", link: "/supported-sources/stripe.md" },
+              { text: "Sumble", link: "/supported-sources/sumble.md" },
               { text: "SurveyMonkey", link: "/supported-sources/surveymonkey.md" },
               { text: "TikTok Ads", link: "/supported-sources/tiktok-ads.md" },
               { text: "Trello", link: "/supported-sources/trello.md" },

--- a/docs/supported-sources/platforms.md
+++ b/docs/supported-sources/platforms.md
@@ -45,6 +45,7 @@ Use this page to browse platforms by category. The sidebar keeps the full alphab
 - [Pipedrive](/supported-sources/pipedrive.md)
 - [Plus Vibe AI](/supported-sources/plusvibeai.md)
 - [Salesforce](/supported-sources/salesforce.md)
+- [Sumble](/supported-sources/sumble.md)
 - [Twenty CRM](/supported-sources/twenty.md)
 - [Zendesk](/supported-sources/zendesk.md)
 

--- a/docs/supported-sources/sumble.md
+++ b/docs/supported-sources/sumble.md
@@ -1,0 +1,77 @@
+# Sumble
+
+[Sumble](https://sumble.com/) provides organization, people, and intent-signal data for go-to-market teams.
+
+ingestr supports Sumble as a source through Sumble's v9 API.
+
+## URI format
+
+```text
+sumble://?api_key=<api-key>
+```
+
+Create an API key from the API keys page in your Sumble account. The key is sent to Sumble as a bearer token.
+
+The following command copies Sumble signals into DuckDB:
+
+```sh
+ingestr ingest \
+  --source-uri 'sumble://?api_key=your-api-key' \
+  --source-table 'signals' \
+  --dest-uri 'duckdb:///sumble.duckdb' \
+  --dest-table 'main.signals'
+```
+
+Sumble charges API credits according to the resource and number of records returned. Check your Sumble plan and credit balance before running large extracts.
+
+## Tables
+
+| Table | Primary key | Incremental key | Strategy | Data |
+| --- | --- | --- | --- | --- |
+| `organization_lists` | `id` | – | replace | Saved organization-list metadata, including deleted lists |
+| `organization_list_organizations` | `_ingestr_id` | – | replace | Organizations in every saved organization list, including deleted lists |
+| `contact_lists` | `id` | – | replace | Saved contact-list metadata |
+| `contact_list_people` | `_ingestr_id` | – | replace | People in every saved contact list, including available contact information. Deleted lists are excluded — the contact-list endpoint has no `include_deleted` option |
+| `signals` | `_ingestr_id` | `date` | merge | Intent signals visible to the authenticated account |
+| `priority_signals` | `id` | `date` | merge | Curated priority signals and relevance feedback |
+| `signal_configs` | `id` | – | replace | Signal configuration definitions visible to the authenticated account |
+
+Nested Sumble objects and arrays are preserved as JSON columns.
+
+## Table parameters
+
+Tables accept optional filters appended to the table name as query parameters. Multiple values are comma-separated, e.g. `signals?organization_ids=12,34`.
+
+| Table | Parameters |
+| --- | --- |
+| `organization_list_organizations` | `list_ids` — restrict to specific lists instead of every list |
+| `contact_list_people` | `list_ids` — restrict to specific lists instead of every list |
+| `signals` | `organization_ids`, `person_ids`, `signal_ids`, `technology_slugs`, `job_functions`, `priorities`, `account_list_ids`, `signal_config_ids` |
+| `priority_signals` | `organization_ids`, `person_ids`, `signal_ids`, `job_post_ids`, `is_relevant` |
+| `signal_configs` | `signal_config_ids`, `types`, `priorities` |
+
+`priorities` accepts `high`, `medium`, or `low`. `is_relevant` accepts `true` or `false`. For `signal_configs`, `signal_config_ids` cannot be combined with `types` or `priorities`.
+
+```sh
+ingestr ingest \
+  --source-uri 'sumble://?api_key=your-api-key' \
+  --source-table 'signals?organization_ids=12,34&priorities=high' \
+  --dest-uri 'duckdb:///sumble.duckdb' \
+  --dest-table 'main.signals'
+```
+
+## Limits
+
+`signals` and `priority_signals` are paged with Sumble's offset pagination, which stops at an offset of 10,000. Extracts larger than that are truncated with a warning — narrow them with the table parameters above. Sumble's `signals` endpoint also only returns signals from the last 60 days unless you look them up directly with `signal_ids`.
+
+## Incremental loading
+
+`signals` and `priority_signals` support interval-based loading on `date`. The Sumble API does not provide a server-side date range for these resources, so ingestr pages through the matching results and applies the interval locally. The interval start is inclusive and the interval end is exclusive.
+
+`signals` is returned newest-first, so paging stops as soon as a page falls entirely before the interval start. This only bounds the old end of the window: an interval far in the past is still reached by paging back from the newest signal, so it costs a full extract in credits and usually hits the offset limit first. `priority_signals` is ordered by completion time rather than by `date`, so a narrow interval always pages through the full result set. Both endpoints charge one credit per record returned, whether or not the record survives the interval filter.
+
+`priority_signals` carries a date-only `date`, so a row is kept whenever any part of its day falls in the interval. Rows whose `date` is missing or unparseable are always kept, which means they are re-fetched on every run.
+
+`signals` rows are keyed on `signal_id`. Sumble leaves that field empty for some signals, and those rows fall back to a hash of the row itself: if such a signal later changes, the merge writes it as a new row rather than updating the existing one.
+
+The remaining tables are replaced in full so removals from lists and changes to configuration are reflected in the destination.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -406,6 +406,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("starrocks", "StarRocks", []string{"starrocks"}, true, true),
 		genericURIConnector("square", "Square", []string{"square"}, true, false),
 		genericURIConnector("stripe", "Stripe", []string{"stripe"}, true, false),
+		genericURIConnector("sumble", "Sumble", []string{"sumble"}, true, false),
 		genericURIConnector("surveymonkey", "SurveyMonkey", []string{"surveymonkey"}, true, false),
 		genericURIConnector("synapse", "Azure Synapse", []string{"synapse"}, false, true),
 		genericURIConnector("tiktok", "TikTok Ads", []string{"tiktok"}, true, false),

--- a/pkg/source/sumble/register.go
+++ b/pkg/source/sumble/register.go
@@ -1,0 +1,10 @@
+package sumble
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"sumble"},
+		func() interface{} { return NewSumbleSource() },
+	)
+}

--- a/pkg/source/sumble/sumble.go
+++ b/pkg/source/sumble/sumble.go
@@ -1,0 +1,899 @@
+package sumble
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/internal/output"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/tablespec"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	baseURL        = "https://api.sumble.com/v9"
+	maxPageSize    = 100
+	maxOffset      = 10000
+	maxWorkers     = 5
+	requestTimeout = 60 * time.Second
+
+	// Sumble allows 10 requests per second across all endpoints.
+	rateLimit      = 8.0
+	rateLimitBurst = 5
+)
+
+var supportedTables = []string{
+	"organization_lists",
+	"organization_list_organizations",
+	"contact_lists",
+	"contact_list_people",
+	"signals",
+	"priority_signals",
+	"signal_configs",
+}
+
+type SumbleSource struct {
+	apiKey string
+	client *httpclient.Client
+}
+
+func NewSumbleSource() *SumbleSource {
+	return &SumbleSource{}
+}
+
+func (s *SumbleSource) HandlesIncrementality() bool {
+	return true
+}
+
+func (s *SumbleSource) Schemes() []string {
+	return []string{"sumble"}
+}
+
+func (s *SumbleSource) Connect(ctx context.Context, uri string) error {
+	apiKey, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+	s.apiKey = apiKey
+
+	s.client = httpclient.New(
+		httpclient.WithBaseURL(baseURL),
+		httpclient.WithTimeout(requestTimeout),
+		httpclient.WithRateLimiter(rateLimit, rateLimitBurst),
+		httpclient.WithRetry(5, 2*time.Second, 30*time.Second),
+		// The signal endpoints are POST, which resty does not retry by default.
+		httpclient.WithAllowNonIdempotentRetry(),
+		httpclient.WithDebug(config.DebugMode),
+		httpclient.WithAuth(httpclient.NewBearerAuth(s.apiKey)),
+		httpclient.WithHeader("Accept", "application/json"),
+		httpclient.WithHeader("Content-Type", "application/json"),
+	)
+
+	config.Debug("[SUMBLE] Connected successfully")
+	return nil
+}
+
+func (s *SumbleSource) Close(ctx context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func parseURI(rawURI string) (string, error) {
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return "", fmt.Errorf("invalid sumble URI: %w", err)
+	}
+	if parsed.Scheme != "sumble" {
+		return "", fmt.Errorf("invalid sumble URI: must start with sumble://")
+	}
+
+	apiKey := parsed.Query().Get("api_key")
+	if apiKey == "" {
+		return "", fmt.Errorf("api_key query parameter is required in sumble URI: sumble://?api_key=<key>")
+	}
+	return apiKey, nil
+}
+
+func (s *SumbleSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	spec, err := parseTableSpec(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	primaryKeys := []string{"id"}
+	incrementalKey := ""
+	strategy := config.StrategyReplace
+
+	switch spec.table {
+	case "organization_list_organizations":
+		primaryKeys = []string{"_ingestr_id"}
+	case "contact_list_people":
+		primaryKeys = []string{"_ingestr_id"}
+	case "signals":
+		primaryKeys = []string{"_ingestr_id"}
+		incrementalKey = "date"
+		strategy = config.StrategyMerge
+	case "priority_signals":
+		incrementalKey = "date"
+		strategy = config.StrategyMerge
+	}
+
+	return &source.DynamicSourceTable{
+		TableName:           spec.table,
+		TablePrimaryKeys:    primaryKeys,
+		TableIncrementalKey: incrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         false,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("sumble source does not have a predefined schema; schema inference is required")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, spec, opts)
+		},
+	}, nil
+}
+
+func isValidTable(table string) bool {
+	for _, supported := range supportedTables {
+		if table == supported {
+			return true
+		}
+	}
+	return false
+}
+
+type sumbleParams struct {
+	ListIDs         []string `mapstructure:"list_ids"`
+	OrganizationIDs []string `mapstructure:"organization_ids"`
+	PersonIDs       []string `mapstructure:"person_ids"`
+	SignalIDs       []string `mapstructure:"signal_ids"`
+	TechnologySlugs []string `mapstructure:"technology_slugs"`
+	JobFunctions    []string `mapstructure:"job_functions"`
+	Priorities      []string `mapstructure:"priorities"`
+	AccountListIDs  []string `mapstructure:"account_list_ids"`
+	SignalConfigIDs []string `mapstructure:"signal_config_ids"`
+	JobPostIDs      []string `mapstructure:"job_post_ids"`
+	Types           []string `mapstructure:"types"`
+	IsRelevant      string   `mapstructure:"is_relevant"`
+}
+
+type sumbleReadSpec struct {
+	table   string
+	listIDs []int64
+	filter  map[string]any
+}
+
+// allowedParams lists the table parameters each table accepts. Tables absent
+// from the map take no parameters.
+var allowedParams = map[string][]string{
+	"organization_list_organizations": {"list_ids"},
+	"contact_list_people":             {"list_ids"},
+	"signals": {
+		"organization_ids", "person_ids", "signal_ids", "technology_slugs",
+		"job_functions", "priorities", "account_list_ids", "signal_config_ids",
+	},
+	"priority_signals": {"organization_ids", "person_ids", "signal_ids", "job_post_ids", "is_relevant"},
+	"signal_configs":   {"signal_config_ids", "types", "priorities"},
+}
+
+func parseTableSpec(raw string) (sumbleReadSpec, error) {
+	var params sumbleParams
+	path, hasParams, err := tablespec.Parse(raw, &params, tablespec.WithListSeparator(","))
+	if err != nil {
+		return sumbleReadSpec{}, err
+	}
+
+	table := strings.TrimSpace(path)
+	if !isValidTable(table) {
+		return sumbleReadSpec{}, fmt.Errorf("unsupported table: %s (supported: %s)", table, strings.Join(supportedTables, ", "))
+	}
+
+	spec := sumbleReadSpec{table: table}
+	if !hasParams {
+		return spec, nil
+	}
+	if err := validateParams(table, raw); err != nil {
+		return sumbleReadSpec{}, err
+	}
+
+	switch table {
+	case "organization_list_organizations", "contact_list_people":
+		spec.listIDs, err = parsePositiveIDs("list_ids", params.ListIDs)
+	case "signals":
+		spec.filter, err = buildSignalsFilter(params)
+	case "priority_signals":
+		spec.filter, err = buildPrioritySignalsFilter(params)
+	case "signal_configs":
+		spec.filter, err = buildSignalConfigsFilter(params)
+	}
+	if err != nil {
+		return sumbleReadSpec{}, err
+	}
+	return spec, nil
+}
+
+// validateParams rejects parameters the table does not accept, and parameters
+// supplied with an empty value, which decode to a zero value and would
+// otherwise be dropped without any filtering taking effect.
+func validateParams(table, raw string) error {
+	_, params, _, err := tablespec.Split(raw)
+	if err != nil {
+		return err
+	}
+
+	allowed := make(map[string]struct{}, len(allowedParams[table]))
+	for _, name := range allowedParams[table] {
+		allowed[name] = struct{}{}
+	}
+
+	names := make([]string, 0, len(params))
+	for name := range params {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if _, ok := allowed[name]; !ok {
+			return fmt.Errorf("%s table does not accept the %s parameter", table, name)
+		}
+		for _, value := range params[name] {
+			if !hasListValue(value) {
+				return fmt.Errorf("%s parameter must not be empty", name)
+			}
+		}
+	}
+	return nil
+}
+
+// hasListValue reports whether a raw parameter value carries at least one
+// element once the list separator is applied; "," alone decodes to an empty
+// slice, which would silently drop the filter.
+func hasListValue(value string) bool {
+	for _, part := range strings.Split(value, ",") {
+		if strings.TrimSpace(part) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func parsePositiveIDs(name string, values []string) ([]int64, error) {
+	ids := make([]int64, 0, len(values))
+	for _, value := range values {
+		id, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || id <= 0 {
+			return nil, fmt.Errorf("%s must contain positive integer IDs, got %q", name, value)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func addIDFilter(filter map[string]any, name string, values []string) error {
+	if len(values) == 0 {
+		return nil
+	}
+	ids, err := parsePositiveIDs(name, values)
+	if err != nil {
+		return err
+	}
+	filter[name] = ids
+	return nil
+}
+
+func validatePriorities(priorities []string) error {
+	for _, priority := range priorities {
+		switch priority {
+		case "high", "medium", "low":
+		default:
+			return fmt.Errorf("priorities must contain high, medium, or low, got %q", priority)
+		}
+	}
+	return nil
+}
+
+func buildSignalsFilter(params sumbleParams) (map[string]any, error) {
+	filter := make(map[string]any)
+	for _, field := range []struct {
+		name   string
+		values []string
+	}{
+		{"organization_ids", params.OrganizationIDs},
+		{"person_ids", params.PersonIDs},
+		{"signal_ids", params.SignalIDs},
+		{"account_list_ids", params.AccountListIDs},
+		{"signal_config_ids", params.SignalConfigIDs},
+	} {
+		if err := addIDFilter(filter, field.name, field.values); err != nil {
+			return nil, err
+		}
+	}
+	if len(params.TechnologySlugs) > 0 {
+		filter["technology_slugs"] = params.TechnologySlugs
+	}
+	if len(params.JobFunctions) > 0 {
+		filter["job_functions"] = params.JobFunctions
+	}
+	if len(params.Priorities) > 0 {
+		if err := validatePriorities(params.Priorities); err != nil {
+			return nil, err
+		}
+		filter["priorities"] = params.Priorities
+	}
+	return filter, nil
+}
+
+func buildPrioritySignalsFilter(params sumbleParams) (map[string]any, error) {
+	filter := make(map[string]any)
+	for _, field := range []struct {
+		name   string
+		values []string
+	}{
+		{"organization_ids", params.OrganizationIDs},
+		{"person_ids", params.PersonIDs},
+		{"signal_ids", params.SignalIDs},
+		{"job_post_ids", params.JobPostIDs},
+	} {
+		if err := addIDFilter(filter, field.name, field.values); err != nil {
+			return nil, err
+		}
+	}
+	if params.IsRelevant != "" {
+		isRelevant, err := strconv.ParseBool(params.IsRelevant)
+		if err != nil {
+			return nil, fmt.Errorf("is_relevant must be true or false, got %q", params.IsRelevant)
+		}
+		filter["is_relevant"] = isRelevant
+	}
+	return filter, nil
+}
+
+func buildSignalConfigsFilter(params sumbleParams) (map[string]any, error) {
+	filter := make(map[string]any)
+	if err := addIDFilter(filter, "signal_config_ids", params.SignalConfigIDs); err != nil {
+		return nil, err
+	}
+	if len(params.Types) > 0 {
+		filter["types"] = params.Types
+	}
+	if len(params.Priorities) > 0 {
+		if err := validatePriorities(params.Priorities); err != nil {
+			return nil, err
+		}
+		filter["priorities"] = params.Priorities
+	}
+	if len(params.SignalConfigIDs) > 0 && (len(params.Types) > 0 || len(params.Priorities) > 0) {
+		return nil, fmt.Errorf("signal_config_ids cannot be combined with types or priorities")
+	}
+	return filter, nil
+}
+
+func (s *SumbleSource) read(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		var err error
+		switch spec.table {
+		case "organization_lists":
+			err = s.readOrganizationLists(ctx, opts, results)
+		case "organization_list_organizations":
+			err = s.readOrganizationListOrganizations(ctx, spec, opts, results)
+		case "contact_lists":
+			err = s.readContactLists(ctx, opts, results)
+		case "contact_list_people":
+			err = s.readContactListPeople(ctx, spec, opts, results)
+		case "signals":
+			err = s.readSignals(ctx, spec, opts, results)
+		case "priority_signals":
+			err = s.readPrioritySignals(ctx, spec, opts, results)
+		case "signal_configs":
+			err = s.readSignalConfigs(ctx, spec, opts, results)
+		default:
+			err = fmt.Errorf("unsupported table: %s", spec.table)
+		}
+
+		if err != nil {
+			results <- source.RecordBatchResult{Err: err}
+		}
+	}()
+
+	return results, nil
+}
+
+func (s *SumbleSource) readOrganizationLists(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SUMBLE] reading organization_lists")
+	items, err := s.fetchGETItems(ctx, "/organization-lists", "organization_lists", "organization lists", map[string]string{"include_deleted": "true"})
+	if err != nil {
+		return err
+	}
+	return sendItems(ctx, items, "organization lists", opts, results)
+}
+
+func (s *SumbleSource) readContactLists(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SUMBLE] reading contact_lists")
+	items, err := s.fetchGETItems(ctx, "/contact-lists", "contact_lists", "contact lists", nil)
+	if err != nil {
+		return err
+	}
+	return sendItems(ctx, items, "contact lists", opts, results)
+}
+
+func (s *SumbleSource) readOrganizationListOrganizations(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SUMBLE] reading organization_list_organizations")
+	listIDs := spec.listIDs
+	if len(listIDs) == 0 {
+		items, err := s.fetchGETItems(ctx, "/organization-lists", "organization_lists", "organization lists", map[string]string{"include_deleted": "true"})
+		if err != nil {
+			return err
+		}
+		listIDs, err = extractIDs(items)
+		if err != nil {
+			return fmt.Errorf("failed to parse organization list IDs: %w", err)
+		}
+	}
+
+	return s.readListMembers(ctx, listIDs, listMemberConfig{
+		path:          "/organization-lists/%d",
+		responseKey:   "organizations",
+		label:         "organization list organizations",
+		parentIDField: "organization_list_id",
+		parentObject:  "organization_list",
+		query:         map[string]string{"include_deleted": "true"},
+	}, opts, results)
+}
+
+func (s *SumbleSource) readContactListPeople(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SUMBLE] reading contact_list_people")
+	listIDs := spec.listIDs
+	if len(listIDs) == 0 {
+		items, err := s.fetchGETItems(ctx, "/contact-lists", "contact_lists", "contact lists", nil)
+		if err != nil {
+			return err
+		}
+		listIDs, err = extractIDs(items)
+		if err != nil {
+			return fmt.Errorf("failed to parse contact list IDs: %w", err)
+		}
+	}
+
+	return s.readListMembers(ctx, listIDs, listMemberConfig{
+		path:          "/contact-lists/%d",
+		responseKey:   "people",
+		label:         "contact list people",
+		parentIDField: "contact_list_id",
+		parentObject:  "contact_list",
+	}, opts, results)
+}
+
+type listMemberConfig struct {
+	path          string
+	responseKey   string
+	label         string
+	parentIDField string
+	parentObject  string
+	query         map[string]string
+}
+
+func (s *SumbleSource) readListMembers(ctx context.Context, listIDs []int64, cfg listMemberConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	workers := opts.Parallelism
+	if workers <= 0 || workers > maxWorkers {
+		workers = maxWorkers
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(workers)
+	for _, listID := range listIDs {
+		if groupCtx.Err() != nil {
+			break
+		}
+		listID := listID
+		group.Go(func() error {
+			endpoint := fmt.Sprintf(cfg.path, listID)
+			body, err := s.fetchGET(groupCtx, endpoint, cfg.label, cfg.query)
+			if err != nil {
+				return err
+			}
+			items, err := envelopeItems(body, cfg.responseKey)
+			if err != nil {
+				return fmt.Errorf("failed to parse %s for list %d: %w", cfg.label, listID, err)
+			}
+
+			listInfo, _ := body["list_info"].(map[string]any)
+			for _, item := range items {
+				item[cfg.parentIDField] = listID
+				if listInfo != nil {
+					item[cfg.parentObject] = listInfo
+				}
+			}
+			if err := addScopedPrimaryKeys(items, listID); err != nil {
+				return fmt.Errorf("failed to key %s for list %d: %w", cfg.label, listID, err)
+			}
+			return sendItems(groupCtx, items, cfg.label, opts, results)
+		})
+	}
+	return group.Wait()
+}
+
+func (s *SumbleSource) readSignals(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SUMBLE] reading signals")
+	return s.paginateAndSend(ctx, paginatedRead{
+		endpoint:      "/signals",
+		responseKey:   "signals",
+		label:         "signals",
+		filter:        spec.filter,
+		intervalField: "date",
+		newestFirst:   true,
+		transform:     addSignalPrimaryKeys,
+	}, opts, results)
+}
+
+func (s *SumbleSource) readPrioritySignals(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SUMBLE] reading priority_signals")
+	// Priority signals are ordered by completion time rather than by date, so
+	// pagination cannot stop early on the interval start.
+	return s.paginateAndSend(ctx, paginatedRead{
+		endpoint:      "/signals/priority",
+		responseKey:   "priority_signals",
+		label:         "priority signals",
+		filter:        spec.filter,
+		intervalField: "date",
+	}, opts, results)
+}
+
+func (s *SumbleSource) readSignalConfigs(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	config.Debug("[SUMBLE] reading signal_configs")
+	body := requestBody(spec.filter)
+	response, err := s.post(ctx, "/signals/configs", "signal configs", body)
+	if err != nil {
+		return err
+	}
+	items, err := envelopeItems(response, "signal_configs")
+	if err != nil {
+		return fmt.Errorf("failed to parse signal configs response: %w", err)
+	}
+	return sendItems(ctx, items, "signal configs", opts, results)
+}
+
+type itemTransform func([]map[string]any) error
+
+type paginatedRead struct {
+	endpoint      string
+	responseKey   string
+	label         string
+	filter        map[string]any
+	intervalField string
+	// newestFirst marks endpoints Sumble documents as ordering rows by
+	// intervalField descending, which lets pagination stop at the interval start
+	// instead of paging the endpoint's whole retention window.
+	newestFirst bool
+	transform   itemTransform
+}
+
+func (s *SumbleSource) paginateAndSend(
+	ctx context.Context,
+	read paginatedRead,
+	opts source.ReadOptions,
+	results chan<- source.RecordBatchResult,
+) error {
+	pageSize := opts.PageSize
+	if pageSize <= 0 || pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+
+	fetched := 0
+	for offset := 0; offset <= maxOffset; offset += pageSize {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		body := requestBody(read.filter)
+		body["limit"] = pageSize
+		body["offset"] = offset
+
+		response, err := s.post(ctx, read.endpoint, read.label, body)
+		if err != nil {
+			return err
+		}
+		page, err := envelopeItems(response, read.responseKey)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s response: %w", read.label, err)
+		}
+		fetched += len(page)
+
+		items := filterItemsByInterval(page, read.intervalField, opts.IntervalStart, opts.IntervalEnd)
+		if read.transform != nil {
+			if err := read.transform(items); err != nil {
+				return fmt.Errorf("failed to transform %s: %w", read.label, err)
+			}
+		}
+		if err := sendItems(ctx, items, read.label, opts, results); err != nil {
+			return err
+		}
+
+		if len(page) < pageSize {
+			return nil
+		}
+		if read.newestFirst && opts.IntervalStart != nil && pageEndsBeforeStart(page, read.intervalField, *opts.IntervalStart) {
+			config.Debug("[SUMBLE] reached the interval start after %d %s", fetched, read.label)
+			return nil
+		}
+	}
+
+	output.Warnf("[SUMBLE] WARNING: %s reached the API offset limit after fetching %d records; any older records were not ingested, narrow the extract with table parameters\n", read.label, fetched)
+	return nil
+}
+
+// pageEndsBeforeStart reports whether every remaining row of a newest-first
+// endpoint is older than the interval start. It gives up unless every row on the
+// page carries a parseable value, so an unexpected payload never truncates.
+func pageEndsBeforeStart(items []map[string]any, field string, start time.Time) bool {
+	if field == "" || len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		timestamp, dateOnly, ok := parseTimestamp(item[field])
+		if !ok || !beforeIntervalStart(timestamp, dateOnly, start) {
+			return false
+		}
+	}
+	return true
+}
+
+func requestBody(filter map[string]any) map[string]any {
+	body := make(map[string]any)
+	if len(filter) > 0 {
+		body["filter"] = filter
+	}
+	return body
+}
+
+func (s *SumbleSource) fetchGETItems(ctx context.Context, endpoint, responseKey, label string, query map[string]string) ([]map[string]any, error) {
+	body, err := s.fetchGET(ctx, endpoint, label, query)
+	if err != nil {
+		return nil, err
+	}
+	items, err := envelopeItems(body, responseKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %s response: %w", label, err)
+	}
+	return items, nil
+}
+
+func (s *SumbleSource) fetchGET(ctx context.Context, endpoint, label string, query map[string]string) (map[string]any, error) {
+	req := s.client.R(ctx)
+	if len(query) > 0 {
+		req.SetQueryParams(query)
+	}
+	resp, err := req.Get(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s from %s: %w", label, endpoint, err)
+	}
+	if !resp.IsSuccess() {
+		return nil, fmt.Errorf("sumble API %s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+	}
+
+	var body map[string]any
+	if err := jsonUseNumber(resp.Body(), &body); err != nil {
+		return nil, fmt.Errorf("failed to decode %s response from %s: %w", label, endpoint, err)
+	}
+	return body, nil
+}
+
+func (s *SumbleSource) post(ctx context.Context, endpoint, label string, body map[string]any) (map[string]any, error) {
+	resp, err := s.client.R(ctx).SetBody(body).Post(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch %s from %s: %w", label, endpoint, err)
+	}
+	if !resp.IsSuccess() {
+		return nil, fmt.Errorf("sumble API %s returned status %d: %s", endpoint, resp.StatusCode(), resp.String())
+	}
+
+	var response map[string]any
+	if err := jsonUseNumber(resp.Body(), &response); err != nil {
+		return nil, fmt.Errorf("failed to decode %s response from %s: %w", label, endpoint, err)
+	}
+	return response, nil
+}
+
+func jsonUseNumber(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	return decoder.Decode(target)
+}
+
+func envelopeItems(body map[string]any, key string) ([]map[string]any, error) {
+	raw, ok := body[key]
+	if !ok {
+		return nil, fmt.Errorf("response missing %q field", key)
+	}
+	if raw == nil {
+		return nil, nil
+	}
+	values, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("response field %q has type %T, expected array", key, raw)
+	}
+
+	items := make([]map[string]any, 0, len(values))
+	for index, value := range values {
+		item, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("response field %q item %d has type %T, expected object", key, index, value)
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func extractIDs(items []map[string]any) ([]int64, error) {
+	ids := make([]int64, 0, len(items))
+	for _, item := range items {
+		id, err := int64Value(item["id"])
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func int64Value(value any) (int64, error) {
+	switch typed := value.(type) {
+	case json.Number:
+		id, err := typed.Int64()
+		if err != nil || id <= 0 {
+			return 0, fmt.Errorf("invalid ID %q", typed)
+		}
+		return id, nil
+	case int64:
+		if typed > 0 {
+			return typed, nil
+		}
+	case int:
+		if typed > 0 {
+			return int64(typed), nil
+		}
+	case float64:
+		if typed > 0 && typed == float64(int64(typed)) {
+			return int64(typed), nil
+		}
+	}
+	return 0, fmt.Errorf("invalid ID value %v", value)
+}
+
+func sendItems(ctx context.Context, items []map[string]any, label string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	if len(items) == 0 {
+		return nil
+	}
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	if err != nil {
+		return fmt.Errorf("failed to convert %s to Arrow: %w", label, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		record.Release()
+		return ctx.Err()
+	case results <- source.RecordBatchResult{Batch: record}:
+		return nil
+	}
+}
+
+func filterItemsByInterval(items []map[string]any, field string, start, end *time.Time) []map[string]any {
+	if field == "" || (start == nil && end == nil) {
+		return items
+	}
+
+	filtered := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		timestamp, dateOnly, ok := parseTimestamp(item[field])
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		if start != nil && beforeIntervalStart(timestamp, dateOnly, start.UTC()) {
+			continue
+		}
+		if end != nil && !timestamp.Before(end.UTC()) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+// beforeIntervalStart reports whether a value falls entirely before the interval
+// start. A date-only value covers a whole day, so it stays in range as long as
+// any part of that day falls at or after the start.
+func beforeIntervalStart(timestamp time.Time, dateOnly bool, start time.Time) bool {
+	if dateOnly {
+		return !timestamp.AddDate(0, 0, 1).After(start)
+	}
+	return timestamp.Before(start)
+}
+
+// parseTimestamp reports the parsed value and whether it carried date-only
+// granularity, which callers need to place it against a sub-day interval.
+func parseTimestamp(value any) (timestamp time.Time, dateOnly, ok bool) {
+	text, isString := value.(string)
+	if !isString || text == "" {
+		return time.Time{}, false, false
+	}
+	if parsed, err := time.Parse(time.RFC3339Nano, text); err == nil {
+		return parsed.UTC(), false, true
+	}
+	if parsed, err := time.Parse(time.DateOnly, text); err == nil {
+		return parsed.UTC(), true, true
+	}
+	return time.Time{}, false, false
+}
+
+func addSignalPrimaryKeys(items []map[string]any) error {
+	for _, item := range items {
+		if signalID := scalarString(item["signal_id"]); signalID != "" {
+			item["_ingestr_id"] = "signal:" + signalID
+			continue
+		}
+
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			return err
+		}
+		digest := sha256.Sum256(encoded)
+		item["_ingestr_id"] = "hash:" + hex.EncodeToString(digest[:])
+	}
+	return nil
+}
+
+func addScopedPrimaryKeys(items []map[string]any, parentID int64) error {
+	for _, item := range items {
+		if itemID := scalarString(item["id"]); itemID != "" {
+			item["_ingestr_id"] = fmt.Sprintf("%d:id:%s", parentID, itemID)
+			continue
+		}
+
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			return err
+		}
+		digest := sha256.Sum256(encoded)
+		item["_ingestr_id"] = fmt.Sprintf("%d:hash:%s", parentID, hex.EncodeToString(digest[:]))
+	}
+	return nil
+}
+
+func scalarString(value any) string {
+	switch typed := value.(type) {
+	case json.Number:
+		return typed.String()
+	case string:
+		return typed
+	case int:
+		return strconv.Itoa(typed)
+	case int64:
+		return strconv.FormatInt(typed, 10)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	default:
+		return ""
+	}
+}

--- a/pkg/source/sumble/sumble.go
+++ b/pkg/source/sumble/sumble.go
@@ -507,6 +507,12 @@ func (s *SumbleSource) readListMembers(ctx context.Context, listIDs []int64, cfg
 	if workers <= 0 || workers > maxWorkers {
 		workers = maxWorkers
 	}
+	// A list's size is only known once it has been fetched, so parallel workers
+	// would each start a fetch that the row budget then discards. Serialize the
+	// fan-out to spend exactly as many requests as the budget needs.
+	if rc.opts.Limit > 0 {
+		workers = 1
+	}
 
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(workers)

--- a/pkg/source/sumble/sumble.go
+++ b/pkg/source/sumble/sumble.go
@@ -612,17 +612,31 @@ func (s *SumbleSource) paginateAndSend(ctx context.Context, read paginatedRead, 
 		pageSize = maxPageSize
 	}
 
+	// A page can only be clamped to the row budget when every fetched row is
+	// kept. Under interval filtering a dropped row spends no budget, so clamping
+	// would just split the same work across more requests.
+	clampToBudget := read.intervalField == "" || (rc.opts.IntervalStart == nil && rc.opts.IntervalEnd == nil)
+
 	fetched := 0
-	for offset := 0; offset <= maxOffset; offset += pageSize {
+	for offset := 0; offset <= maxOffset; {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
+		limit := pageSize
+		if remaining := rc.limiter.remaining(); clampToBudget && remaining >= 0 && remaining < limit {
+			limit = remaining
+		}
+		if limit <= 0 {
+			return nil
+		}
+
 		body := requestBody(read.filter)
-		body["limit"] = pageSize
+		body["limit"] = limit
 		body["offset"] = offset
+		offset += limit
 
 		response, err := s.post(ctx, read.endpoint, read.label, body)
 		if err != nil {
@@ -644,7 +658,7 @@ func (s *SumbleSource) paginateAndSend(ctx context.Context, read paginatedRead, 
 			return err
 		}
 
-		if len(page) < pageSize || rc.limiter.exhausted() {
+		if len(page) < limit || rc.limiter.exhausted() {
 			return nil
 		}
 		if read.newestFirst && rc.opts.IntervalStart != nil && pageEndsBeforeStart(page, read.intervalField, *rc.opts.IntervalStart) {
@@ -844,6 +858,14 @@ func (l *rowLimiter) take(n int) int {
 
 func (l *rowLimiter) exhausted() bool {
 	return l.limit > 0 && l.used.Load() >= l.limit
+}
+
+// remaining reports how many rows still fit in the budget, or -1 when unlimited.
+func (l *rowLimiter) remaining() int {
+	if l.limit <= 0 {
+		return -1
+	}
+	return int(max(l.limit-l.used.Load(), 0))
 }
 
 func filterItemsByInterval(items []map[string]any, field string, start, end *time.Time) []map[string]any {

--- a/pkg/source/sumble/sumble.go
+++ b/pkg/source/sumble/sumble.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/bruin-data/ingestr/internal/config"
@@ -383,8 +384,18 @@ func buildSignalConfigsFilter(params sumbleParams) (map[string]any, error) {
 	return filter, nil
 }
 
+// readContext carries the per-read state every reader needs: the caller's
+// options, the destination channel, and the row budget shared across the
+// parallel list workers.
+type readContext struct {
+	opts    source.ReadOptions
+	limiter *rowLimiter
+	results chan<- source.RecordBatchResult
+}
+
 func (s *SumbleSource) read(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 	results := make(chan source.RecordBatchResult, 8)
+	rc := readContext{opts: opts, limiter: newRowLimiter(opts.Limit), results: results}
 
 	go func() {
 		defer close(results)
@@ -392,19 +403,19 @@ func (s *SumbleSource) read(ctx context.Context, spec sumbleReadSpec, opts sourc
 		var err error
 		switch spec.table {
 		case "organization_lists":
-			err = s.readOrganizationLists(ctx, opts, results)
+			err = s.readOrganizationLists(ctx, rc)
 		case "organization_list_organizations":
-			err = s.readOrganizationListOrganizations(ctx, spec, opts, results)
+			err = s.readOrganizationListOrganizations(ctx, spec, rc)
 		case "contact_lists":
-			err = s.readContactLists(ctx, opts, results)
+			err = s.readContactLists(ctx, rc)
 		case "contact_list_people":
-			err = s.readContactListPeople(ctx, spec, opts, results)
+			err = s.readContactListPeople(ctx, spec, rc)
 		case "signals":
-			err = s.readSignals(ctx, spec, opts, results)
+			err = s.readSignals(ctx, spec, rc)
 		case "priority_signals":
-			err = s.readPrioritySignals(ctx, spec, opts, results)
+			err = s.readPrioritySignals(ctx, spec, rc)
 		case "signal_configs":
-			err = s.readSignalConfigs(ctx, spec, opts, results)
+			err = s.readSignalConfigs(ctx, spec, rc)
 		default:
 			err = fmt.Errorf("unsupported table: %s", spec.table)
 		}
@@ -417,25 +428,25 @@ func (s *SumbleSource) read(ctx context.Context, spec sumbleReadSpec, opts sourc
 	return results, nil
 }
 
-func (s *SumbleSource) readOrganizationLists(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *SumbleSource) readOrganizationLists(ctx context.Context, rc readContext) error {
 	config.Debug("[SUMBLE] reading organization_lists")
 	items, err := s.fetchGETItems(ctx, "/organization-lists", "organization_lists", "organization lists", map[string]string{"include_deleted": "true"})
 	if err != nil {
 		return err
 	}
-	return sendItems(ctx, items, "organization lists", opts, results)
+	return sendItems(ctx, items, "organization lists", rc)
 }
 
-func (s *SumbleSource) readContactLists(ctx context.Context, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *SumbleSource) readContactLists(ctx context.Context, rc readContext) error {
 	config.Debug("[SUMBLE] reading contact_lists")
 	items, err := s.fetchGETItems(ctx, "/contact-lists", "contact_lists", "contact lists", nil)
 	if err != nil {
 		return err
 	}
-	return sendItems(ctx, items, "contact lists", opts, results)
+	return sendItems(ctx, items, "contact lists", rc)
 }
 
-func (s *SumbleSource) readOrganizationListOrganizations(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *SumbleSource) readOrganizationListOrganizations(ctx context.Context, spec sumbleReadSpec, rc readContext) error {
 	config.Debug("[SUMBLE] reading organization_list_organizations")
 	listIDs := spec.listIDs
 	if len(listIDs) == 0 {
@@ -456,10 +467,10 @@ func (s *SumbleSource) readOrganizationListOrganizations(ctx context.Context, sp
 		parentIDField: "organization_list_id",
 		parentObject:  "organization_list",
 		query:         map[string]string{"include_deleted": "true"},
-	}, opts, results)
+	}, rc)
 }
 
-func (s *SumbleSource) readContactListPeople(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *SumbleSource) readContactListPeople(ctx context.Context, spec sumbleReadSpec, rc readContext) error {
 	config.Debug("[SUMBLE] reading contact_list_people")
 	listIDs := spec.listIDs
 	if len(listIDs) == 0 {
@@ -479,7 +490,7 @@ func (s *SumbleSource) readContactListPeople(ctx context.Context, spec sumbleRea
 		label:         "contact list people",
 		parentIDField: "contact_list_id",
 		parentObject:  "contact_list",
-	}, opts, results)
+	}, rc)
 }
 
 type listMemberConfig struct {
@@ -491,8 +502,8 @@ type listMemberConfig struct {
 	query         map[string]string
 }
 
-func (s *SumbleSource) readListMembers(ctx context.Context, listIDs []int64, cfg listMemberConfig, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
-	workers := opts.Parallelism
+func (s *SumbleSource) readListMembers(ctx context.Context, listIDs []int64, cfg listMemberConfig, rc readContext) error {
+	workers := rc.opts.Parallelism
 	if workers <= 0 || workers > maxWorkers {
 		workers = maxWorkers
 	}
@@ -500,11 +511,14 @@ func (s *SumbleSource) readListMembers(ctx context.Context, listIDs []int64, cfg
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.SetLimit(workers)
 	for _, listID := range listIDs {
-		if groupCtx.Err() != nil {
+		if groupCtx.Err() != nil || rc.limiter.exhausted() {
 			break
 		}
 		listID := listID
 		group.Go(func() error {
+			if rc.limiter.exhausted() {
+				return nil
+			}
 			endpoint := fmt.Sprintf(cfg.path, listID)
 			body, err := s.fetchGET(groupCtx, endpoint, cfg.label, cfg.query)
 			if err != nil {
@@ -525,13 +539,13 @@ func (s *SumbleSource) readListMembers(ctx context.Context, listIDs []int64, cfg
 			if err := addScopedPrimaryKeys(items, listID); err != nil {
 				return fmt.Errorf("failed to key %s for list %d: %w", cfg.label, listID, err)
 			}
-			return sendItems(groupCtx, items, cfg.label, opts, results)
+			return sendItems(groupCtx, items, cfg.label, rc)
 		})
 	}
 	return group.Wait()
 }
 
-func (s *SumbleSource) readSignals(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *SumbleSource) readSignals(ctx context.Context, spec sumbleReadSpec, rc readContext) error {
 	config.Debug("[SUMBLE] reading signals")
 	return s.paginateAndSend(ctx, paginatedRead{
 		endpoint:      "/signals",
@@ -541,10 +555,10 @@ func (s *SumbleSource) readSignals(ctx context.Context, spec sumbleReadSpec, opt
 		intervalField: "date",
 		newestFirst:   true,
 		transform:     addSignalPrimaryKeys,
-	}, opts, results)
+	}, rc)
 }
 
-func (s *SumbleSource) readPrioritySignals(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *SumbleSource) readPrioritySignals(ctx context.Context, spec sumbleReadSpec, rc readContext) error {
 	config.Debug("[SUMBLE] reading priority_signals")
 	// Priority signals are ordered by completion time rather than by date, so
 	// pagination cannot stop early on the interval start.
@@ -554,10 +568,10 @@ func (s *SumbleSource) readPrioritySignals(ctx context.Context, spec sumbleReadS
 		label:         "priority signals",
 		filter:        spec.filter,
 		intervalField: "date",
-	}, opts, results)
+	}, rc)
 }
 
-func (s *SumbleSource) readSignalConfigs(ctx context.Context, spec sumbleReadSpec, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func (s *SumbleSource) readSignalConfigs(ctx context.Context, spec sumbleReadSpec, rc readContext) error {
 	config.Debug("[SUMBLE] reading signal_configs")
 	body := requestBody(spec.filter)
 	response, err := s.post(ctx, "/signals/configs", "signal configs", body)
@@ -568,7 +582,7 @@ func (s *SumbleSource) readSignalConfigs(ctx context.Context, spec sumbleReadSpe
 	if err != nil {
 		return fmt.Errorf("failed to parse signal configs response: %w", err)
 	}
-	return sendItems(ctx, items, "signal configs", opts, results)
+	return sendItems(ctx, items, "signal configs", rc)
 }
 
 type itemTransform func([]map[string]any) error
@@ -586,13 +600,8 @@ type paginatedRead struct {
 	transform   itemTransform
 }
 
-func (s *SumbleSource) paginateAndSend(
-	ctx context.Context,
-	read paginatedRead,
-	opts source.ReadOptions,
-	results chan<- source.RecordBatchResult,
-) error {
-	pageSize := opts.PageSize
+func (s *SumbleSource) paginateAndSend(ctx context.Context, read paginatedRead, rc readContext) error {
+	pageSize := rc.opts.PageSize
 	if pageSize <= 0 || pageSize > maxPageSize {
 		pageSize = maxPageSize
 	}
@@ -619,20 +628,20 @@ func (s *SumbleSource) paginateAndSend(
 		}
 		fetched += len(page)
 
-		items := filterItemsByInterval(page, read.intervalField, opts.IntervalStart, opts.IntervalEnd)
+		items := filterItemsByInterval(page, read.intervalField, rc.opts.IntervalStart, rc.opts.IntervalEnd)
 		if read.transform != nil {
 			if err := read.transform(items); err != nil {
 				return fmt.Errorf("failed to transform %s: %w", read.label, err)
 			}
 		}
-		if err := sendItems(ctx, items, read.label, opts, results); err != nil {
+		if err := sendItems(ctx, items, read.label, rc); err != nil {
 			return err
 		}
 
-		if len(page) < pageSize {
+		if len(page) < pageSize || rc.limiter.exhausted() {
 			return nil
 		}
-		if read.newestFirst && opts.IntervalStart != nil && pageEndsBeforeStart(page, read.intervalField, *opts.IntervalStart) {
+		if read.newestFirst && rc.opts.IntervalStart != nil && pageEndsBeforeStart(page, read.intervalField, *rc.opts.IntervalStart) {
 			config.Debug("[SUMBLE] reached the interval start after %d %s", fetched, read.label)
 			return nil
 		}
@@ -780,11 +789,12 @@ func int64Value(value any) (int64, error) {
 	return 0, fmt.Errorf("invalid ID value %v", value)
 }
 
-func sendItems(ctx context.Context, items []map[string]any, label string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+func sendItems(ctx context.Context, items []map[string]any, label string, rc readContext) error {
+	items = items[:rc.limiter.take(len(items))]
 	if len(items) == 0 {
 		return nil
 	}
-	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, opts.ExcludeColumns)
+	record, err := arrowconv.ItemsToArrowRecordWithSchema(items, nil, rc.opts.ExcludeColumns)
 	if err != nil {
 		return fmt.Errorf("failed to convert %s to Arrow: %w", label, err)
 	}
@@ -793,9 +803,41 @@ func sendItems(ctx context.Context, items []map[string]any, label string, opts s
 	case <-ctx.Done():
 		record.Release()
 		return ctx.Err()
-	case results <- source.RecordBatchResult{Batch: record}:
+	case rc.results <- source.RecordBatchResult{Batch: record}:
 		return nil
 	}
+}
+
+// rowLimiter enforces --sql-limit across the parallel list workers. A limit of
+// zero or less means unlimited.
+type rowLimiter struct {
+	limit int64
+	used  atomic.Int64
+}
+
+func newRowLimiter(limit int) *rowLimiter {
+	return &rowLimiter{limit: int64(limit)}
+}
+
+// take claims up to n rows and reports how many of them fit in the budget.
+func (l *rowLimiter) take(n int) int {
+	if l.limit <= 0 {
+		return n
+	}
+	for {
+		used := l.used.Load()
+		allowed := min(int64(n), l.limit-used)
+		if allowed <= 0 {
+			return 0
+		}
+		if l.used.CompareAndSwap(used, used+allowed) {
+			return int(allowed)
+		}
+	}
+}
+
+func (l *rowLimiter) exhausted() bool {
+	return l.limit > 0 && l.used.Load() >= l.limit
 }
 
 func filterItemsByInterval(items []map[string]any, field string, start, end *time.Time) []map[string]any {

--- a/pkg/source/sumble/sumble_test.go
+++ b/pkg/source/sumble/sumble_test.go
@@ -501,3 +501,36 @@ func TestRowLimiterSharesBudgetAcrossWorkers(t *testing.T) {
 	assert.Equal(t, 7, unlimited.take(7))
 	assert.False(t, unlimited.exhausted())
 }
+
+// A row limit serializes the list fan-out so no worker spends a request the
+// budget would immediately discard.
+func TestListMembersStopFetchingAtRowLimit(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"list_info":{"id":1},"people":[{"id":1},{"id":2}]}`))
+	}))
+	defer server.Close()
+
+	connector := NewSumbleSource()
+	connector.client = testSumbleClient(server.URL)
+
+	spec := sumbleReadSpec{table: "contact_list_people", listIDs: []int64{1, 2, 3, 4, 5}}
+	results, err := connector.read(context.Background(), spec, source.ReadOptions{Limit: 3})
+	require.NoError(t, err)
+	batches, readErr := drain(results)
+	require.NoError(t, readErr)
+	defer func() {
+		for _, batch := range batches {
+			batch.Release()
+		}
+	}()
+
+	total := 0
+	for _, batch := range batches {
+		total += int(batch.NumRows())
+	}
+	assert.Equal(t, 3, total)
+	assert.EqualValues(t, 2, requests.Load())
+}

--- a/pkg/source/sumble/sumble_test.go
+++ b/pkg/source/sumble/sumble_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/source"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 func TestParseURI(t *testing.T) {
@@ -447,4 +448,56 @@ func TestPaginationStopsAtOffsetLimit(t *testing.T) {
 
 	assert.EqualValues(t, maxOffset/maxPageSize+1, requests.Load())
 	assert.Equal(t, strconv.Itoa(maxOffset), lastOffset)
+}
+
+func TestPaginationHonorsRowLimit(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"signals":[{"signal_id":1,"date":"2026-08-01T00:00:00Z"},{"signal_id":2,"date":"2026-08-01T00:00:00Z"}]}`))
+	}))
+	defer server.Close()
+
+	connector := NewSumbleSource()
+	connector.client = testSumbleClient(server.URL)
+
+	results, err := connector.read(context.Background(), sumbleReadSpec{table: "signals"}, source.ReadOptions{PageSize: 2, Limit: 3})
+	require.NoError(t, err)
+	batches, readErr := drain(results)
+	require.NoError(t, readErr)
+	defer func() {
+		for _, batch := range batches {
+			batch.Release()
+		}
+	}()
+
+	total := 0
+	for _, batch := range batches {
+		total += int(batch.NumRows())
+	}
+	assert.Equal(t, 3, total)
+	assert.EqualValues(t, 2, requests.Load())
+}
+
+func TestRowLimiterSharesBudgetAcrossWorkers(t *testing.T) {
+	limiter := newRowLimiter(10)
+	var group errgroup.Group
+	for i := 0; i < 8; i++ {
+		group.Go(func() error {
+			for j := 0; j < 5; j++ {
+				limiter.take(3)
+			}
+			return nil
+		})
+	}
+	require.NoError(t, group.Wait())
+
+	assert.EqualValues(t, 10, limiter.used.Load())
+	assert.True(t, limiter.exhausted())
+	assert.Equal(t, 0, limiter.take(1))
+
+	unlimited := newRowLimiter(0)
+	assert.Equal(t, 7, unlimited.take(7))
+	assert.False(t, unlimited.exhausted())
 }

--- a/pkg/source/sumble/sumble_test.go
+++ b/pkg/source/sumble/sumble_test.go
@@ -1,0 +1,450 @@
+package sumble
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
+	ingestrhttp "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURI(t *testing.T) {
+	tests := []struct {
+		name      string
+		uri       string
+		wantKey   string
+		wantError string
+	}{
+		{name: "valid", uri: "sumble://?api_key=secret", wantKey: "secret"},
+		{name: "valid with host", uri: "sumble://default?api_key=secret", wantKey: "secret"},
+		{name: "wrong scheme", uri: "https://?api_key=secret", wantError: "must start with sumble://"},
+		{name: "missing API key", uri: "sumble://", wantError: "api_key query parameter is required"},
+		{name: "empty API key", uri: "sumble://?api_key=", wantError: "api_key query parameter is required"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			apiKey, err := parseURI(test.uri)
+			if test.wantError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.wantError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.wantKey, apiKey)
+		})
+	}
+}
+
+func TestIsValidTable(t *testing.T) {
+	for _, table := range supportedTables {
+		assert.True(t, isValidTable(table), "expected %s to be valid", table)
+	}
+	assert.False(t, isValidTable(""))
+	assert.False(t, isValidTable("unknown"))
+	assert.False(t, isValidTable("Signals"))
+}
+
+func TestGetTableMetadata(t *testing.T) {
+	tests := []struct {
+		name           string
+		primaryKeys    []string
+		incrementalKey string
+		strategy       config.IncrementalStrategy
+	}{
+		{name: "organization_lists", primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+		{name: "organization_list_organizations", primaryKeys: []string{"_ingestr_id"}, strategy: config.StrategyReplace},
+		{name: "contact_lists", primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+		{name: "contact_list_people", primaryKeys: []string{"_ingestr_id"}, strategy: config.StrategyReplace},
+		{name: "signals", primaryKeys: []string{"_ingestr_id"}, incrementalKey: "date", strategy: config.StrategyMerge},
+		{name: "priority_signals", primaryKeys: []string{"id"}, incrementalKey: "date", strategy: config.StrategyMerge},
+		{name: "signal_configs", primaryKeys: []string{"id"}, strategy: config.StrategyReplace},
+	}
+
+	connector := NewSumbleSource()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			table, err := connector.GetTable(context.Background(), source.TableRequest{Name: test.name})
+			require.NoError(t, err)
+			assert.Equal(t, test.name, table.Name())
+			assert.Equal(t, test.primaryKeys, table.PrimaryKeys())
+			assert.Equal(t, test.incrementalKey, table.IncrementalKey())
+			assert.Equal(t, test.strategy, table.Strategy())
+			assert.False(t, table.HasKnownSchema())
+		})
+	}
+}
+
+func TestParseTableSpec(t *testing.T) {
+	t.Run("plain table", func(t *testing.T) {
+		spec, err := parseTableSpec("organization_lists")
+		require.NoError(t, err)
+		assert.Equal(t, "organization_lists", spec.table)
+		assert.Empty(t, spec.listIDs)
+		assert.Empty(t, spec.filter)
+	})
+
+	t.Run("list IDs", func(t *testing.T) {
+		spec, err := parseTableSpec("organization_list_organizations?list_ids=12,34")
+		require.NoError(t, err)
+		assert.Equal(t, []int64{12, 34}, spec.listIDs)
+	})
+
+	t.Run("signal filters", func(t *testing.T) {
+		spec, err := parseTableSpec("signals?organization_ids=12,34&technology_slugs=kubernetes&priorities=high,low")
+		require.NoError(t, err)
+		assert.Equal(t, []int64{12, 34}, spec.filter["organization_ids"])
+		assert.Equal(t, []string{"kubernetes"}, spec.filter["technology_slugs"])
+		assert.Equal(t, []string{"high", "low"}, spec.filter["priorities"])
+	})
+
+	t.Run("false relevance filter", func(t *testing.T) {
+		spec, err := parseTableSpec("priority_signals?is_relevant=false")
+		require.NoError(t, err)
+		assert.Equal(t, false, spec.filter["is_relevant"])
+	})
+
+	t.Run("unknown parameter", func(t *testing.T) {
+		_, err := parseTableSpec("signals?organisation_ids=12")
+		require.ErrorContains(t, err, "unknown table parameter")
+	})
+
+	t.Run("parameter rejected for table", func(t *testing.T) {
+		_, err := parseTableSpec("organization_lists?list_ids=12")
+		require.ErrorContains(t, err, "does not accept the list_ids parameter")
+	})
+
+	t.Run("invalid ID", func(t *testing.T) {
+		_, err := parseTableSpec("contact_list_people?list_ids=not-a-number")
+		require.ErrorContains(t, err, "positive integer IDs")
+	})
+
+	t.Run("invalid priority", func(t *testing.T) {
+		_, err := parseTableSpec("signals?priorities=urgent")
+		require.ErrorContains(t, err, "high, medium, or low")
+	})
+
+	t.Run("mutually exclusive signal config filters", func(t *testing.T) {
+		_, err := parseTableSpec("signal_configs?signal_config_ids=12&priorities=high")
+		require.ErrorContains(t, err, "cannot be combined")
+	})
+
+	t.Run("empty parameter value", func(t *testing.T) {
+		_, err := parseTableSpec("priority_signals?organization_ids=5&is_relevant=")
+		require.ErrorContains(t, err, "is_relevant parameter must not be empty")
+	})
+
+	t.Run("separator-only parameter value", func(t *testing.T) {
+		_, err := parseTableSpec("organization_list_organizations?list_ids=,")
+		require.ErrorContains(t, err, "list_ids parameter must not be empty")
+	})
+
+	t.Run("empty value for a rejected parameter", func(t *testing.T) {
+		_, err := parseTableSpec("organization_lists?list_ids=")
+		require.ErrorContains(t, err, "does not accept the list_ids parameter")
+	})
+}
+
+func TestJsonUseNumber(t *testing.T) {
+	var result map[string]any
+	require.NoError(t, jsonUseNumber([]byte(`{"id":9007199254740993,"score":3.14}`), &result))
+
+	id, ok := result["id"].(json.Number)
+	require.True(t, ok)
+	assert.Equal(t, "9007199254740993", id.String())
+	assert.IsType(t, json.Number(""), result["score"])
+}
+
+func TestFilterItemsByInterval(t *testing.T) {
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	items := []map[string]any{
+		{"id": 1, "date": "2026-07-31T23:59:59Z"},
+		{"id": 2, "date": "2026-08-01T00:00:00Z"},
+		{"id": 3, "date": "2026-08-02"},
+		{"id": 4, "date": "2026-08-03T00:00:00Z"},
+		{"id": 5},
+	}
+
+	filtered := filterItemsByInterval(items, "date", &start, &end)
+	require.Len(t, filtered, 3)
+	assert.Equal(t, 2, filtered[0]["id"])
+	assert.Equal(t, 3, filtered[1]["id"])
+	assert.Equal(t, 5, filtered[2]["id"])
+}
+
+func TestFilterItemsByIntervalKeepsDateOnlyWithinSubDayInterval(t *testing.T) {
+	start := time.Date(2026, 8, 2, 6, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 3, 6, 0, 0, 0, time.UTC)
+	items := []map[string]any{
+		{"id": 1, "date": "2026-08-01"},
+		{"id": 2, "date": "2026-08-02"},
+		{"id": 3, "date": "2026-08-03"},
+		{"id": 4, "date": "2026-08-04"},
+	}
+
+	filtered := filterItemsByInterval(items, "date", &start, &end)
+	require.Len(t, filtered, 2)
+	assert.Equal(t, 2, filtered[0]["id"])
+	assert.Equal(t, 3, filtered[1]["id"])
+}
+
+func TestAddSignalPrimaryKeys(t *testing.T) {
+	items := []map[string]any{
+		{"signal_id": json.Number("123"), "title": "with ID"},
+		{"title": "without ID", "date": "2026-08-01T00:00:00Z"},
+	}
+	require.NoError(t, addSignalPrimaryKeys(items))
+	assert.Equal(t, "signal:123", items[0]["_ingestr_id"])
+
+	generated := items[1]["_ingestr_id"]
+	assert.Regexp(t, `^hash:[0-9a-f]{64}$`, generated)
+	delete(items[1], "_ingestr_id")
+	require.NoError(t, addSignalPrimaryKeys(items[1:]))
+	assert.Equal(t, generated, items[1]["_ingestr_id"])
+}
+
+func TestAddScopedPrimaryKeys(t *testing.T) {
+	items := []map[string]any{
+		{"id": json.Number("123"), "name": "matched"},
+		{"name": "unmatched"},
+	}
+	require.NoError(t, addScopedPrimaryKeys(items, 42))
+	assert.Equal(t, "42:id:123", items[0]["_ingestr_id"])
+	assert.Regexp(t, `^42:hash:[0-9a-f]{64}$`, items[1]["_ingestr_id"])
+}
+
+func testSumbleClient(baseURL string) *ingestrhttp.Client {
+	return ingestrhttp.New(
+		ingestrhttp.WithBaseURL(baseURL),
+		ingestrhttp.WithDisableRetry(),
+		ingestrhttp.WithAuth(ingestrhttp.NewBearerAuth("test-key")),
+		ingestrhttp.WithHeaders(map[string]string{"Accept": "application/json", "Content-Type": "application/json"}),
+	)
+}
+
+// Sumble is schema-less, so every column arrives as a JSON-encoded unknown
+// extension array.
+func columnValue(t *testing.T, batch arrow.RecordBatch, name string, row int) string {
+	t.Helper()
+	indices := batch.Schema().FieldIndices(name)
+	require.Len(t, indices, 1, "column %q not found", name)
+
+	column, ok := batch.Column(indices[0]).(array.ExtensionArray)
+	require.True(t, ok, "column %q is not an extension array", name)
+	raw := column.Storage().(*array.String).Value(row)
+
+	var decoded string
+	if err := json.Unmarshal([]byte(raw), &decoded); err == nil {
+		return decoded
+	}
+	return raw
+}
+
+func drain(results <-chan source.RecordBatchResult) ([]arrow.RecordBatch, error) {
+	var batches []arrow.RecordBatch
+	var err error
+	for result := range results {
+		if result.Err != nil && err == nil {
+			err = result.Err
+		}
+		if result.Batch != nil {
+			batches = append(batches, result.Batch)
+		}
+	}
+	return batches, err
+}
+
+// A failing list member fetch must surface the API error rather than racing the
+// close of the results channel with the still-running workers.
+func TestReadListMembersSurfacesWorkerFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if request.URL.Path == "/organization-lists" {
+			_, _ = w.Write([]byte(`{"organization_lists":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6},{"id":7},{"id":8}]}`))
+			return
+		}
+		if request.URL.Path == "/organization-lists/1" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"boom"}`))
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"list_info":{"id":9,"name":"list"},"organizations":[{"id":100,"name":"acme"}]}`))
+	}))
+	defer server.Close()
+
+	connector := NewSumbleSource()
+	connector.client = testSumbleClient(server.URL)
+
+	for i := 0; i < 20; i++ {
+		results, err := connector.read(context.Background(), sumbleReadSpec{table: "organization_list_organizations"}, source.ReadOptions{})
+		require.NoError(t, err)
+		batches, readErr := drain(results)
+		for _, batch := range batches {
+			batch.Release()
+		}
+		require.ErrorContains(t, readErr, "500")
+	}
+}
+
+func TestReadListMembersScopesRowsToTheirList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.Equal(t, "true", request.URL.Query().Get("include_deleted"))
+		_, _ = w.Write([]byte(`{"list_info":{"id":7,"name":"seven"},"organizations":[{"id":100,"name":"acme"}]}`))
+	}))
+	defer server.Close()
+
+	connector := NewSumbleSource()
+	connector.client = testSumbleClient(server.URL)
+
+	results, err := connector.read(context.Background(), sumbleReadSpec{table: "organization_list_organizations", listIDs: []int64{7}}, source.ReadOptions{})
+	require.NoError(t, err)
+	batches, readErr := drain(results)
+	require.NoError(t, readErr)
+	require.Len(t, batches, 1)
+	defer batches[0].Release()
+
+	require.EqualValues(t, 1, batches[0].NumRows())
+	assert.Equal(t, "7:id:100", columnValue(t, batches[0], "_ingestr_id", 0))
+	assert.Equal(t, "7", columnValue(t, batches[0], "organization_list_id", 0))
+	assert.Contains(t, columnValue(t, batches[0], "organization_list", 0), `"name":"seven"`)
+}
+
+func TestPaginateStopsOnShortPage(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		assert.Equal(t, http.MethodPost, request.Method)
+		assert.Equal(t, "/signals", request.URL.Path)
+
+		var body map[string]any
+		decoder := json.NewDecoder(request.Body)
+		decoder.UseNumber()
+		assert.NoError(t, decoder.Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		switch body["offset"].(json.Number).String() {
+		case "0":
+			_, _ = w.Write([]byte(`{"signals":[{"signal_id":1,"date":"2026-08-01T00:00:00Z"},{"signal_id":2,"date":"2026-08-02T00:00:00Z"}]}`))
+		default:
+			_, _ = w.Write([]byte(`{"signals":[{"signal_id":3,"date":"2026-08-03T00:00:00Z"}]}`))
+		}
+	}))
+	defer server.Close()
+
+	connector := NewSumbleSource()
+	connector.client = testSumbleClient(server.URL)
+
+	results, err := connector.read(context.Background(), sumbleReadSpec{table: "signals"}, source.ReadOptions{PageSize: 2})
+	require.NoError(t, err)
+	batches, readErr := drain(results)
+	require.NoError(t, readErr)
+	defer func() {
+		for _, batch := range batches {
+			batch.Release()
+		}
+	}()
+
+	assert.EqualValues(t, 2, requests.Load())
+	total := 0
+	for _, batch := range batches {
+		total += int(batch.NumRows())
+	}
+	assert.Equal(t, 3, total)
+	assert.Equal(t, "signal:1", columnValue(t, batches[0], "_ingestr_id", 0))
+}
+
+// /signals is documented as newest-first, so paging stops once a page falls
+// entirely before the interval start instead of walking the 60-day window.
+func TestSignalsPaginationStopsAtIntervalStart(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+
+		var body map[string]any
+		decoder := json.NewDecoder(request.Body)
+		decoder.UseNumber()
+		assert.NoError(t, decoder.Decode(&body))
+
+		w.Header().Set("Content-Type", "application/json")
+		switch body["offset"].(json.Number).String() {
+		case "0":
+			_, _ = w.Write([]byte(`{"signals":[{"signal_id":1,"date":"2026-08-10T00:00:00Z"},{"signal_id":2,"date":"2026-08-09T00:00:00Z"}]}`))
+		default:
+			_, _ = w.Write([]byte(`{"signals":[{"signal_id":3,"date":"2026-07-01T00:00:00Z"},{"signal_id":4,"date":"2026-06-30T00:00:00Z"}]}`))
+		}
+	}))
+	defer server.Close()
+
+	connector := NewSumbleSource()
+	connector.client = testSumbleClient(server.URL)
+
+	start := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	results, err := connector.read(context.Background(), sumbleReadSpec{table: "signals"}, source.ReadOptions{PageSize: 2, IntervalStart: &start})
+	require.NoError(t, err)
+	batches, readErr := drain(results)
+	require.NoError(t, readErr)
+	defer func() {
+		for _, batch := range batches {
+			batch.Release()
+		}
+	}()
+
+	assert.EqualValues(t, 2, requests.Load())
+	total := 0
+	for _, batch := range batches {
+		total += int(batch.NumRows())
+	}
+	assert.Equal(t, 2, total)
+}
+
+// Sumble caps offset at 10,000, so the last page starts there and paging stops.
+func TestPaginationStopsAtOffsetLimit(t *testing.T) {
+	var requests atomic.Int32
+	lastOffset := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+
+		var body map[string]any
+		decoder := json.NewDecoder(request.Body)
+		decoder.UseNumber()
+		assert.NoError(t, decoder.Decode(&body))
+		lastOffset = body["offset"].(json.Number).String()
+
+		rows := make([]string, 0, maxPageSize)
+		for i := 0; i < maxPageSize; i++ {
+			rows = append(rows, `{"id":1}`)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"priority_signals":[` + strings.Join(rows, ",") + `]}`))
+	}))
+	defer server.Close()
+
+	connector := NewSumbleSource()
+	connector.client = testSumbleClient(server.URL)
+
+	results, err := connector.read(context.Background(), sumbleReadSpec{table: "priority_signals"}, source.ReadOptions{})
+	require.NoError(t, err)
+	batches, readErr := drain(results)
+	for _, batch := range batches {
+		batch.Release()
+	}
+	require.NoError(t, readErr)
+
+	assert.EqualValues(t, maxOffset/maxPageSize+1, requests.Load())
+	assert.Equal(t, strconv.Itoa(maxOffset), lastOffset)
+}

--- a/pkg/source/sumble/sumble_test.go
+++ b/pkg/source/sumble/sumble_test.go
@@ -534,3 +534,37 @@ func TestListMembersStopFetchingAtRowLimit(t *testing.T) {
 	assert.Equal(t, 3, total)
 	assert.EqualValues(t, 2, requests.Load())
 }
+
+// Without interval filtering every fetched row counts against the budget, so
+// the last page asks for exactly the rows that are still needed.
+func TestPaginationClampsPageToRowLimit(t *testing.T) {
+	var limits []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		var body map[string]any
+		decoder := json.NewDecoder(request.Body)
+		decoder.UseNumber()
+		assert.NoError(t, decoder.Decode(&body))
+		limits = append(limits, body["limit"].(json.Number).String())
+
+		rows := make([]string, 0)
+		for i := 0; i < 2; i++ {
+			rows = append(rows, `{"signal_id":1,"date":"2026-08-01T00:00:00Z"}`)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"signals":[` + strings.Join(rows, ",") + `]}`))
+	}))
+	defer server.Close()
+
+	connector := NewSumbleSource()
+	connector.client = testSumbleClient(server.URL)
+
+	results, err := connector.read(context.Background(), sumbleReadSpec{table: "signals"}, source.ReadOptions{PageSize: 2, Limit: 3})
+	require.NoError(t, err)
+	batches, readErr := drain(results)
+	require.NoError(t, readErr)
+	for _, batch := range batches {
+		batch.Release()
+	}
+
+	assert.Equal(t, []string{"2", "1"}, limits)
+}


### PR DESCRIPTION
## What

Adds Sumble as a source, so ingestr can pull organization/contact lists and intent signals from Sumble's v9 API.

## Changes
- `pkg/source/sumble/` — new source with seven tables (`organization_lists`, `organization_list_organizations`, `contact_lists`, `contact_list_people`, `signals`, `priority_signals`, `signal_configs`), offset pagination, per-list parallel fetching, and optional table parameters for filtering.
- `docs/supported-sources/sumble.md` — new docs page covering the URI format, tables, table parameters, API limits, and incremental behavior.
- `README.md`, `docs/.vitepress/config.mjs`, `docs/supported-sources/platforms.md`, `internal/server/connectors.go` — register Sumble in the source lists.

## How to test
1. `make test` (the package has unit and `httptest`-backed tests).
2. `ingestr ingest --source-uri 'sumble://?api_key=<key>' --source-table signals --dest-uri 'duckdb:///sumble.duckdb' --dest-table main.signals`
3. Repeat for the other tables and check the row counts against the Sumble UI.

## Risk & rollback
- **Risk:** low — new source package, no existing code paths change.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues