### PR TITLE
fix(clickhouse): read decimal precision/scale in GetTableSchema via shared mapper

### DIFF
--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -22,6 +22,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	srcclickhouse "github.com/bruin-data/ingestr/pkg/source/clickhouse"
 	"github.com/bruin-data/ingestr/pkg/tablename"
 	"github.com/shopspring/decimal"
 )
@@ -617,36 +618,41 @@ func (d *ClickHouseDestination) GetScheme() string { return "clickhouse" }
 func (d *ClickHouseDestination) GetTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
 	database, tableName := d.parseTableName(table)
 
-	query := fmt.Sprintf("DESCRIBE TABLE %s.%s", quoteIdentifier(database), quoteIdentifier(tableName))
+	query := `
+		SELECT name, type
+		FROM system.columns
+		WHERE database = ? AND table = ?
+		ORDER BY position`
 
-	rows, err := d.conn.Query(ctx, query)
+	rows, err := d.conn.Query(ctx, query, database, tableName)
 	if err != nil {
-		errLower := strings.ToLower(err.Error())
-		if strings.Contains(errLower, "doesn't exist") ||
-			strings.Contains(errLower, "does not exist") ||
-			strings.Contains(errLower, "unknown_table") {
-			return nil, nil
-		}
 		config.LogFailedQuery(query, err)
-		return nil, fmt.Errorf("failed to describe table: %w", err)
+		return nil, fmt.Errorf("failed to read table schema: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
 	var columns []schema.Column
 	for rows.Next() {
-		var colName, colType, defaultType, defaultExpr, comment, codecExpr, ttlExpr string
-
-		if err := rows.Scan(&colName, &colType, &defaultType, &defaultExpr, &comment, &codecExpr, &ttlExpr); err != nil {
+		var colName, colType string
+		if err := rows.Scan(&colName, &colType); err != nil {
 			return nil, fmt.Errorf("failed to scan column: %w", err)
 		}
 
-		col := schema.Column{
-			Name:     colName,
-			DataType: mapClickHouseTypeToSchema(colType),
-			Nullable: strings.HasPrefix(colType, "Nullable("),
+		dataType, precision, scale, arrayType := srcclickhouse.MapClickHouseToDataType(colType)
+		// The shared mapper collapses every DateTime64 to TypeTimestamp, but the
+		// destination writes TypeTimestampTZ as DateTime64(..., 'UTC'); keep that
+		// distinction so a timezone-aware column reads back as it was written.
+		if dataType == schema.TypeTimestamp && strings.Contains(strings.ToUpper(colType), "UTC") {
+			dataType = schema.TypeTimestampTZ
 		}
-
-		columns = append(columns, col)
+		columns = append(columns, schema.Column{
+			Name:      colName,
+			DataType:  dataType,
+			Precision: precision,
+			Scale:     scale,
+			ArrayType: arrayType,
+			Nullable:  strings.Contains(strings.ToLower(colType), "nullable"),
+		})
 	}
 
 	if err := rows.Err(); err != nil {
@@ -662,55 +668,6 @@ func (d *ClickHouseDestination) GetTableSchema(ctx context.Context, table string
 		Schema:  database,
 		Columns: columns,
 	}, nil
-}
-
-func mapClickHouseTypeToSchema(colType string) schema.DataType {
-	if strings.HasPrefix(colType, "Nullable(") {
-		colType = strings.TrimPrefix(colType, "Nullable(")
-		colType = strings.TrimSuffix(colType, ")")
-	}
-
-	if strings.HasPrefix(colType, "Array(") {
-		return schema.TypeArray
-	}
-
-	if strings.HasPrefix(colType, "Decimal") {
-		return schema.TypeDecimal
-	}
-
-	if strings.HasPrefix(colType, "DateTime64") {
-		if strings.Contains(colType, "UTC") {
-			return schema.TypeTimestampTZ
-		}
-		return schema.TypeTimestamp
-	}
-
-	switch colType {
-	case "Bool":
-		return schema.TypeBoolean
-	case "Int8", "UInt8", "Int16":
-		return schema.TypeInt16
-	case "UInt16", "Int32":
-		return schema.TypeInt32
-	case "UInt32", "Int64":
-		return schema.TypeInt64
-	case "UInt64":
-		return schema.TypeInt64
-	case "Float32":
-		return schema.TypeFloat32
-	case "Float64":
-		return schema.TypeFloat64
-	case "String":
-		return schema.TypeString
-	case "Date", "Date32":
-		return schema.TypeDate
-	case "DateTime":
-		return schema.TypeTimestamp
-	case "UUID":
-		return schema.TypeUUID
-	default:
-		return schema.TypeString
-	}
 }
 
 func parseClickHouseURI(uri string) (*clickhouse.Options, string, string, map[string]string, error) {

--- a/pkg/destination/clickhouse/integration_test.go
+++ b/pkg/destination/clickhouse/integration_test.go
@@ -261,6 +261,125 @@ func TestClickHouseDestination_DeleteInsert(t *testing.T) {
 	assert.Equal(t, 1, countClickHouseRowsByID(t, ctx, uri, targetTable, 5))
 }
 
+// Regression: before GetTableSchema read back decimal precision/scale, the
+// destination column came back as Decimal(38, 0). Widening a real Decimal(38, 9)
+// source against that asked for precision 47 and failed every sync after the first.
+func TestClickHouseDestination_MergeDecimalTwice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, uri, err := startClickHouseContainer(ctx)
+	if err != nil {
+		t.Skipf("failed to start ClickHouse container: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	sourceTable := fmt.Sprintf("source_decimal_%d", time.Now().UnixNano())
+	createClickHouseDecimalTable(t, ctx, uri, sourceTable)
+	defer cleanupClickHouseTable(ctx, uri, sourceTable)
+
+	destTable := fmt.Sprintf("%s.dest_decimal_%d", clickhouseDB, time.Now().UnixNano())
+
+	cfg := &config.IngestConfig{
+		SourceURI:           uri,
+		SourceTable:         sourceTable,
+		DestURI:             uri,
+		DestTable:           destTable,
+		IncrementalStrategy: config.StrategyMerge,
+		PrimaryKeys:         []string{"id"},
+	}
+
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "first merge should succeed")
+	require.NoError(t, pipeline.New(cfg).Run(ctx), "second merge must not fail on decimal widening")
+}
+
+func TestClickHouseDestination_GetTableSchemaDecimalAndArray(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	container, uri, err := startClickHouseContainer(ctx)
+	if err != nil {
+		t.Skipf("failed to start ClickHouse container: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	table := fmt.Sprintf("%s.dest_schema_%d", clickhouseDB, time.Now().UnixNano())
+	defer cleanupClickHouseTable(ctx, uri, table)
+
+	opts, err := clickhouse.ParseDSN(uri)
+	require.NoError(t, err)
+	db := clickhouse.OpenDB(opts)
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE %s (
+			id Int64,
+			amount Nullable(Decimal(38, 9)),
+			tags Array(String),
+			created_at Nullable(DateTime64(6, 'UTC')),
+			seen_on Date
+		) ENGINE = MergeTree() ORDER BY id`, table))
+	require.NoError(t, err)
+	_ = db.Close()
+
+	dest := chdest.NewClickHouseDestination()
+	require.NoError(t, dest.Connect(ctx, uri))
+	t.Cleanup(func() { _ = dest.Close(ctx) })
+
+	ts, err := dest.GetTableSchema(ctx, table)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+
+	cols := make(map[string]schema.Column, len(ts.Columns))
+	for _, c := range ts.Columns {
+		cols[c.Name] = c
+	}
+
+	amount := cols["amount"]
+	assert.Equal(t, schema.TypeDecimal, amount.DataType)
+	assert.Equal(t, 38, amount.Precision)
+	assert.Equal(t, 9, amount.Scale)
+	assert.True(t, amount.Nullable)
+
+	tags := cols["tags"]
+	assert.Equal(t, schema.TypeArray, tags.DataType)
+	assert.Equal(t, schema.TypeString, tags.ArrayType)
+
+	createdAt := cols["created_at"]
+	assert.Equal(t, schema.TypeTimestampTZ, createdAt.DataType)
+	assert.True(t, createdAt.Nullable)
+
+	seenOn := cols["seen_on"]
+	assert.Equal(t, schema.TypeDate, seenOn.DataType)
+}
+
+func createClickHouseDecimalTable(t *testing.T, ctx context.Context, uri string, table string) {
+	t.Helper()
+
+	opts, err := clickhouse.ParseDSN(uri)
+	require.NoError(t, err)
+
+	db := clickhouse.OpenDB(opts)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id Int64,
+			amount Decimal(38, 9)
+		) ENGINE = MergeTree()
+		ORDER BY id
+	`, table))
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s VALUES (1, 123.456789), (2, 999.111)", table))
+	require.NoError(t, err)
+}
+
 func setupClickHouseSourceTable(t *testing.T, ctx context.Context, uri string, table string, numRows int) {
 	t.Helper()
 


### PR DESCRIPTION
## What

`ClickHouseDestination.GetTableSchema` left `Precision`/`Scale` unset, so schema evolution
compared a real `Decimal(38, 9)` source column against a phantom `Decimal(38, 0)` and **every
merge/append sync after the first failed** for any table with a decimal column:

```
decimal widening requires precision 47 (integer digits 38 + scale 9),
maximum supported precision is 38
```

## Fix

Read the schema from `system.columns` and reuse the source's existing `MapClickHouseToDataType`
instead of hand-parsing `DESCRIBE` output. This aligns the destination read-back with how the
ClickHouse source already reads schema, removes the duplicated local mapper, and populates
`Precision`, `Scale`, and `ArrayType`. `DateTime64(..., 'UTC')` is kept as `TypeTimestampTZ` so
timezone-aware timestamps round-trip.

`GetTableSchema` is used only for schema-evolution comparison and existence/naming detection; it
does not affect writes, table creation, or row data.