### PR TITLE
feat(iceberg): support Cloudflare R2 Data Catalog as an Iceberg destination

### DIFF
--- a/docs/supported-sources/iceberg.md
+++ b/docs/supported-sources/iceberg.md
@@ -17,6 +17,7 @@ Supported catalog schemes:
 - `iceberg+sqlite`
 - `iceberg+postgres`
 - `iceberg+rest`
+- `iceberg+r2` for Cloudflare R2 Data Catalog
 - `iceberg+glue`
 - `iceberg+hadoop`
 - `iceberg+hive`
@@ -114,6 +115,24 @@ docker run -d -p 8181:8181 \
   -e AWS_ACCESS_KEY_ID=minioadmin -e AWS_SECRET_ACCESS_KEY=minioadmin -e AWS_REGION=us-east-1 \
   apache/iceberg-rest-fixture
 ```
+:::
+
+### Cloudflare R2 Data Catalog
+
+[R2 Data Catalog](https://developers.cloudflare.com/r2/data-catalog/) is a managed Iceberg REST catalog built into Cloudflare R2. The `iceberg+r2` scheme takes your account ID and bucket and assembles the catalog URI (`https://catalog.cloudflarestorage.com/<account_id>/<bucket>`) and warehouse (`<account_id>_<bucket>`) for you. Pass the R2 API token as `token`:
+
+```bash
+ingestr ingest \
+  --source-uri 'postgresql://user:pass@localhost:5432/app' \
+  --source-table public.orders \
+  --dest-uri 'iceberg+r2://<account_id>/<bucket>?token=<r2_api_token>' \
+  --dest-table analytics.orders \
+  --incremental-strategy replace \
+  --primary-key id
+```
+
+::: info
+The token needs **R2 Data Catalog** and **R2 Storage** read/write permissions. No S3 keys are required — R2 supplies them through the catalog. Get the account ID, bucket, and token from the catalog page after enabling it on your bucket.
 :::
 
 ### AWS Glue catalog

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -293,7 +293,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("arrowstream", "Arrow Stream", []string{"arrow-stream", "arrowstream"}, true, false),
 		genericURIConnector("asana", "Asana", []string{"asana"}, true, false),
 		genericURIConnector("athena", "Amazon Athena", []string{"athena"}, true, true),
