### PR TITLE
feat(ducklake): support partitioning and sorting

### DIFF
--- a/docs/supported-sources/duckdb.md
+++ b/docs/supported-sources/duckdb.md
@@ -162,6 +162,45 @@ Linux/containers, which must have `ca-certificates` installed.
 
 ---
 
+### DuckLake table layout
+
+The ingest command applies `--partition-by` and `--cluster-by` to DuckLake destination tables.
+As with the other destinations, both options apply to single-table ingests; multi-table runs
+ignore them.
+
+`--partition-by` accepts one date or timestamp column, matching the BigQuery destination's
+interface. Date columns use identity partitioning; timestamp columns are partitioned by
+`year`/`month`/`day`, giving one partition per calendar date:
+
+```bash
+ingestr ingest \
+  --source-uri="postgres://..." \
+  --source-table="public.events" \
+  --dest-uri="ducklake://?..." \
+  --dest-table="analytics.events" \
+  --partition-by="created_at"
+```
+
+For DuckLake, `--cluster-by` defines the table's physical sort order. Columns are sorted
+in the configured order, ascending:
+
+```bash
+--cluster-by="tenant_id,created_at"
+```
+
+Both options need the `ducklake` extension shipped with DuckDB 1.5 or newer. On an older
+cached DuckDB ADBC driver, `--cluster-by` fails with `Unsupported ALTER TABLE type in
+DuckLake`, and a partition specification does not survive the table rename that completes a
+replace run.
+
+An explicit layout is applied before writing, and DuckLake applies a changed partition or
+sort specification to newly written data; a replace/full-refresh writes the complete
+replacement using the requested layout. Omitting an option leaves that part of an existing
+table's layout untouched for incremental strategies, which write into the live table. A
+replace run builds a new table each time, so a layout must be passed on every run to be kept.
+
+---
+
 ### Examples
 
 #### MinIO + DuckDB catalog (local development)

