### PR TITLE
Make SQL Server Change Tracking reads consistent

### DIFF
--- a/docs/supported-sources/mssql.md
+++ b/docs/supported-sources/mssql.md
@@ -50,10 +50,15 @@ ALTER DATABASE your_database
 SET CHANGE_TRACKING = ON
 (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON);
 
+ALTER DATABASE your_database
+SET ALLOW_SNAPSHOT_ISOLATION ON;
+
 ALTER TABLE dbo.users
 ENABLE CHANGE_TRACKING
 WITH (TRACK_COLUMNS_UPDATED = OFF);
 ```
+
+Enabling snapshot isolation is recommended: ingestr then reads each change window inside one SNAPSHOT transaction, which is how SQL Server guarantees a consistent change set while retention cleanup runs. Without it, the initial snapshot is taken under a `HOLDLOCK` table lock that blocks writers to the table until the snapshot finishes, and incremental reads run under READ COMMITTED with the cursor re-validated after the read; if cleanup (or a `TRUNCATE TABLE`, which resets a table's tracking) invalidated the cursor mid-read, the run fails and asks for `--full-refresh` instead of loading an incomplete change set.
 
 Change Tracking returns net row changes since the last loaded version. For inserts and updates, ingestr joins the changed primary keys back to the source table and loads the current row. For deletes, SQL Server only returns the primary key, so ingestr marks the destination row as deleted with `_cdc_deleted = true` while preserving existing destination values for other columns. If a row is updated and then deleted between two ingestr runs, Change Tracking cannot reconstruct the intermediate updated values.
 

--- a/pkg/source/mssql/change_tracking.go
+++ b/pkg/source/mssql/change_tracking.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -339,16 +340,48 @@ func (s *MSSQLChangeTrackingSource) currentCTVersion(ctx context.Context, q ctQu
 	return version.Int64, nil
 }
 
+func (s *MSSQLChangeTrackingSource) ensureCTVersionValid(ctx context.Context, q ctQueryer, table string, version int64) error {
+	minVersion, err := s.minValidCTVersion(ctx, q, table)
+	if err != nil {
+		return err
+	}
+	if version < minVersion {
+		return &ctVersionExpiredError{table: table, version: version, minVersion: minVersion}
+	}
+	return nil
+}
+
+// ctCursorValidationHook runs after the resume cursor is validated and before
+// CHANGETABLE is queried. Only integration builds install one, to race cursor
+// invalidation against the read.
+var ctCursorValidationHook atomic.Pointer[func(ctx context.Context, sourceURI, table string) error]
+
+// snapshotCTTable probes snapshot_isolation_state instead of trying SNAPSHOT
+// and falling back on failure: when the database disallows SNAPSHOT, SQL
+// Server may raise error 3952 only after streaming rows, and a retry would
+// re-emit them. Falling back on any other error would rescan the table under
+// HOLDLOCK for no benefit.
 func (s *MSSQLChangeTrackingSource) snapshotCTTable(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult) (int64, error) {
-	version, emittedRows, err := s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSnapshot)
-	if err == nil {
-		return version, nil
+	useSnapshot, err := SnapshotIsolationAllowed(ctx, s.db)
+	if err != nil {
+		return 0, err
 	}
-	if emittedRows > 0 {
-		return 0, fmt.Errorf("SNAPSHOT isolation snapshot for %s failed after emitting %d rows; not retrying with table lock to avoid duplicate records: %w", table, emittedRows, err)
+	if useSnapshot {
+		version, emittedRows, err := s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSnapshot)
+		if err == nil {
+			return version, nil
+		}
+		if emittedRows > 0 {
+			return 0, fmt.Errorf("SNAPSHOT isolation snapshot for %s failed after emitting %d rows; not retrying with table lock to avoid duplicate records: %w", table, emittedRows, err)
+		}
+		if !IsSnapshotIsolationUnavailableError(err) {
+			return 0, err
+		}
+		config.Debug("[MSSQL CT] SNAPSHOT isolation became unavailable (%v); retrying snapshot of %s with a table lock", err, table)
+	} else {
+		config.Debug("[MSSQL CT] Snapshot isolation is not allowed for this database; snapshotting %s with a table lock", table)
 	}
-	config.Debug("[MSSQL CT] SNAPSHOT isolation snapshot failed for %s: %v; retrying with table lock", table, err)
-	version, _, err = s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSerializable)
+	version, _, err := s.snapshotCTTableWithIsolation(ctx, table, tableSchema, opts, results, sql.LevelSerializable)
 	return version, err
 }
 
@@ -370,11 +403,14 @@ func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Con
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to query snapshot for %s: %w", table, err)
 	}
-	defer func() { _ = rows.Close() }()
 
 	emittedRows, err := s.rowsToCTBatches(rows, columns, opts, results)
 	if err != nil {
+		_ = rows.Close()
 		return 0, emittedRows, err
+	}
+	if err := rows.Close(); err != nil {
+		return 0, emittedRows, fmt.Errorf("failed to read snapshot for %s: %w", table, err)
 	}
 	if emittedRows == 0 && !opts.FullRefresh {
 		if err := emitSyntheticCTHeartbeat(tableSchema.Columns, tableSchema.PrimaryKeys, version, results); err != nil {
@@ -390,71 +426,109 @@ func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Con
 	return version, emittedRows, nil
 }
 
+// readCTChanges enumerates changes after fromVersion. SQL Server documents
+// that cursor validation, CHANGE_TRACKING_CURRENT_VERSION() and CHANGETABLE
+// must share one SNAPSHOT transaction: otherwise retention cleanup (or a
+// TRUNCATE, which resets the table's tracking) can invalidate the cursor
+// between validation and CHANGETABLE, and the change set comes back silently
+// incomplete. When the database disallows SNAPSHOT, the read runs under READ
+// COMMITTED and re-validates the cursor after CHANGETABLE, which is the
+// documented alternative.
 func (s *MSSQLChangeTrackingSource) readCTChanges(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, emitHeartbeat bool) (int64, error) {
-	readThroughVersion, err := s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelReadCommitted, emitHeartbeat)
-	if err == nil {
-		return readThroughVersion, nil
-	}
-	var expired *ctVersionExpiredError
-	if errors.As(err, &expired) {
+	useSnapshot, err := SnapshotIsolationAllowed(ctx, s.db)
+	if err != nil {
 		return 0, err
 	}
-	return 0, fmt.Errorf("failed to read SQL Server Change Tracking changes using READ COMMITTED isolation: %w", err)
+	if useSnapshot {
+		readThroughVersion, emittedRows, err := s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelSnapshot, emitHeartbeat)
+		if err == nil {
+			return readThroughVersion, nil
+		}
+		if emittedRows > 0 || !IsSnapshotIsolationUnavailableError(err) {
+			return 0, wrapCTReadError(err, "SNAPSHOT")
+		}
+		config.Debug("[MSSQL CT] SNAPSHOT isolation became unavailable (%v); reading changes for %s under READ COMMITTED", err, table)
+	} else {
+		config.Debug("[MSSQL CT] Snapshot isolation is not allowed for this database; reading changes for %s under READ COMMITTED with post-read cursor validation", table)
+	}
+
+	readThroughVersion, _, err := s.readCTChangesWithIsolation(ctx, table, tableSchema, primaryKeys, fromVersion, opts, results, sql.LevelReadCommitted, emitHeartbeat)
+	if err != nil {
+		return 0, wrapCTReadError(err, "READ COMMITTED")
+	}
+	return readThroughVersion, nil
 }
 
-func (s *MSSQLChangeTrackingSource) readCTChangesWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel, emitHeartbeat bool) (int64, error) {
+func wrapCTReadError(err error, isolation string) error {
+	var expired *ctVersionExpiredError
+	if errors.As(err, &expired) {
+		return err
+	}
+	return fmt.Errorf("failed to read SQL Server Change Tracking changes using %s isolation: %w", isolation, err)
+}
+
+func (s *MSSQLChangeTrackingSource) readCTChangesWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel, emitHeartbeat bool) (int64, int64, error) {
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
 	if err != nil {
-		return 0, fmt.Errorf("failed to begin Change Tracking transaction: %w", err)
+		return 0, 0, fmt.Errorf("failed to begin Change Tracking transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	minVersion, err := s.minValidCTVersion(ctx, tx, table)
-	if err != nil {
-		return 0, err
+	if err := s.ensureCTVersionValid(ctx, tx, table, fromVersion); err != nil {
+		return 0, 0, err
 	}
-	if fromVersion < minVersion {
-		return 0, &ctVersionExpiredError{table: table, version: fromVersion, minVersion: minVersion}
+	if hook := ctCursorValidationHook.Load(); hook != nil {
+		if err := (*hook)(ctx, s.uri, table); err != nil {
+			return 0, 0, err
+		}
 	}
 
 	targetVersion, err := s.currentCTVersion(ctx, tx)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 	if targetVersion <= fromVersion {
 		if err := tx.Commit(); err != nil {
-			return 0, fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
+			return 0, 0, fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
 		}
-		return fromVersion, nil
+		return fromVersion, 0, nil
 	}
 
 	columns := tableSchema.Columns
 	query := buildCTChangesQuery(table, sourceColumnsWithoutCT(tableSchema), primaryKeys)
 	rows, err := tx.QueryContext(ctx, query, fromVersion, targetVersion)
 	if err != nil {
-		return 0, fmt.Errorf("failed to query Change Tracking changes for %s: %w", table, err)
+		return 0, 0, fmt.Errorf("failed to query Change Tracking changes for %s: %w", table, err)
 	}
 
 	changeRows, err := s.rowsToCTBatches(rows, columns, opts, results)
 	if err != nil {
 		_ = rows.Close()
-		return 0, err
+		return 0, changeRows, err
 	}
 	if err := rows.Close(); err != nil {
-		return 0, fmt.Errorf("failed to close Change Tracking rows for %s: %w", table, err)
+		return 0, changeRows, fmt.Errorf("failed to close Change Tracking rows for %s: %w", table, err)
 	}
 
+	emittedRows := changeRows
 	if shouldEmitCTHeartbeat(emitHeartbeat, changeRows) {
 		if err := s.emitCTHeartbeat(ctx, tx, table, tableSchema, primaryKeys, targetVersion, opts, results); err != nil {
-			return 0, err
+			return 0, emittedRows, err
+		}
+		emittedRows++
+	}
+
+	if isolation != sql.LevelSnapshot {
+		if err := s.ensureCTVersionValid(ctx, tx, table, fromVersion); err != nil {
+			return 0, emittedRows, err
 		}
 	}
 
 	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
+		return 0, emittedRows, fmt.Errorf("failed to commit Change Tracking transaction: %w", err)
 	}
 
-	return targetVersion, nil
+	return targetVersion, emittedRows, nil
 }
 
 func (s *MSSQLChangeTrackingSource) emitCTHeartbeat(ctx context.Context, tx *sql.Tx, table string, tableSchema *schema.TableSchema, primaryKeys []string, targetVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
@@ -463,11 +537,14 @@ func (s *MSSQLChangeTrackingSource) emitCTHeartbeat(ctx context.Context, tx *sql
 	if err != nil {
 		return fmt.Errorf("failed to query Change Tracking heartbeat for %s: %w", table, err)
 	}
-	defer func() { _ = rows.Close() }()
 
 	emittedRows, err := s.rowsToCTBatches(rows, tableSchema.Columns, opts, results)
 	if err != nil {
+		_ = rows.Close()
 		return err
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("failed to read Change Tracking heartbeat for %s: %w", table, err)
 	}
 	if emittedRows == 0 {
 		return emitSyntheticCTHeartbeat(tableSchema.Columns, primaryKeys, targetVersion, results)

--- a/pkg/source/mssql/change_tracking.go
+++ b/pkg/source/mssql/change_tracking.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"math"
@@ -351,16 +352,10 @@ func (s *MSSQLChangeTrackingSource) ensureCTVersionValid(ctx context.Context, q 
 	return nil
 }
 
-// ctCursorValidationHook runs after the resume cursor is validated and before
-// CHANGETABLE is queried. Only integration builds install one, to race cursor
-// invalidation against the read.
+// Integration tests use this to invalidate a cursor before CHANGETABLE runs.
 var ctCursorValidationHook atomic.Pointer[func(ctx context.Context, sourceURI, table string) error]
 
-// snapshotCTTable probes snapshot_isolation_state instead of trying SNAPSHOT
-// and falling back on failure: when the database disallows SNAPSHOT, SQL
-// Server may raise error 3952 only after streaming rows, and a retry would
-// re-emit them. Falling back on any other error would rescan the table under
-// HOLDLOCK for no benefit.
+// Probe before SNAPSHOT so fallback never re-emits a partially streamed scan.
 func (s *MSSQLChangeTrackingSource) snapshotCTTable(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult) (int64, error) {
 	useSnapshot, err := SnapshotIsolationAllowed(ctx, s.db)
 	if err != nil {
@@ -385,8 +380,23 @@ func (s *MSSQLChangeTrackingSource) snapshotCTTable(ctx context.Context, table s
 	return version, err
 }
 
+func resetCTConnection(ctx context.Context, conn *sql.Conn) {
+	resetCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if _, err := conn.ExecContext(resetCtx, "SET TRANSACTION ISOLATION LEVEL READ COMMITTED"); err != nil {
+		_ = conn.Raw(func(any) error { return driver.ErrBadConn })
+	}
+	_ = conn.Close()
+}
+
 func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel) (int64, int64, error) {
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to acquire snapshot connection: %w", err)
+	}
+	defer resetCTConnection(ctx, conn)
+
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to begin snapshot transaction: %w", err)
 	}
@@ -426,14 +436,8 @@ func (s *MSSQLChangeTrackingSource) snapshotCTTableWithIsolation(ctx context.Con
 	return version, emittedRows, nil
 }
 
-// readCTChanges enumerates changes after fromVersion. SQL Server documents
-// that cursor validation, CHANGE_TRACKING_CURRENT_VERSION() and CHANGETABLE
-// must share one SNAPSHOT transaction: otherwise retention cleanup (or a
-// TRUNCATE, which resets the table's tracking) can invalidate the cursor
-// between validation and CHANGETABLE, and the change set comes back silently
-// incomplete. When the database disallows SNAPSHOT, the read runs under READ
-// COMMITTED and re-validates the cursor after CHANGETABLE, which is the
-// documented alternative.
+// Keep validation and enumeration in one SNAPSHOT transaction. The READ
+// COMMITTED fallback revalidates after enumeration to detect cleanup races.
 func (s *MSSQLChangeTrackingSource) readCTChanges(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, emitHeartbeat bool) (int64, error) {
 	useSnapshot, err := SnapshotIsolationAllowed(ctx, s.db)
 	if err != nil {
@@ -468,7 +472,13 @@ func wrapCTReadError(err error, isolation string) error {
 }
 
 func (s *MSSQLChangeTrackingSource) readCTChangesWithIsolation(ctx context.Context, table string, tableSchema *schema.TableSchema, primaryKeys []string, fromVersion int64, opts source.ReadOptions, results chan<- source.RecordBatchResult, isolation sql.IsolationLevel, emitHeartbeat bool) (int64, int64, error) {
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to acquire Change Tracking connection: %w", err)
+	}
+	defer resetCTConnection(ctx, conn)
+
+	tx, err := conn.BeginTx(ctx, &sql.TxOptions{Isolation: isolation})
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to begin Change Tracking transaction: %w", err)
 	}

--- a/pkg/source/mssql/change_tracking_test.go
+++ b/pkg/source/mssql/change_tracking_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	mssqldb "github.com/microsoft/go-mssqldb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,6 +83,7 @@ func TestSnapshotCTTableDoesNotRetryAfterEmittingRows(t *testing.T) {
 		}, ctMetadataColumns...),
 	}
 
+	mock.ExpectQuery("snapshot_isolation_state").WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(1))
 	mock.ExpectBegin()
 	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").
 		WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(int64(7)))
@@ -310,4 +312,218 @@ func TestCTVersionExpiredErrorMentionsFullRefresh(t *testing.T) {
 	assert.Contains(t, err, "version 10")
 	assert.Contains(t, err, "minimum valid version is 20")
 	assert.Contains(t, err, "--full-refresh")
+}
+
+func newCTTestSchema() *schema.TableSchema {
+	return &schema.TableSchema{
+		Columns: append([]schema.Column{
+			{Name: "id", DataType: schema.TypeInt64, Nullable: false},
+		}, ctMetadataColumns...),
+		PrimaryKeys: []string{"id"},
+	}
+}
+
+func ctVersionRows(version int64) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{"version"}).AddRow(version)
+}
+
+func ctChangeRows(id, version int64) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		destination.CDCLSNColumn,
+		destination.CDCDeletedColumn,
+		destination.CDCSyncedAtColumn,
+	}).AddRow(id, formatCTVersion(version), false, time.Now())
+}
+
+func drainCTResults(t *testing.T, results chan source.RecordBatchResult) int64 {
+	t.Helper()
+	var rows int64
+	for {
+		select {
+		case res := <-results:
+			require.NoError(t, res.Err)
+			require.NotNil(t, res.Batch)
+			rows += res.Batch.NumRows()
+			res.Batch.Release()
+		default:
+			return rows
+		}
+	}
+}
+
+func TestReadCTChangesUsesSnapshotIsolationWithoutPostReadRevalidation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	src := &MSSQLChangeTrackingSource{MSSQLSource: MSSQLSource{db: db}}
+
+	mock.ExpectQuery("snapshot_isolation_state").WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(1))
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnRows(ctVersionRows(5))
+	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(20))
+	mock.ExpectQuery("CHANGETABLE").WithArgs(int64(10), int64(20)).WillReturnRows(ctChangeRows(1, 20))
+	mock.ExpectCommit()
+
+	results := make(chan source.RecordBatchResult, 4)
+	through, err := src.readCTChanges(t.Context(), "dbo.items", newCTTestSchema(), []string{"id"}, 10, source.ReadOptions{PageSize: 100}, results, true)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 20, through)
+	assert.EqualValues(t, 1, drainCTResults(t, results))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReadCTChangesRevalidatesCursorAfterReadWithoutSnapshot(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	src := &MSSQLChangeTrackingSource{MSSQLSource: MSSQLSource{db: db}}
+
+	mock.ExpectQuery("snapshot_isolation_state").WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(0))
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnRows(ctVersionRows(5))
+	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(20))
+	mock.ExpectQuery("CHANGETABLE").WithArgs(int64(10), int64(20)).WillReturnRows(ctChangeRows(1, 20))
+	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnRows(ctVersionRows(15))
+	mock.ExpectRollback()
+
+	results := make(chan source.RecordBatchResult, 4)
+	_, err = src.readCTChanges(t.Context(), "dbo.items", newCTTestSchema(), []string{"id"}, 10, source.ReadOptions{PageSize: 100}, results, true)
+
+	var expired *ctVersionExpiredError
+	require.ErrorAs(t, err, &expired)
+	assert.EqualValues(t, 10, expired.version)
+	assert.EqualValues(t, 15, expired.minVersion)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReadCTChangesFallsBackToReadCommittedWhenSnapshotRejected(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	src := &MSSQLChangeTrackingSource{MSSQLSource: MSSQLSource{db: db}}
+
+	mock.ExpectQuery("snapshot_isolation_state").WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(1))
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnError(mssqldb.Error{Number: 3952})
+	mock.ExpectRollback()
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnRows(ctVersionRows(5))
+	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(20))
+	mock.ExpectQuery("CHANGETABLE").WithArgs(int64(10), int64(20)).WillReturnRows(ctChangeRows(1, 20))
+	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnRows(ctVersionRows(5))
+	mock.ExpectCommit()
+
+	results := make(chan source.RecordBatchResult, 4)
+	through, err := src.readCTChanges(t.Context(), "dbo.items", newCTTestSchema(), []string{"id"}, 10, source.ReadOptions{PageSize: 100}, results, true)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 20, through)
+	assert.EqualValues(t, 1, drainCTResults(t, results))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestReadCTChangesDoesNotRetryOtherSnapshotErrors(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	src := &MSSQLChangeTrackingSource{MSSQLSource: MSSQLSource{db: db}}
+
+	mock.ExpectQuery("snapshot_isolation_state").WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(1))
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnError(errors.New("login timeout"))
+	mock.ExpectRollback()
+
+	results := make(chan source.RecordBatchResult, 4)
+	_, err = src.readCTChanges(t.Context(), "dbo.items", newCTTestSchema(), []string{"id"}, 10, source.ReadOptions{PageSize: 100}, results, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SNAPSHOT isolation")
+	assert.Contains(t, err.Error(), "login timeout")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSnapshotCTTableUsesTableLockWhenSnapshotIsolationDisallowed(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	src := &MSSQLChangeTrackingSource{MSSQLSource: MSSQLSource{db: db}}
+
+	mock.ExpectQuery("snapshot_isolation_state").WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(0))
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(7))
+	mock.ExpectQuery("FROM \\[dbo\\]\\.\\[items\\] WITH \\(HOLDLOCK\\)").WillReturnRows(ctChangeRows(1, 7))
+	mock.ExpectCommit()
+
+	results := make(chan source.RecordBatchResult, 4)
+	version, err := src.snapshotCTTable(t.Context(), "dbo.items", newCTTestSchema(), source.ReadOptions{PageSize: 100}, results)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 7, version)
+	assert.EqualValues(t, 1, drainCTResults(t, results))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSnapshotCTTableFallsBackToTableLockOnlyWhenSnapshotRejected(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	src := &MSSQLChangeTrackingSource{MSSQLSource: MSSQLSource{db: db}}
+
+	mock.ExpectQuery("snapshot_isolation_state").WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(1))
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnError(mssqldb.Error{Number: 3952})
+	mock.ExpectRollback()
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(7))
+	mock.ExpectQuery("FROM \\[dbo\\]\\.\\[items\\] WITH \\(HOLDLOCK\\)").WillReturnRows(ctChangeRows(1, 7))
+	mock.ExpectCommit()
+
+	results := make(chan source.RecordBatchResult, 4)
+	version, err := src.snapshotCTTable(t.Context(), "dbo.items", newCTTestSchema(), source.ReadOptions{PageSize: 100}, results)
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 7, version)
+	assert.EqualValues(t, 1, drainCTResults(t, results))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSnapshotCTTableDoesNotRetryOtherSnapshotErrors(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	src := &MSSQLChangeTrackingSource{MSSQLSource: MSSQLSource{db: db}}
+
+	mock.ExpectQuery("snapshot_isolation_state").WillReturnRows(sqlmock.NewRows([]string{"state"}).AddRow(1))
+	mock.ExpectBegin()
+	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnError(errors.New("permission denied"))
+	mock.ExpectRollback()
+
+	results := make(chan source.RecordBatchResult, 4)
+	_, err = src.snapshotCTTable(t.Context(), "dbo.items", newCTTestSchema(), source.ReadOptions{PageSize: 100}, results)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRowsToArrowRecordBatchSurfacesErrorOnEmptyResult(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	mock.ExpectQuery("SELECT").WillReturnRows(sqlmock.NewRows([]string{"id"}).RowError(0, errors.New("late failure")).AddRow(int64(1)))
+
+	rows, err := db.QueryContext(t.Context(), "SELECT id FROM t")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	columns := []schema.Column{{Name: "id", DataType: schema.TypeInt64}}
+	record, count, err := rowsToArrowRecordBatch(rows, buildArrowSchema(columns), columns, 100, 0, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "late failure")
+	assert.Nil(t, record)
+	assert.EqualValues(t, 0, count)
 }

--- a/pkg/source/mssql/change_tracking_test.go
+++ b/pkg/source/mssql/change_tracking_test.go
@@ -95,6 +95,7 @@ func TestSnapshotCTTableDoesNotRetryAfterEmittingRows(t *testing.T) {
 			destination.CDCSyncedAtColumn,
 		}).AddRow(int64(1), "00000000000000000007", false, time.Now()))
 	mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+	expectCTIsolationReset(mock)
 
 	results := make(chan source.RecordBatchResult, 2)
 	_, err = src.snapshotCTTable(t.Context(), "dbo.items", tableSchema, source.ReadOptions{PageSize: 100}, results)
@@ -352,6 +353,11 @@ func drainCTResults(t *testing.T, results chan source.RecordBatchResult) int64 {
 	}
 }
 
+func expectCTIsolationReset(mock sqlmock.Sqlmock) {
+	mock.ExpectExec("SET TRANSACTION ISOLATION LEVEL READ COMMITTED").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
 func TestReadCTChangesUsesSnapshotIsolationWithoutPostReadRevalidation(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
@@ -364,6 +370,7 @@ func TestReadCTChangesUsesSnapshotIsolationWithoutPostReadRevalidation(t *testin
 	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(20))
 	mock.ExpectQuery("CHANGETABLE").WithArgs(int64(10), int64(20)).WillReturnRows(ctChangeRows(1, 20))
 	mock.ExpectCommit()
+	expectCTIsolationReset(mock)
 
 	results := make(chan source.RecordBatchResult, 4)
 	through, err := src.readCTChanges(t.Context(), "dbo.items", newCTTestSchema(), []string{"id"}, 10, source.ReadOptions{PageSize: 100}, results, true)
@@ -387,6 +394,7 @@ func TestReadCTChangesRevalidatesCursorAfterReadWithoutSnapshot(t *testing.T) {
 	mock.ExpectQuery("CHANGETABLE").WithArgs(int64(10), int64(20)).WillReturnRows(ctChangeRows(1, 20))
 	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnRows(ctVersionRows(15))
 	mock.ExpectRollback()
+	expectCTIsolationReset(mock)
 
 	results := make(chan source.RecordBatchResult, 4)
 	_, err = src.readCTChanges(t.Context(), "dbo.items", newCTTestSchema(), []string{"id"}, 10, source.ReadOptions{PageSize: 100}, results, true)
@@ -408,12 +416,14 @@ func TestReadCTChangesFallsBackToReadCommittedWhenSnapshotRejected(t *testing.T)
 	mock.ExpectBegin()
 	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnError(mssqldb.Error{Number: 3952})
 	mock.ExpectRollback()
+	expectCTIsolationReset(mock)
 	mock.ExpectBegin()
 	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnRows(ctVersionRows(5))
 	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(20))
 	mock.ExpectQuery("CHANGETABLE").WithArgs(int64(10), int64(20)).WillReturnRows(ctChangeRows(1, 20))
 	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnRows(ctVersionRows(5))
 	mock.ExpectCommit()
+	expectCTIsolationReset(mock)
 
 	results := make(chan source.RecordBatchResult, 4)
 	through, err := src.readCTChanges(t.Context(), "dbo.items", newCTTestSchema(), []string{"id"}, 10, source.ReadOptions{PageSize: 100}, results, true)
@@ -434,6 +444,7 @@ func TestReadCTChangesDoesNotRetryOtherSnapshotErrors(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery("CHANGE_TRACKING_MIN_VALID_VERSION").WillReturnError(errors.New("login timeout"))
 	mock.ExpectRollback()
+	expectCTIsolationReset(mock)
 
 	results := make(chan source.RecordBatchResult, 4)
 	_, err = src.readCTChanges(t.Context(), "dbo.items", newCTTestSchema(), []string{"id"}, 10, source.ReadOptions{PageSize: 100}, results, true)
@@ -455,6 +466,7 @@ func TestSnapshotCTTableUsesTableLockWhenSnapshotIsolationDisallowed(t *testing.
 	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(7))
 	mock.ExpectQuery("FROM \\[dbo\\]\\.\\[items\\] WITH \\(HOLDLOCK\\)").WillReturnRows(ctChangeRows(1, 7))
 	mock.ExpectCommit()
+	expectCTIsolationReset(mock)
 
 	results := make(chan source.RecordBatchResult, 4)
 	version, err := src.snapshotCTTable(t.Context(), "dbo.items", newCTTestSchema(), source.ReadOptions{PageSize: 100}, results)
@@ -475,10 +487,12 @@ func TestSnapshotCTTableFallsBackToTableLockOnlyWhenSnapshotRejected(t *testing.
 	mock.ExpectBegin()
 	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnError(mssqldb.Error{Number: 3952})
 	mock.ExpectRollback()
+	expectCTIsolationReset(mock)
 	mock.ExpectBegin()
 	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnRows(ctVersionRows(7))
 	mock.ExpectQuery("FROM \\[dbo\\]\\.\\[items\\] WITH \\(HOLDLOCK\\)").WillReturnRows(ctChangeRows(1, 7))
 	mock.ExpectCommit()
+	expectCTIsolationReset(mock)
 
 	results := make(chan source.RecordBatchResult, 4)
 	version, err := src.snapshotCTTable(t.Context(), "dbo.items", newCTTestSchema(), source.ReadOptions{PageSize: 100}, results)
@@ -499,6 +513,7 @@ func TestSnapshotCTTableDoesNotRetryOtherSnapshotErrors(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery("CHANGE_TRACKING_CURRENT_VERSION").WillReturnError(errors.New("permission denied"))
 	mock.ExpectRollback()
+	expectCTIsolationReset(mock)
 
 	results := make(chan source.RecordBatchResult, 4)
 	_, err = src.snapshotCTTable(t.Context(), "dbo.items", newCTTestSchema(), source.ReadOptions{PageSize: 100}, results)

--- a/pkg/source/mssql/change_tracking_testhook.go
+++ b/pkg/source/mssql/change_tracking_testhook.go
@@ -4,9 +4,8 @@ package mssql
 
 import "context"
 
-// SetChangeTrackingCursorValidationHook installs fn to run after the resume
-// cursor is validated and before CHANGETABLE is queried, so integration tests
-// can invalidate the cursor mid-read. Pass nil to clear it.
+// SetChangeTrackingCursorValidationHook installs the integration-test cursor
+// invalidation hook. Pass nil to clear it.
 func SetChangeTrackingCursorValidationHook(fn func(ctx context.Context, sourceURI, table string) error) {
 	if fn == nil {
 		ctCursorValidationHook.Store(nil)

--- a/pkg/source/mssql/change_tracking_testhook.go
+++ b/pkg/source/mssql/change_tracking_testhook.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+package mssql
+
+import "context"
+
+// SetChangeTrackingCursorValidationHook installs fn to run after the resume
+// cursor is validated and before CHANGETABLE is queried, so integration tests
+// can invalidate the cursor mid-read. Pass nil to clear it.
+func SetChangeTrackingCursorValidationHook(fn func(ctx context.Context, sourceURI, table string) error) {
+	if fn == nil {
+		ctCursorValidationHook.Store(nil)
+		return
+	}
+	ctCursorValidationHook.Store(&fn)
+}

--- a/pkg/source/mssql/mssql.go
+++ b/pkg/source/mssql/mssql.go
@@ -3,6 +3,7 @@ package mssql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -768,18 +769,18 @@ func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns [
 		}
 	}
 
-	if rowCount == 0 {
-		for _, b := range builders {
-			b.Release()
-		}
-		return nil, 0, nil
-	}
-
 	if err := rows.Err(); err != nil {
 		for _, b := range builders {
 			b.Release()
 		}
 		return nil, 0, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	if rowCount == 0 {
+		for _, b := range builders {
+			b.Release()
+		}
+		return nil, 0, nil
 	}
 
 	arrays := make([]arrow.Array, len(builders))
@@ -853,4 +854,22 @@ func formatUUIDBytes(raw []byte, guidConversion bool) (string, error) {
 		return "", err
 	}
 	return uuid.String(), nil
+}
+
+// SnapshotIsolationAllowed reports whether the database permits SNAPSHOT
+// isolation (sys.databases.snapshot_isolation_state = 1). Shared with the CDC
+// source.
+func SnapshotIsolationAllowed(ctx context.Context, db *sql.DB) (bool, error) {
+	var state int
+	if err := db.QueryRowContext(ctx, "SELECT CONVERT(int, snapshot_isolation_state) FROM sys.databases WHERE database_id = DB_ID()").Scan(&state); err != nil {
+		return false, fmt.Errorf("failed to check snapshot isolation state: %w", err)
+	}
+	return state == 1, nil
+}
+
+// IsSnapshotIsolationUnavailableError matches error 3952: the database does
+// not allow SNAPSHOT isolation (ALLOW_SNAPSHOT_ISOLATION is OFF).
+func IsSnapshotIsolationUnavailableError(err error) bool {
+	var sqlErr mssqldb.Error
+	return errors.As(err, &sqlErr) && sqlErr.Number == 3952
 }

--- a/pkg/source/mssql_cdc/source.go
+++ b/pkg/source/mssql_cdc/source.go
@@ -1157,7 +1157,7 @@ func (s *MSSQLCDCSource) snapshotTable(ctx context.Context, meta tableMetadata, 
 	// the session isolation level set on the pooled connection (SQL Server
 	// scopes SET TRANSACTION ISOLATION LEVEL to the session, not the
 	// transaction), poisoning later queries with error 3952.
-	useSnapshot, err := s.snapshotIsolationAllowed(ctx)
+	useSnapshot, err := mssql.SnapshotIsolationAllowed(ctx, s.db)
 	if err != nil {
 		return "", err
 	}
@@ -1170,7 +1170,7 @@ func (s *MSSQLCDCSource) snapshotTable(ctx context.Context, meta tableMetadata, 
 		// all (the setting can flip between probe and scan). Retrying every
 		// failure would rescan the whole table under HOLDLOCK, holding shared
 		// locks on a live table for no benefit.
-		if !isSnapshotIsolationUnavailableError(err) {
+		if !mssql.IsSnapshotIsolationUnavailableError(err) {
 			return "", err
 		}
 		config.Debug("[MSSQL CDC] SNAPSHOT isolation became unavailable (%v); retrying snapshot of %s with a table lock", err, tableName(meta))
@@ -1178,23 +1178,6 @@ func (s *MSSQLCDCSource) snapshotTable(ctx context.Context, meta tableMetadata, 
 		config.Debug("[MSSQL CDC] Snapshot isolation is not allowed for this database; snapshotting %s with a table lock", tableName(meta))
 	}
 	return s.snapshotTableWithIsolation(ctx, meta, tableSchema, opts, results, resultTable, sql.LevelSerializable)
-}
-
-// snapshotIsolationAllowed reports whether the database permits SNAPSHOT
-// isolation (sys.databases.snapshot_isolation_state = 1).
-func (s *MSSQLCDCSource) snapshotIsolationAllowed(ctx context.Context) (bool, error) {
-	var state int
-	if err := s.db.QueryRowContext(ctx, "SELECT CONVERT(int, snapshot_isolation_state) FROM sys.databases WHERE database_id = DB_ID()").Scan(&state); err != nil {
-		return false, fmt.Errorf("failed to check snapshot isolation state: %w", err)
-	}
-	return state == 1, nil
-}
-
-// isSnapshotIsolationUnavailableError matches error 3952: the database does
-// not allow SNAPSHOT isolation (ALLOW_SNAPSHOT_ISOLATION is OFF).
-func isSnapshotIsolationUnavailableError(err error) bool {
-	var sqlErr mssqldb.Error
-	return errors.As(err, &sqlErr) && sqlErr.Number == 3952
 }
 
 func (s *MSSQLCDCSource) snapshotTableWithIsolation(ctx context.Context, meta tableMetadata, tableSchema *schema.TableSchema, opts source.ReadOptions, results chan<- source.RecordBatchResult, resultTable string, isolation sql.IsolationLevel) (string, error) {

--- a/pkg/source/mssql_cdc/source_test.go
+++ b/pkg/source/mssql_cdc/source_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bruin-data/ingestr/pkg/destination"
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/source/mssql"
 	mssqldb "github.com/microsoft/go-mssqldb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -678,9 +679,9 @@ func TestErrorClassifiers(t *testing.T) {
 	assert.False(t, isInvalidLSNRangeError(mssqldb.Error{Number: 1205}))
 	assert.False(t, isInvalidLSNRangeError(errors.New("boom")))
 
-	assert.True(t, isSnapshotIsolationUnavailableError(mssqldb.Error{Number: 3952}))
-	assert.False(t, isSnapshotIsolationUnavailableError(mssqldb.Error{Number: 1205}))
-	assert.False(t, isSnapshotIsolationUnavailableError(nil))
+	assert.True(t, mssql.IsSnapshotIsolationUnavailableError(mssqldb.Error{Number: 3952}))
+	assert.False(t, mssql.IsSnapshotIsolationUnavailableError(mssqldb.Error{Number: 1205}))
+	assert.False(t, mssql.IsSnapshotIsolationUnavailableError(nil))
 }
 
 func TestIsTransientMSSQLError(t *testing.T) {

--- a/tests/integration/mssql_ct_test.go
+++ b/tests/integration/mssql_ct_test.go
@@ -7,15 +7,22 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/source/mssql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func setupMSSQLCTDatabase(t *testing.T, ctx context.Context) (string, *sql.DB) {
+	t.Helper()
+	return setupMSSQLCTDatabaseWithSnapshotIsolation(t, ctx, true)
+}
+
+func setupMSSQLCTDatabaseWithSnapshotIsolation(t *testing.T, ctx context.Context, snapshotIsolation bool) (string, *sql.DB) {
 	t.Helper()
 
 	if mssqlDest.uri == "" {
@@ -33,8 +40,10 @@ func setupMSSQLCTDatabase(t *testing.T, ctx context.Context) (string, *sql.DB) {
 		_, _ = adminDB.ExecContext(ctx, fmt.Sprintf("DROP DATABASE [%s]", dbName))
 	})
 
-	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET ALLOW_SNAPSHOT_ISOLATION ON", dbName))
-	require.NoError(t, err)
+	if snapshotIsolation {
+		_, err = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET ALLOW_SNAPSHOT_ISOLATION ON", dbName))
+		require.NoError(t, err)
+	}
 	_, err = adminDB.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE [%s] SET CHANGE_TRACKING = ON (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON)", dbName))
 	require.NoError(t, err)
 
@@ -208,4 +217,101 @@ func TestMSSQLChangeTracking_EmptyTableSnapshot_DuckDB(t *testing.T) {
 
 	assert.EqualValues(t, 0, queryDuckCount(`SELECT COUNT(*) FROM items_empty_dest WHERE NOT "_cdc_deleted"`), "insert+delete on an empty table should not create an active destination row")
 	assert.NotEmpty(t, queryDuckString(`SELECT MAX("_cdc_lsn") FROM items_empty_dest`), "empty-table cursor tombstone should advance resume state")
+}
+
+// A cursor validated at the start of an incremental read can stop being valid
+// before CHANGETABLE runs: retention cleanup, or a TRUNCATE, which resets the
+// table's tracking. Either isolation path must fail the run instead of
+// committing a partial change set and advancing the cursor past the hole.
+func TestMSSQLChangeTracking_CursorInvalidatedMidRead_DuckDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	for _, tc := range []struct {
+		name              string
+		snapshotIsolation bool
+	}{
+		{name: "read_committed", snapshotIsolation: false},
+		{name: "snapshot", snapshotIsolation: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dbName, db := setupMSSQLCTDatabaseWithSnapshotIsolation(t, ctx, tc.snapshotIsolation)
+			createMSSQLCTItemsTable(t, ctx, db)
+
+			tmpDir, err := os.MkdirTemp("", "mssql_ct_invalidated_*")
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+			duckdbPath := tmpDir + "/test.duckdb"
+
+			cfg := &config.IngestConfig{
+				SourceURI:   mssqlURIForDatabase(t, mssqlDest.uri, "mssql+ct", dbName, nil),
+				SourceTable: "dbo.items",
+				DestURI:     "duckdb:///" + duckdbPath,
+				DestTable:   "items_dest",
+			}
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+			queryDuckCount := func(query string) int64 {
+				duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+				require.NoError(t, err)
+				defer func() { _ = duck.Close() }()
+
+				var v int64
+				require.NoError(t, duck.QueryRow(query).Scan(&v))
+				return v
+			}
+			queryDuckString := func(query string) string {
+				duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckdbPath)
+				require.NoError(t, err)
+				defer func() { _ = duck.Close() }()
+
+				var v string
+				require.NoError(t, duck.QueryRow(query).Scan(&v))
+				return v
+			}
+
+			require.EqualValues(t, 3, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE NOT "_cdc_deleted"`))
+			cursorAfterSnapshot := queryDuckString(`SELECT MAX("_cdc_lsn") FROM items_dest`)
+
+			_, err = db.ExecContext(ctx, `UPDATE dbo.items SET value = 150 WHERE id = 1`)
+			require.NoError(t, err)
+
+			var fired atomic.Bool
+			hookErrs := make(chan error, 1)
+			mssql.SetChangeTrackingCursorValidationHook(func(hookCtx context.Context, sourceURI, table string) error {
+				if sourceURI != cfg.SourceURI || !fired.CompareAndSwap(false, true) {
+					return nil
+				}
+				_, err := db.ExecContext(hookCtx, `TRUNCATE TABLE dbo.items`)
+				if err == nil {
+					_, err = db.ExecContext(hookCtx, `INSERT INTO dbo.items (id, name, value) VALUES (10, N'item10', 1000)`)
+				}
+				hookErrs <- err
+				return nil
+			})
+			t.Cleanup(func() { mssql.SetChangeTrackingCursorValidationHook(nil) })
+
+			err = pipeline.New(cfg).Run(ctx)
+			require.True(t, fired.Load(), "hook must run between cursor validation and CHANGETABLE")
+			require.NoError(t, <-hookErrs)
+			require.Error(t, err, "run must fail instead of committing a change set read past an invalidated cursor")
+			if !tc.snapshotIsolation {
+				assert.Contains(t, err.Error(), "no longer valid")
+			}
+
+			assert.EqualValues(t, 3, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE NOT "_cdc_deleted"`), "failed run must not touch the destination")
+			assert.Equal(t, cursorAfterSnapshot, queryDuckString(`SELECT MAX("_cdc_lsn") FROM items_dest`), "failed run must not advance the cursor")
+
+			mssql.SetChangeTrackingCursorValidationHook(nil)
+			fullRefresh := *cfg
+			fullRefresh.FullRefresh = true
+			require.NoError(t, pipeline.New(&fullRefresh).Run(ctx))
+			assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE NOT "_cdc_deleted"`))
+			assert.EqualValues(t, 1, queryDuckCount(`SELECT COUNT(*) FROM items_dest WHERE id = 10 AND value = 1000 AND NOT "_cdc_deleted"`))
+
+			require.NoError(t, pipeline.New(cfg).Run(ctx), "incremental runs resume after the rebuild")
+		})
+	}
 }


### PR DESCRIPTION
## What
Make SQL Server Change Tracking snapshots and incremental reads consistent when cleanup or truncation races with ingestion.

## Changes
- Use SNAPSHOT isolation when available, with safe locking and READ COMMITTED fallbacks.
- Revalidate resume cursors, surface late row errors, and share snapshot checks with MSSQL CDC.
- Add unit, integration, and documentation coverage.

## How to test
1. make format && make lint && make test
2. INTEGRATION_BACKENDS=mssql go test -tags integration -v -run TestMSSQLChangeTracking_ -timeout 20m ./tests/integration/...

## Risk & rollback
- **Risk:** Medium; this changes MSSQL Change Tracking transaction isolation and fallback behavior.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (make test)
- [x] Format and lint pass (make format, make lint)
- [x] Integration tests pass if affected (focused MSSQL CT suite)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues
None.