-		genericURIConnector("iceberg", "Apache Iceberg", []string{"iceberg", "iceberg+rest", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"}, false, true),
+		genericURIConnector("iceberg", "Apache Iceberg", []string{"iceberg", "iceberg+rest", "iceberg+r2", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"}, false, true),
 		genericURIConnector("attio", "Attio", []string{"attio"}, true, false),
 		genericURIConnector("avro", "Avro File", []string{"avro"}, true, false),
 		genericURIConnector("balldontlie", "balldontlie", []string{"balldontlie"}, true, false),

--- a/pkg/destination/iceberg/config.go
+++ b/pkg/destination/iceberg/config.go
@@ -152,6 +152,8 @@ func applyCatalogShorthand(parsed *url.URL, cfg *icebergConfig) error {
 		if parsed.Host != "" {
 			cfg.Properties["uri"] = catalogHTTPURL(parsed, "rest")
 		}
+	case "iceberg+r2":
+		return applyR2Shorthand(parsed, cfg)
 	case "iceberg+hive":
 		cfg.Properties["type"] = "hive"
 		if parsed.Host != "" {
@@ -171,6 +173,24 @@ func applyCatalogShorthand(parsed *url.URL, cfg *icebergConfig) error {
 			cfg.Properties["type"] = catalogType
 		}
 	}
+	return nil
+}
+
+// applyR2Shorthand maps iceberg+r2://<account_id>/<bucket> to Cloudflare R2 Data
+// Catalog, a managed Iceberg REST catalog. Pass the R2 API token as ?token=; R2
+// vends the S3 storage credentials through the catalog, so none are needed here.
+func applyR2Shorthand(parsed *url.URL, cfg *icebergConfig) error {
+	accountID := parsed.Host
+	bucket := strings.Trim(parsed.Path, "/")
+	if accountID == "" || bucket == "" {
+		return fmt.Errorf("iceberg uri: iceberg+r2 requires an account id and bucket, e.g. iceberg+r2://<account_id>/<bucket>?token=<r2_token>")
+	}
+	if strings.Contains(bucket, "/") {
+		return fmt.Errorf("iceberg uri: iceberg+r2 bucket %q must not contain a path", bucket)
+	}
+	cfg.Properties["type"] = "rest"
+	cfg.Properties["uri"] = fmt.Sprintf("https://catalog.cloudflarestorage.com/%s/%s", accountID, bucket)
+	cfg.Properties["warehouse"] = accountID + "_" + bucket
 	return nil
 }
 

--- a/pkg/destination/iceberg/iceberg.go
+++ b/pkg/destination/iceberg/iceberg.go
@@ -60,7 +60,7 @@ func NewDestination() *Destination {
 }
 
 func (d *Destination) Schemes() []string {
-	return []string{"iceberg", "iceberg+rest", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"}
+	return []string{"iceberg", "iceberg+rest", "iceberg+r2", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"}
 }
 
 func (d *Destination) Connect(ctx context.Context, rawURI string) error {
@@ -631,10 +631,11 @@ func (d *Destination) ensureLocalTableDirs(ident icebergtable.Identifier) error 
 }
 
 func (d *Destination) localTableLocation(ident icebergtable.Identifier) (string, bool) {
+	restCatalog := d.cfg.Properties.Get("type", "") == "rest"
 	if d.cfg.TableLocation != "" {
-		return localFilesystemPath(renderTableLocation(d.cfg.TableLocation, ident))
+		return warehouseLocalPath(renderTableLocation(d.cfg.TableLocation, ident), restCatalog)
 	}
-	warehouse, ok := localFilesystemPath(d.cfg.Properties.Get("warehouse", ""))
+	warehouse, ok := warehouseLocalPath(d.cfg.Properties.Get("warehouse", ""), restCatalog)
 	if !ok || warehouse == "" {
 		return "", false
 	}
@@ -642,18 +643,36 @@ func (d *Destination) localTableLocation(ident icebergtable.Identifier) (string,
 	return filepath.Join(parts...), true
 }
 
+// warehouseLocalPath reports whether a warehouse/table-location value points at
+// the local filesystem. For REST catalogs a scheme-less relative value is a
+// catalog warehouse identifier (e.g. R2's "<account>_<bucket>", or a Glue
+// warehouse), not a path, so only file:// URLs and absolute paths qualify. Other
+// catalog types keep treating any non-URI value as a local path.
+func warehouseLocalPath(location string, restCatalog bool) (string, bool) {
+	if restCatalog {
+		return localFilesystemPath(location)
+	}
+	if location != "" && !strings.Contains(location, "://") {
+		return location, true
+	}
+	return localFilesystemPath(location)
+}
+
 func localFilesystemPath(location string) (string, bool) {
 	if location == "" {
 		return "", false
 	}
-	if !strings.Contains(location, "://") {
-		return location, true
+	if strings.Contains(location, "://") {
+		parsed, err := url.Parse(location)
+		if err != nil || parsed.Scheme != "file" {
+			return "", false
+		}
+		return parsed.Path, parsed.Path != ""
 	}
-	parsed, err := url.Parse(location)
-	if err != nil || parsed.Scheme != "file" {
+	if !filepath.IsAbs(location) {
 		return "", false
 	}
-	return parsed.Path, parsed.Path != ""
+	return location, true
 }
 
 func prepareTableSchema(s *schema.TableSchema, primaryKeys []string) *schema.TableSchema {

--- a/pkg/destination/iceberg/iceberg_test.go
+++ b/pkg/destination/iceberg/iceberg_test.go
@@ -79,6 +79,16 @@ func TestParseIcebergConfigFriendlyURIs(t *testing.T) {
 			},
 		},
 		{
+			name: "r2 data catalog",
+			uri:  "iceberg+r2://abc123/analytics?token=r2-secret",
+			wantProp: map[string]string{
+				"type":      "rest",
+				"uri":       "https://catalog.cloudflarestorage.com/abc123/analytics",
+				"warehouse": "abc123_analytics",
+				"token":     "r2-secret",
+			},
+		},
+		{
 			name: "hive metastore host",
 			uri:  "iceberg+hive://localhost:9083?storage=s3&bucket=warehouse&endpoint=localhost:9000&use_ssl=false",
 			wantProp: map[string]string{
@@ -175,6 +185,64 @@ func TestSqliteCatalogURIBusyTimeout(t *testing.T) {
 	cfg, err = parseIcebergConfig("iceberg+sqlite:///:memory:")
 	require.NoError(t, err)
 	require.Equal(t, ":memory:", cfg.Properties["uri"])
+}
+
+func TestParseIcebergConfigR2RequiresAccountAndBucket(t *testing.T) {
+	_, err := parseIcebergConfig("iceberg+r2://abc123?token=x")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "account id and bucket")
+
+	_, err = parseIcebergConfig("iceberg+r2://abc123/nested/bucket?token=x")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not contain a path")
+}
+
+func TestLocalFilesystemPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		location string
+		wantPath string
+		wantOK   bool
+	}{
+		{"r2 warehouse identifier", "abc123_analytics", "", false},
+		{"glue-style identifier", "my_warehouse", "", false},
+		{"s3 warehouse", "s3://bucket/prefix/", "", false},
+		{"absolute path", "/var/warehouse", "/var/warehouse", true},
+		{"file url", "file:///var/warehouse", "/var/warehouse", true},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, ok := localFilesystemPath(tc.location)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantPath, path)
+		})
+	}
+}
+
+func TestWarehouseLocalPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		location string
+		rest     bool
+		wantPath string
+		wantOK   bool
+	}{
+		{"rest r2 identifier", "abc123_analytics", true, "", false},
+		{"rest absolute warehouse", "/srv/warehouse", true, "/srv/warehouse", true},
+		{"rest s3 warehouse", "s3://bucket/w/", true, "", false},
+		{"local relative warehouse", "relative/warehouse", false, "relative/warehouse", true},
+		{"local absolute warehouse", "/var/warehouse", false, "/var/warehouse", true},
+		{"local file url", "file:///var/warehouse", false, "/var/warehouse", true},
+		{"local s3 warehouse", "s3://bucket/w/", false, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path, ok := warehouseLocalPath(tc.location, tc.rest)
+			require.Equal(t, tc.wantOK, ok)
+			require.Equal(t, tc.wantPath, path)
+		})
+	}
 }
 
 func TestParseIcebergConfigSQLCatalogRequiresDriverDialect(t *testing.T) {

--- a/pkg/destination/iceberg/register.go
+++ b/pkg/destination/iceberg/register.go
@@ -4,7 +4,7 @@ import "github.com/bruin-data/ingestr/internal/registry"
 
 func init() {
 	registry.RegisterDestination(
-		[]string{"iceberg", "iceberg+rest", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"},
+		[]string{"iceberg", "iceberg+rest", "iceberg+r2", "iceberg+glue", "iceberg+hive", "iceberg+hadoop", "iceberg+sql", "iceberg+sqlite", "iceberg+postgres"},
 		func() interface{} { return NewDestination() },
 	)
 }


### PR DESCRIPTION
## Summary

Adds an `iceberg+r2` destination shorthand for [Cloudflare R2 Data Catalog](https://developers.cloudflare.com/r2/data-catalog/), a managed Apache Iceberg REST catalog backed by R2 (BRU-5738).

R2 Data Catalog is a standard Iceberg REST catalog, so this is a thin alias over the existing REST-catalog + vended-credentials path — not a new catalog engine. The shorthand:

```
iceberg+r2://<account_id>/<bucket>?token=<r2_api_token>
```