--- a/pkg/destination/destination.go
+++ b/pkg/destination/destination.go
@@ -21,8 +21,8 @@ type PrepareOptions struct {
 	DropFirst              bool
 	PrimaryKeys            []string
 	DeferredPrimaryKeys    []string // PK columns whose constraint is created after loading.
-	PartitionBy            string   // Column to partition by (BigQuery)
-	ClusterBy              []string // Columns to cluster by (BigQuery)
+	PartitionBy            string   // Destination partition specification.
+	ClusterBy              []string // Destination clustering or sort columns.
 	CDCMode                bool     // If true, make non-PK columns nullable for CDC delete handling.
 	CDCKeys                []string // CDC keys kept non-nullable without declaring a table constraint.
 	RequirePrimaryKeyMatch bool     // Require the physical target PK to match PrimaryKeys for CDC merge safety.

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -51,6 +51,16 @@ type DuckDBDestination struct {
 	// runs don't clobber each other.
 	schemas   map[string]*schema.TableSchema
 	schemasMu sync.Mutex
+
+	// onTargetRecreated, when set, runs inside SwapTable's cross-schema branch
+	// after the target is recreated and before the staging rows are copied in.
+	// DuckLake uses it to restore the target's partition/sort layout, which the
+	// plain CREATE TABLE drops and which only applies to rows written after it.
+	onTargetRecreated func(ctx context.Context, stagingTable, targetTable string) error
+
+	// onSchemaEvolvedLocked, when set, runs inside conditional schema evolution's
+	// transaction after its DDL and before the target incarnation is rechecked.
+	onSchemaEvolvedLocked func(ctx context.Context, table string) error
 }
 
 type duckDBManagedCDCRunLease struct {
@@ -798,6 +808,12 @@ func (d *DuckDBDestination) SwapTable(ctx context.Context, opts destination.Swap
 		createSQL := buildCreateTableSQL(destination.QuoteTableName(targetTable), sch.Columns, sch.PrimaryKeys)
 		if err := d.exec(ctx, createSQL); err != nil {
 			return fmt.Errorf("failed to recreate target table: %w", err)
+		}
+
+		if d.onTargetRecreated != nil {
+			if err := d.onTargetRecreated(ctx, stagingTable, targetTable); err != nil {
+				return err
+			}
 		}
 
 		quotedCols := make([]string, len(sch.Columns))

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -57,6 +57,9 @@ type DuckDBDestination struct {
 
 	// onSchemaEvolvedLocked runs inside the conditional evolution transaction.
 	onSchemaEvolvedLocked func(ctx context.Context, table string) error
+
+	// onStagingConsumed releases per-staging-table state after a committed swap.
+	onStagingConsumed func(stagingTable string)
 }
 
 type duckDBManagedCDCRunLease struct {
@@ -844,6 +847,10 @@ func (d *DuckDBDestination) SwapTable(ctx context.Context, opts destination.Swap
 		return fmt.Errorf("failed to commit swap: %w", err)
 	}
 	commit = true
+
+	if d.onStagingConsumed != nil {
+		d.onStagingConsumed(stagingTable)
+	}
 
 	config.Debug("[DUCKDB] Table swap completed in %v", time.Since(startSwap))
 	return nil

--- a/pkg/destination/duckdb/duckdb.go
+++ b/pkg/destination/duckdb/duckdb.go
@@ -52,14 +52,10 @@ type DuckDBDestination struct {
 	schemas   map[string]*schema.TableSchema
 	schemasMu sync.Mutex
 
-	// onTargetRecreated, when set, runs inside SwapTable's cross-schema branch
-	// after the target is recreated and before the staging rows are copied in.
-	// DuckLake uses it to restore the target's partition/sort layout, which the
-	// plain CREATE TABLE drops and which only applies to rows written after it.
+	// onTargetRecreated preserves destination metadata during cross-schema swaps.
 	onTargetRecreated func(ctx context.Context, stagingTable, targetTable string) error
 
-	// onSchemaEvolvedLocked, when set, runs inside conditional schema evolution's
-	// transaction after its DDL and before the target incarnation is rechecked.
+	// onSchemaEvolvedLocked runs inside the conditional evolution transaction.
 	onSchemaEvolvedLocked func(ctx context.Context, table string) error
 }
 

--- a/pkg/destination/duckdb/evolve.go
+++ b/pkg/destination/duckdb/evolve.go
@@ -52,6 +52,11 @@ func (d *DuckDBDestination) ApplySchemaEvolutionIfIncarnation(
 			return warnings, "", fmt.Errorf("apply schema evolution: %s: %w", statement, err)
 		}
 	}
+	if d.onSchemaEvolvedLocked != nil {
+		if err := d.onSchemaEvolvedLocked(ctx, table); err != nil {
+			return warnings, "", err
+		}
+	}
 	result, exists, err := d.cdcTargetIncarnationLocked(ctx, table)
 	if err != nil {
 		return warnings, "", err

--- a/pkg/destination/duckdb/lakehouse.go
+++ b/pkg/destination/duckdb/lakehouse.go
@@ -25,9 +25,7 @@ type DuckLakeDestination struct {
 	// or targets whose names sanitize identically.
 	stageSeq atomic.Uint64
 
-	// layouts records the partition/sort spec each prepared table was given,
-	// keyed by the fully-qualified opts.Table name, so SwapTable can restore it
-	// on the target when the swap recreates the table rather than renaming it.
+	// layouts tracks prepared table layouts for swap replay.
 	layouts        map[string]duckLakeTableLayout
 	pendingLayouts map[string]struct{}
 	layoutsMu      sync.Mutex
@@ -98,18 +96,12 @@ func (d *DuckLakeDestination) ApplySchemaEvolutionIfIncarnation(
 	return warnings, resultIncarnation, nil
 }
 
-// reapplyLayoutOnSwap restores the staging table's layout on a target that
-// SwapTable recreated instead of renaming into place. DuckLake only applies a
-// partition or sort spec to files written after the ALTER, so this has to run
-// before the swap copies the rows in — hence the hook rather than a SwapTable
-// override. The rename path needs nothing: DuckLake carries both specs across
-// ALTER TABLE ... RENAME TO.
+// reapplyLayoutOnSwap configures a recreated target before rows are copied in.
 func (d *DuckLakeDestination) reapplyLayoutOnSwap(ctx context.Context, stagingTable, targetTable string) error {
 	return d.execLayoutStatements(ctx, targetTable, d.layoutForSwap(stagingTable, targetTable), false)
 }
 
-// layoutForSwap reports the DDL the swap must replay on targetTable: the layout
-// recorded for the staging table being swapped in.
+// layoutForSwap replays the staging layout against the target table.
 func (d *DuckLakeDestination) layoutForSwap(stagingTable, targetTable string) []duckLakeLayoutStatement {
 	layout, ok := d.lookupLayout(stagingTable)
 	if !ok {
@@ -121,8 +113,7 @@ func (d *DuckLakeDestination) layoutForSwap(stagingTable, targetTable string) []
 func (d *DuckLakeDestination) rememberLayout(table string, layout duckLakeTableLayout) {
 	d.layoutsMu.Lock()
 	defer d.layoutsMu.Unlock()
-	// An empty layout clears any spec recorded for the same name by an earlier
-	// run, so a run without layout flags never resurrects the previous one.
+	// An empty layout clears any spec recorded by an earlier run.
 	if layout.empty() {
 		delete(d.layouts, table)
 		delete(d.pendingLayouts, table)

--- a/pkg/destination/duckdb/lakehouse.go
+++ b/pkg/destination/duckdb/lakehouse.go
@@ -35,6 +35,7 @@ func NewDuckLakeDestination() *DuckLakeDestination {
 	d := &DuckLakeDestination{DuckDBDestination: NewDuckDBDestination()}
 	d.onTargetRecreated = d.reapplyLayoutOnSwap
 	d.onSchemaEvolvedLocked = d.execPendingLayoutLocked
+	d.onStagingConsumed = d.forgetLayout
 	return d
 }
 
@@ -123,6 +124,15 @@ func (d *DuckLakeDestination) rememberLayout(table string, layout duckLakeTableL
 		d.layouts = make(map[string]duckLakeTableLayout)
 	}
 	d.layouts[table] = layout
+}
+
+// forgetLayout drops a table's recorded layout once its staging table is gone,
+// so long-lived destinations don't accumulate stale per-run entries.
+func (d *DuckLakeDestination) forgetLayout(table string) {
+	d.layoutsMu.Lock()
+	defer d.layoutsMu.Unlock()
+	delete(d.layouts, table)
+	delete(d.pendingLayouts, table)
 }
 
 func (d *DuckLakeDestination) markLayoutPending(table string) {

--- a/pkg/destination/duckdb/lakehouse.go
+++ b/pkg/destination/duckdb/lakehouse.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
 	srcduckdb "github.com/bruin-data/ingestr/pkg/source/duckdb"
 )
@@ -23,10 +24,20 @@ type DuckLakeDestination struct {
 	// stageSeq makes each staging table name unique, even for the same target
 	// or targets whose names sanitize identically.
 	stageSeq atomic.Uint64
+
+	// layouts records the partition/sort spec each prepared table was given,
+	// keyed by the fully-qualified opts.Table name, so SwapTable can restore it
+	// on the target when the swap recreates the table rather than renaming it.
+	layouts        map[string]duckLakeTableLayout
+	pendingLayouts map[string]struct{}
+	layoutsMu      sync.Mutex
 }
 
 func NewDuckLakeDestination() *DuckLakeDestination {
-	return &DuckLakeDestination{DuckDBDestination: NewDuckDBDestination()}
+	d := &DuckLakeDestination{DuckDBDestination: NewDuckDBDestination()}
+	d.onTargetRecreated = d.reapplyLayoutOnSwap
+	d.onSchemaEvolvedLocked = d.execPendingLayoutLocked
+	return d
 }
 
 func (d *DuckLakeDestination) Schemes() []string { return []string{"ducklake"} }
@@ -36,6 +47,141 @@ func (d *DuckLakeDestination) GetScheme() string { return "ducklake" }
 // leasing is rejected the same way the MotherDuck path is.
 func (d *DuckLakeDestination) AcquireManagedCDCRunLease(context.Context, string) (source.ConnectorLease, error) {
 	return nil, fmt.Errorf("DuckLake does not support local managed CDC run leases")
+}
+
+func (d *DuckLakeDestination) PrepareTable(ctx context.Context, opts destination.PrepareOptions) error {
+	layout, err := buildDuckLakeTableLayout(opts)
+	if err != nil {
+		return err
+	}
+	if err := d.DuckDBDestination.PrepareTable(ctx, opts); err != nil {
+		return err
+	}
+	d.rememberLayout(opts.Table, layout)
+	if layout.empty() {
+		return nil
+	}
+
+	d.markLayoutPending(opts.Table)
+	preparedSchema, err := d.DuckDBDestination.GetTableSchema(ctx, opts.Table)
+	if err != nil {
+		return fmt.Errorf("ducklake: inspect table before applying layout: %w", err)
+	}
+	if !duckLakeLayoutAppliesToSchema(layout, preparedSchema) {
+		return nil
+	}
+	return d.applyPendingLayout(ctx, opts.Table)
+}
+
+func (d *DuckLakeDestination) ApplySchemaEvolution(ctx context.Context, table string, comparison *schemaevolution.SchemaComparison) ([]string, error) {
+	warnings, err := d.DuckDBDestination.ApplySchemaEvolution(ctx, table, comparison)
+	if err != nil {
+		return warnings, err
+	}
+	if err := d.applyPendingLayout(ctx, table); err != nil {
+		return warnings, err
+	}
+	return warnings, nil
+}
+
+func (d *DuckLakeDestination) ApplySchemaEvolutionIfIncarnation(
+	ctx context.Context,
+	table string,
+	comparison *schemaevolution.SchemaComparison,
+	expectedIncarnation string,
+) ([]string, string, error) {
+	warnings, resultIncarnation, err := d.DuckDBDestination.ApplySchemaEvolutionIfIncarnation(ctx, table, comparison, expectedIncarnation)
+	if err != nil {
+		return warnings, resultIncarnation, err
+	}
+	d.clearPendingLayout(table)
+	return warnings, resultIncarnation, nil
+}
+
+// reapplyLayoutOnSwap restores the staging table's layout on a target that
+// SwapTable recreated instead of renaming into place. DuckLake only applies a
+// partition or sort spec to files written after the ALTER, so this has to run
+// before the swap copies the rows in — hence the hook rather than a SwapTable
+// override. The rename path needs nothing: DuckLake carries both specs across
+// ALTER TABLE ... RENAME TO.
+func (d *DuckLakeDestination) reapplyLayoutOnSwap(ctx context.Context, stagingTable, targetTable string) error {
+	return d.execLayoutStatements(ctx, targetTable, d.layoutForSwap(stagingTable, targetTable), false)
+}
+
+// layoutForSwap reports the DDL the swap must replay on targetTable: the layout
+// recorded for the staging table being swapped in.
+func (d *DuckLakeDestination) layoutForSwap(stagingTable, targetTable string) []duckLakeLayoutStatement {
+	layout, ok := d.lookupLayout(stagingTable)
+	if !ok {
+		return nil
+	}
+	return duckLakeLayoutStatements(targetTable, layout)
+}
+
+func (d *DuckLakeDestination) rememberLayout(table string, layout duckLakeTableLayout) {
+	d.layoutsMu.Lock()
+	defer d.layoutsMu.Unlock()
+	// An empty layout clears any spec recorded for the same name by an earlier
+	// run, so a run without layout flags never resurrects the previous one.
+	if layout.empty() {
+		delete(d.layouts, table)
+		delete(d.pendingLayouts, table)
+		return
+	}
+	if d.layouts == nil {
+		d.layouts = make(map[string]duckLakeTableLayout)
+	}
+	d.layouts[table] = layout
+}
+
+func (d *DuckLakeDestination) markLayoutPending(table string) {
+	d.layoutsMu.Lock()
+	defer d.layoutsMu.Unlock()
+	if d.pendingLayouts == nil {
+		d.pendingLayouts = make(map[string]struct{})
+	}
+	d.pendingLayouts[table] = struct{}{}
+}
+
+func (d *DuckLakeDestination) applyPendingLayout(ctx context.Context, table string) error {
+	layout, pending := d.pendingLayout(table)
+	if !pending {
+		return nil
+	}
+	if err := d.applyTableLayout(ctx, table, layout); err != nil {
+		return err
+	}
+	d.clearPendingLayout(table)
+	return nil
+}
+
+func (d *DuckLakeDestination) execPendingLayoutLocked(ctx context.Context, table string) error {
+	layout, pending := d.pendingLayout(table)
+	if !pending {
+		return nil
+	}
+	return d.execTableLayout(ctx, table, layout)
+}
+
+func (d *DuckLakeDestination) pendingLayout(table string) (duckLakeTableLayout, bool) {
+	d.layoutsMu.Lock()
+	defer d.layoutsMu.Unlock()
+	layout, remembered := d.layouts[table]
+	_, pending := d.pendingLayouts[table]
+	return layout, remembered && pending
+}
+
+func (d *DuckLakeDestination) clearPendingLayout(table string) {
+	d.layoutsMu.Lock()
+	defer d.layoutsMu.Unlock()
+	delete(d.pendingLayouts, table)
+}
+
+func (d *DuckLakeDestination) lookupLayout(table string) (duckLakeTableLayout, bool) {
+	d.layoutsMu.Lock()
+	defer d.layoutsMu.Unlock()
+	layout, ok := d.layouts[table]
+	return layout, ok
 }
 
 // Write and WriteParallel stage the Arrow stream in a regular in-memory DuckDB

--- a/pkg/destination/duckdb/lakehouse.go
+++ b/pkg/destination/duckdb/lakehouse.go
@@ -63,7 +63,7 @@ func (d *DuckLakeDestination) PrepareTable(ctx context.Context, opts destination
 	}
 
 	d.markLayoutPending(opts.Table)
-	preparedSchema, err := d.DuckDBDestination.GetTableSchema(ctx, opts.Table)
+	preparedSchema, err := d.GetTableSchema(ctx, opts.Table)
 	if err != nil {
 		return fmt.Errorf("ducklake: inspect table before applying layout: %w", err)
 	}

--- a/pkg/destination/duckdb/lakehouse_layout.go
+++ b/pkg/destination/duckdb/lakehouse_layout.go
@@ -1,0 +1,315 @@
+package duckdb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	srcduckdb "github.com/bruin-data/ingestr/pkg/source/duckdb"
+)
+
+type duckLakeTableLayout struct {
+	partitionSet    bool
+	partitionColumn string
+	partitionByDay  bool
+	sortSet         bool
+	sortColumns     []string
+}
+
+func (l duckLakeTableLayout) empty() bool {
+	return !l.partitionSet && !l.sortSet
+}
+
+func buildDuckLakeTableLayout(opts destination.PrepareOptions) (duckLakeTableLayout, error) {
+	requestedSort := make([]string, 0, len(opts.ClusterBy))
+	for _, requested := range opts.ClusterBy {
+		if strings.TrimSpace(requested) != "" {
+			requestedSort = append(requestedSort, requested)
+		}
+	}
+	layout := duckLakeTableLayout{
+		partitionSet: strings.TrimSpace(opts.PartitionBy) != "",
+		sortSet:      len(requestedSort) > 0,
+	}
+	if layout.empty() {
+		return layout, nil
+	}
+	if opts.Schema == nil {
+		return layout, fmt.Errorf("ducklake: schema is required to configure table layout")
+	}
+
+	if layout.partitionSet {
+		column, err := resolveDuckLakeLayoutColumn(opts.Schema, opts.PartitionBy)
+		if err != nil {
+			return layout, err
+		}
+		switch column.DataType {
+		case schema.TypeDate:
+		case schema.TypeTimestamp, schema.TypeTimestampTZ:
+			layout.partitionByDay = true
+		default:
+			return layout, fmt.Errorf("ducklake: partition column %q must be a date or timestamp, got %s", column.Name, column.DataType)
+		}
+		layout.partitionColumn = column.Name
+	}
+
+	if layout.sortSet {
+		layout.sortColumns = make([]string, len(requestedSort))
+		for i, requested := range requestedSort {
+			column, err := resolveDuckLakeLayoutColumn(opts.Schema, requested)
+			if err != nil {
+				return layout, err
+			}
+			layout.sortColumns[i] = column.Name
+		}
+	}
+
+	return layout, nil
+}
+
+func resolveDuckLakeLayoutColumn(tableSchema *schema.TableSchema, requested string) (schema.Column, error) {
+	requested = strings.TrimSpace(requested)
+	for _, column := range tableSchema.Columns {
+		if column.Name == requested || duckDBIdentifierKey(column.Name) == duckDBIdentifierKey(requested) {
+			return column, nil
+		}
+	}
+	return schema.Column{}, fmt.Errorf("ducklake: layout column %q does not exist in the destination schema", requested)
+}
+
+func duckLakeLayoutAppliesToSchema(layout duckLakeTableLayout, tableSchema *schema.TableSchema) bool {
+	if tableSchema == nil {
+		return false
+	}
+	if layout.partitionSet {
+		column, err := resolveDuckLakeLayoutColumn(tableSchema, layout.partitionColumn)
+		if err != nil {
+			return false
+		}
+		if layout.partitionByDay && column.DataType != schema.TypeDate && column.DataType != schema.TypeTimestamp && column.DataType != schema.TypeTimestampTZ {
+			return false
+		}
+	}
+	for _, column := range layout.sortColumns {
+		if _, err := resolveDuckLakeLayoutColumn(tableSchema, column); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func (d *DuckLakeDestination) applyTableLayout(ctx context.Context, table string, layout duckLakeTableLayout) error {
+	if layout.empty() {
+		return nil
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if err := d.exec(ctx, "BEGIN"); err != nil {
+		return fmt.Errorf("ducklake: begin table layout transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = d.exec(context.WithoutCancel(ctx), "ROLLBACK")
+		}
+	}()
+
+	if err := d.execTableLayout(ctx, table, layout); err != nil {
+		return err
+	}
+
+	if err := d.exec(ctx, "COMMIT"); err != nil {
+		return fmt.Errorf("ducklake: commit table layout transaction: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+type duckLakeLayoutStatement struct {
+	kind        string
+	sql         string
+	sortColumns []string
+}
+
+func duckLakeLayoutStatements(table string, layout duckLakeTableLayout) []duckLakeLayoutStatement {
+	stmts := make([]duckLakeLayoutStatement, 0, 2)
+	if layout.partitionSet {
+		stmts = append(stmts, duckLakeLayoutStatement{
+			kind: "partition",
+			sql:  buildDuckLakePartitionSQL(table, layout.partitionColumn, layout.partitionByDay),
+		})
+	}
+	if layout.sortSet {
+		stmts = append(stmts, duckLakeLayoutStatement{
+			kind:        "sort",
+			sql:         buildDuckLakeSortSQL(table, layout.sortColumns),
+			sortColumns: layout.sortColumns,
+		})
+	}
+	return stmts
+}
+
+// execTableLayout issues the layout DDL. Callers own d.mu and the surrounding
+// transaction.
+func (d *DuckLakeDestination) execTableLayout(ctx context.Context, table string, layout duckLakeTableLayout) error {
+	return d.execLayoutStatements(ctx, table, duckLakeLayoutStatements(table, layout), true)
+}
+
+func (d *DuckLakeDestination) execLayoutStatements(ctx context.Context, table string, stmts []duckLakeLayoutStatement, skipMatchingSort bool) error {
+	for _, stmt := range stmts {
+		if stmt.kind == "sort" && skipMatchingSort {
+			matches, err := d.currentSortLayoutMatches(ctx, table, stmt.sortColumns)
+			if err != nil {
+				config.Debug("[DUCKLAKE] Could not inspect current sort layout for %s: %v", table, err)
+			} else if matches {
+				config.Debug("[DUCKLAKE] Sort layout already matches for %s", table)
+				continue
+			}
+		}
+		config.Debug("[DUCKLAKE] Applying %s layout: %s", stmt.kind, stmt.sql)
+		if err := d.exec(ctx, stmt.sql); err != nil {
+			if stmt.kind == "sort" && strings.Contains(err.Error(), "Unsupported ALTER TABLE type") {
+				return fmt.Errorf("ducklake: apply sort layout to %s: %w (SET SORTED BY requires the ducklake extension shipped with DuckDB 1.5 or newer)", table, err)
+			}
+			return fmt.Errorf("ducklake: apply %s layout to %s: %w", stmt.kind, table, err)
+		}
+	}
+	return nil
+}
+
+type duckLakeSortExpression struct {
+	expression string
+	direction  string
+	nullOrder  string
+}
+
+func (d *DuckLakeDestination) currentSortLayoutMatches(ctx context.Context, table string, expected []string) (bool, error) {
+	if len(expected) == 0 {
+		return false, nil
+	}
+	tn := duckTable(table)
+	schemaName := tn.Schema
+	if schemaName == "" {
+		schemaName = "main"
+	}
+	metadataCatalog := destination.QuoteIdentifier("__ducklake_metadata_" + srcduckdb.AttachAlias)
+	query := fmt.Sprintf(`
+		SELECT expression.expression, expression.sort_direction, expression.null_order
+		FROM %s.main.ducklake_sort_info AS info
+		JOIN %s.main.ducklake_sort_expression AS expression
+		  ON expression.sort_id = info.sort_id AND expression.table_id = info.table_id
+		JOIN %s.main.ducklake_table AS tbl ON tbl.table_id = info.table_id
+		JOIN %s.main.ducklake_schema AS sch ON sch.schema_id = tbl.schema_id
+		WHERE info.end_snapshot IS NULL
+		  AND tbl.end_snapshot IS NULL
+		  AND sch.end_snapshot IS NULL
+		  AND tbl.table_name = %s
+		  AND sch.schema_name = %s
+		ORDER BY sort_key_index`,
+		metadataCatalog, metadataCatalog, metadataCatalog, metadataCatalog,
+		duckLakeStringLiteral(tn.Table), duckLakeStringLiteral(schemaName),
+	)
+	stmt, err := d.conn.NewStatement()
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = stmt.Close() }()
+	if err := stmt.SetSqlQuery(query); err != nil {
+		return false, err
+	}
+	reader, _, err := stmt.ExecuteQuery(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer reader.Release()
+
+	var actual []duckLakeSortExpression
+	for reader.Next() {
+		batch := reader.RecordBatch()
+		expressions, expressionsOK := batch.Column(0).(*array.String)
+		directions, directionsOK := batch.Column(1).(*array.String)
+		nullOrders, nullOrdersOK := batch.Column(2).(*array.String)
+		if !expressionsOK || !directionsOK || !nullOrdersOK {
+			return false, fmt.Errorf("ducklake: unexpected sort metadata types")
+		}
+		for row := 0; row < int(batch.NumRows()); row++ {
+			actual = append(actual, duckLakeSortExpression{
+				expression: strings.Clone(expressions.Value(row)),
+				direction:  strings.Clone(directions.Value(row)),
+				nullOrder:  strings.Clone(nullOrders.Value(row)),
+			})
+		}
+	}
+	if err := reader.Err(); err != nil {
+		return false, err
+	}
+	return duckLakeSortLayoutMatches(expected, actual), nil
+}
+
+func duckLakeSortLayoutMatches(expected []string, actual []duckLakeSortExpression) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	for i, column := range expected {
+		actualColumn, ok := duckLakeSortExpressionColumn(actual[i].expression)
+		if !ok || duckDBIdentifierKey(column) != duckDBIdentifierKey(actualColumn) || actual[i].direction != "ASC" || actual[i].nullOrder != "NULLS_LAST" {
+			return false
+		}
+	}
+	return true
+}
+
+func duckLakeSortExpressionColumn(expression string) (string, bool) {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return "", false
+	}
+	if expression[0] != '"' {
+		return expression, !strings.ContainsAny(expression, " \t\r\n.()")
+	}
+
+	var column strings.Builder
+	for i := 1; i < len(expression); i++ {
+		if expression[i] != '"' {
+			column.WriteByte(expression[i])
+			continue
+		}
+		if i+1 < len(expression) && expression[i+1] == '"' {
+			column.WriteByte('"')
+			i++
+			continue
+		}
+		return column.String(), i == len(expression)-1
+	}
+	return "", false
+}
+
+func duckLakeStringLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
+// buildDuckLakePartitionSQL partitions timestamps by year/month/day rather than
+// day() alone: DuckLake's day() extracts the day of the month, so on its own it
+// would collapse every month and year into the same 31 partitions.
+func buildDuckLakePartitionSQL(table, column string, byDay bool) string {
+	quoted := destination.QuoteIdentifier(column)
+	expression := quoted
+	if byDay {
+		expression = fmt.Sprintf("year(%s), month(%s), day(%s)", quoted, quoted, quoted)
+	}
+	return fmt.Sprintf("ALTER TABLE %s SET PARTITIONED BY (%s)", destination.QuoteTableName(table), expression)
+}
+
+func buildDuckLakeSortSQL(table string, columns []string) string {
+	expressions := make([]string, len(columns))
+	for i, column := range columns {
+		expressions[i] = destination.QuoteIdentifier(column) + " ASC"
+	}
+	return fmt.Sprintf("ALTER TABLE %s SET SORTED BY (%s)", destination.QuoteTableName(table), strings.Join(expressions, ", "))
+}

--- a/pkg/destination/duckdb/lakehouse_test.go
+++ b/pkg/destination/duckdb/lakehouse_test.go
@@ -1,8 +1,13 @@
 package duckdb
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDuckLakeMemStageName(t *testing.T) {
@@ -44,4 +49,196 @@ func TestDuckLakeMemStageName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildDuckLakeTableLayout(t *testing.T) {
+	t.Parallel()
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "tenant_id", DataType: schema.TypeInt64},
+		{Name: "created_at", DataType: schema.TypeTimestamp},
+	}}
+	layout, err := buildDuckLakeTableLayout(destination.PrepareOptions{
+		Schema:      tableSchema,
+		PartitionBy: "created_at",
+		ClusterBy:   []string{"tenant_id", "created_at"},
+	})
+	require.NoError(t, err)
+	require.True(t, layout.partitionSet)
+	require.Equal(t, "created_at", layout.partitionColumn)
+	require.True(t, layout.partitionByDay)
+	require.True(t, layout.sortSet)
+	require.Equal(t, []string{"tenant_id", "created_at"}, layout.sortColumns)
+	require.Equal(t,
+		`ALTER TABLE "analytics"."events" SET PARTITIONED BY (year("created_at"), month("created_at"), day("created_at"))`,
+		buildDuckLakePartitionSQL("analytics.events", layout.partitionColumn, layout.partitionByDay),
+	)
+	require.Equal(t,
+		`ALTER TABLE "analytics"."events" SET SORTED BY ("tenant_id" ASC, "created_at" ASC)`,
+		buildDuckLakeSortSQL("analytics.events", layout.sortColumns),
+	)
+}
+
+func TestBuildDuckLakeTableLayoutUsesIdentityForDate(t *testing.T) {
+	t.Parallel()
+	layout, err := buildDuckLakeTableLayout(destination.PrepareOptions{
+		Schema: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "event_date", DataType: schema.TypeDate},
+		}},
+		PartitionBy: "event_date",
+	})
+	require.NoError(t, err)
+	require.False(t, layout.partitionByDay)
+	require.Equal(t,
+		`ALTER TABLE "events" SET PARTITIONED BY ("event_date")`,
+		buildDuckLakePartitionSQL("events", layout.partitionColumn, layout.partitionByDay),
+	)
+}
+
+func TestBuildDuckLakeTableLayoutValidatesColumns(t *testing.T) {
+	t.Parallel()
+	tableSchema := &schema.TableSchema{Columns: []schema.Column{
+		{Name: "created_at", DataType: schema.TypeTimestamp},
+		{Name: "label", DataType: schema.TypeString},
+	}}
+	tests := []struct {
+		name string
+		opts destination.PrepareOptions
+		want string
+	}{
+		{
+			name: "missing partition column",
+			opts: destination.PrepareOptions{Schema: tableSchema, PartitionBy: "missing"},
+			want: `layout column "missing" does not exist`,
+		},
+		{
+			name: "partition requires temporal column",
+			opts: destination.PrepareOptions{Schema: tableSchema, PartitionBy: "label"},
+			want: `partition column "label" must be a date or timestamp, got string`,
+		},
+		{
+			name: "missing sort column",
+			opts: destination.PrepareOptions{Schema: tableSchema, ClusterBy: []string{"missing"}},
+			want: `layout column "missing" does not exist`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := buildDuckLakeTableLayout(tt.opts)
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func TestBuildDuckLakeTableLayoutResolvesColumnsLeniently(t *testing.T) {
+	t.Parallel()
+	layout, err := buildDuckLakeTableLayout(destination.PrepareOptions{
+		Schema: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "tenant_id", DataType: schema.TypeInt64},
+			{Name: "created_at", DataType: schema.TypeTimestampTZ},
+		}},
+		PartitionBy: "Created_At",
+		ClusterBy:   []string{" tenant_id ", "", "  "},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "created_at", layout.partitionColumn)
+	require.True(t, layout.partitionByDay)
+	require.Equal(t, []string{"tenant_id"}, layout.sortColumns)
+}
+
+func TestBuildDuckLakeTableLayoutIgnoresBlankRequests(t *testing.T) {
+	t.Parallel()
+	layout, err := buildDuckLakeTableLayout(destination.PrepareOptions{
+		PartitionBy: "   ",
+		ClusterBy:   []string{"", " "},
+	})
+	require.NoError(t, err)
+	require.True(t, layout.empty())
+}
+
+func TestBuildDuckLakeTableLayoutRequiresSchema(t *testing.T) {
+	t.Parallel()
+	_, err := buildDuckLakeTableLayout(destination.PrepareOptions{PartitionBy: "created_at"})
+	require.ErrorContains(t, err, "schema is required")
+}
+
+func TestDuckLakeLayoutAppliesToPreparedSchema(t *testing.T) {
+	t.Parallel()
+	layout := duckLakeTableLayout{
+		partitionSet:    true,
+		partitionColumn: "created_at",
+		partitionByDay:  true,
+		sortSet:         true,
+		sortColumns:     []string{"tenant_id", "created_at"},
+	}
+	require.False(t, duckLakeLayoutAppliesToSchema(layout, &schema.TableSchema{Columns: []schema.Column{
+		{Name: "tenant_id", DataType: schema.TypeInt64},
+	}}))
+	require.False(t, duckLakeLayoutAppliesToSchema(layout, &schema.TableSchema{Columns: []schema.Column{
+		{Name: "tenant_id", DataType: schema.TypeInt64},
+		{Name: "created_at", DataType: schema.TypeString},
+	}}))
+	require.True(t, duckLakeLayoutAppliesToSchema(layout, &schema.TableSchema{Columns: []schema.Column{
+		{Name: "tenant_id", DataType: schema.TypeInt64},
+		{Name: "created_at", DataType: schema.TypeTimestamp},
+	}}))
+}
+
+func TestDuckLakeSortLayoutMatches(t *testing.T) {
+	t.Parallel()
+	expected := []string{"tenant_id", "created_at"}
+	require.True(t, duckLakeSortLayoutMatches(expected, []duckLakeSortExpression{
+		{expression: "tenant_id", direction: "ASC", nullOrder: "NULLS_LAST"},
+		{expression: "created_at", direction: "ASC", nullOrder: "NULLS_LAST"},
+	}))
+	require.False(t, duckLakeSortLayoutMatches(expected, []duckLakeSortExpression{
+		{expression: "tenant_id", direction: "DESC", nullOrder: "NULLS_LAST"},
+		{expression: "created_at", direction: "ASC", nullOrder: "NULLS_LAST"},
+	}))
+	require.False(t, duckLakeSortLayoutMatches(expected, []duckLakeSortExpression{
+		{expression: "tenant_id", direction: "ASC", nullOrder: "NULLS_LAST"},
+	}))
+	require.True(t, duckLakeSortLayoutMatches([]string{"Order Details", `say"hello`}, []duckLakeSortExpression{
+		{expression: `"Order Details"`, direction: "ASC", nullOrder: "NULLS_LAST"},
+		{expression: `"say""hello"`, direction: "ASC", nullOrder: "NULLS_LAST"},
+	}))
+	require.False(t, duckLakeSortLayoutMatches([]string{"created_at"}, []duckLakeSortExpression{
+		{expression: `date_trunc('day', created_at)`, direction: "ASC", nullOrder: "NULLS_LAST"},
+	}))
+}
+
+func TestDuckLakeSwapRestoresLayoutOnRecreatedTarget(t *testing.T) {
+	t.Parallel()
+	d := NewDuckLakeDestination()
+	require.NotNil(t, d.onTargetRecreated, "cross-schema swap must restore the layout before rows are copied in")
+	require.NotNil(t, d.onSchemaEvolvedLocked, "conditional evolution must apply pending layout inside its transaction")
+
+	// No layout recorded for the staging table: the hook must stay out of the way.
+	require.Nil(t, d.layoutForSwap("staging.events", "analytics.events"))
+	require.NoError(t, d.onTargetRecreated(context.Background(), "staging.events", "analytics.events"))
+
+	opts := destination.PrepareOptions{
+		Table: "staging.events",
+		Schema: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "tenant_id", DataType: schema.TypeInt64},
+			{Name: "created_at", DataType: schema.TypeTimestamp},
+		}},
+		PartitionBy: "created_at",
+		ClusterBy:   []string{"tenant_id"},
+	}
+	layout, err := buildDuckLakeTableLayout(opts)
+	require.NoError(t, err)
+	d.rememberLayout(opts.Table, layout)
+
+	// The recorded staging layout must be replayed against the target table.
+	require.Equal(t, []duckLakeLayoutStatement{
+		{kind: "partition", sql: `ALTER TABLE "analytics"."events" SET PARTITIONED BY (year("created_at"), month("created_at"), day("created_at"))`},
+		{kind: "sort", sql: `ALTER TABLE "analytics"."events" SET SORTED BY ("tenant_id" ASC)`, sortColumns: []string{"tenant_id"}},
+	}, d.layoutForSwap("staging.events", "analytics.events"))
+
+	// A later run without layout flags must not resurrect the recorded spec.
+	cleared, err := buildDuckLakeTableLayout(destination.PrepareOptions{Table: opts.Table, Schema: opts.Schema})
+	require.NoError(t, err)
+	d.rememberLayout(opts.Table, cleared)
+	require.Nil(t, d.layoutForSwap("staging.events", "analytics.events"))
 }

--- a/pkg/destination/duckdb/lakehouse_test.go
+++ b/pkg/destination/duckdb/lakehouse_test.go
@@ -242,3 +242,35 @@ func TestDuckLakeSwapRestoresLayoutOnRecreatedTarget(t *testing.T) {
 	d.rememberLayout(opts.Table, cleared)
 	require.Nil(t, d.layoutForSwap("staging.events", "analytics.events"))
 }
+
+func TestDuckLakeForgetsLayoutAfterStagingConsumed(t *testing.T) {
+	t.Parallel()
+	d := NewDuckLakeDestination()
+	require.NotNil(t, d.onStagingConsumed, "committed swap must release the staging layout")
+
+	opts := destination.PrepareOptions{
+		Table: "staging.events",
+		Schema: &schema.TableSchema{Columns: []schema.Column{
+			{Name: "tenant_id", DataType: schema.TypeInt64},
+			{Name: "created_at", DataType: schema.TypeTimestamp},
+		}},
+		PartitionBy: "created_at",
+		ClusterBy:   []string{"tenant_id"},
+	}
+	layout, err := buildDuckLakeTableLayout(opts)
+	require.NoError(t, err)
+	d.rememberLayout(opts.Table, layout)
+	d.markLayoutPending(opts.Table)
+	require.NotNil(t, d.layoutForSwap("staging.events", "analytics.events"))
+
+	// A committed swap consumes and drops the staging table, so its recorded
+	// layout must not linger and accumulate across runs.
+	d.onStagingConsumed(opts.Table)
+	require.Nil(t, d.layoutForSwap("staging.events", "analytics.events"))
+	d.layoutsMu.Lock()
+	_, layoutKept := d.layouts[opts.Table]
+	_, pendingKept := d.pendingLayouts[opts.Table]
+	d.layoutsMu.Unlock()
+	require.False(t, layoutKept)
+	require.False(t, pendingKept)
+}


### PR DESCRIPTION
## What
Adds DuckLake support for `--partition-by` and `--cluster-by`.

## Changes
- Apply and preserve partition/sort layouts across schema evolution and table swaps, while avoiding redundant sort metadata.
- Add layout validation, tests, and documentation.

## How to test
1. Run `make format`, `make lint`, and `make test`.

## Risk & rollback
- **Risk:** Medium; this changes DuckLake table DDL and swap behavior.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.