### PR TITLE
feat(vertica): add Vertica source

### DIFF
--- a/docs/supported-sources/vertica.md
+++ b/docs/supported-sources/vertica.md
@@ -2,7 +2,7 @@
 
 [Vertica](https://www.vertica.com/) is a columnar, massively parallel processing (MPP) analytical database built for large-scale analytics, available on-premises, in the cloud, and as a free Community Edition.
 
-ingestr supports Vertica as a destination.
+ingestr supports Vertica as both a source and a destination.
 
 ## URI format
 The URI format for Vertica is as follows:
@@ -39,6 +39,28 @@ schema.table     # fully qualified
 ```
 
 The schema is created automatically if it does not already exist.
+
+## Setting Vertica as a source
+
+Use the `--source-uri` and `--source-table` flags to read data from Vertica:
+
+```bash
+ingestr ingest \
+    --source-uri 'vertica://dbadmin:pass@localhost:5433/VMart' \
+    --source-table 'public.users' \
+    --dest-uri 'postgres://user:pass@localhost:5432/analytics' \
+    --dest-table 'public.users'
+```
+
+You can also provide a custom query with the `query:` prefix as the source table:
+
+```bash
+ingestr ingest \
+    --source-uri 'vertica://dbadmin:pass@localhost:5433/VMart' \
+    --source-table 'query:SELECT id, email FROM public.users WHERE active = true' \
+    --dest-uri 'postgres://user:pass@localhost:5432/analytics' \
+    --dest-table 'public.active_users'
+```
 
 ## Setting Vertica as a destination
 

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -417,7 +417,7 @@ func GetConnectors() []ConnectorType {
 		genericURIConnector("twilio", "Twilio", []string{"twilio"}, true, false),
 		genericURIConnector("twocheckout", "2Checkout", []string{"twocheckout"}, true, false),
 		genericURIConnector("typeform", "Typeform", []string{"typeform"}, true, false),
-		genericURIConnector("vertica", "Vertica", []string{"vertica"}, false, true),
+		genericURIConnector("vertica", "Vertica", []string{"vertica"}, true, true),
 		genericURIConnector("wise", "Wise", []string{"wise"}, true, false),
 		genericURIConnector("wistia", "Wistia", []string{"wistia"}, true, false),
 		genericURIConnector("zendesk", "Zendesk", []string{"zendesk"}, true, false),

--- a/pkg/destination/vertica/mapper.go
+++ b/pkg/destination/vertica/mapper.go
@@ -73,16 +73,17 @@ func MapDataTypeToVertica(col schema.Column, isKey bool) string {
 	}
 }
 
-// mapVerticaTypeToSchema maps a Vertica catalog data type to the internal type
+// MapVerticaTypeToSchema maps a Vertica catalog data type to the internal type
 // system. The catalog reports lengths inline (e.g. "varchar(65000)"), so only
-// the leading type name is significant.
-func mapVerticaTypeToSchema(dataType string) schema.DataType {
+// the leading type name is significant. It is the single source of truth shared
+// by the Vertica destination (schema readback) and the Vertica source.
+func MapVerticaTypeToSchema(dataType string) schema.DataType {
 	base := strings.ToLower(strings.TrimSpace(dataType))
 	if idx := strings.IndexByte(base, '('); idx >= 0 {
 		base = strings.TrimSpace(base[:idx])
 	}
 	switch base {
-	case "boolean":
+	case "boolean", "bool":
 		return schema.TypeBoolean
 	case "int", "integer", "bigint", "int8", "smallint", "tinyint":
 		return schema.TypeInt64

--- a/pkg/destination/vertica/vertica.go
+++ b/pkg/destination/vertica/vertica.go
@@ -574,7 +574,7 @@ func (d *VerticaDestination) GetTableSchema(ctx context.Context, table string) (
 		}
 		col := schema.Column{
 			Name:     colName,
-			DataType: mapVerticaTypeToSchema(dataType),
+			DataType: MapVerticaTypeToSchema(dataType),
 			Nullable: nullable,
 		}
 		if precision.Valid {

--- a/pkg/destination/vertica/vertica_test.go
+++ b/pkg/destination/vertica/vertica_test.go
@@ -58,6 +58,7 @@ func TestMapVerticaTypeToSchema(t *testing.T) {
 		want schema.DataType
 	}{
 		{"boolean", schema.TypeBoolean},
+		{"bool", schema.TypeBoolean},
 		{"int", schema.TypeInt64},
 		{"bigint", schema.TypeInt64},
 		{"float", schema.TypeFloat64},
@@ -65,15 +66,18 @@ func TestMapVerticaTypeToSchema(t *testing.T) {
 		{"varchar(65000)", schema.TypeString},
 		{"long varchar", schema.TypeString},
 		{"varbinary(80)", schema.TypeBinary},
+		{"binary", schema.TypeBinary},
+		{"timetz", schema.TypeTime},
 		{"date", schema.TypeDate},
 		{"timestamp", schema.TypeTimestamp},
 		{"timestamptz", schema.TypeTimestampTZ},
+		{"interval day to second", schema.TypeString},
 		{"uuid", schema.TypeString},
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			if got := mapVerticaTypeToSchema(tt.in); got != tt.want {
-				t.Errorf("mapVerticaTypeToSchema(%q) = %v, want %v", tt.in, got, tt.want)
+			if got := MapVerticaTypeToSchema(tt.in); got != tt.want {
+				t.Errorf("MapVerticaTypeToSchema(%q) = %v, want %v", tt.in, got, tt.want)
 			}
 		})
 	}

--- a/pkg/source/vertica/register.go
+++ b/pkg/source/vertica/register.go
@@ -1,0 +1,10 @@
+package vertica
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource(
+		[]string{"vertica"},
+		func() interface{} { return NewVerticaSource() },
+	)
+}

--- a/pkg/source/vertica/vertica.go
+++ b/pkg/source/vertica/vertica.go
@@ -394,15 +394,9 @@ func buildSelectQuery(table string, columns []schema.Column, decimalCols map[str
 
 	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(colNames, ", "), quoteTable(table))
 
-	var conditions []string
-	if opts.IncrementalKey != "" {
-		if opts.IntervalStart != nil {
-			conditions = append(conditions, fmt.Sprintf("%s >= '%s'", quoteIdentifier(opts.IncrementalKey), formatIntervalValue(opts.IntervalStart)))
-		}
-		if opts.IntervalEnd != nil {
-			conditions = append(conditions, fmt.Sprintf("%s <= '%s'", quoteIdentifier(opts.IncrementalKey), formatIntervalValue(opts.IntervalEnd)))
-		}
-	}
+	// DefaultSQLTimeFormat keeps the timezone offset so bounds are unambiguous
+	// regardless of the Vertica session timezone.
+	conditions := source.SQLTimeRangeConditions(opts.IncrementalKey, opts.IntervalStart, opts.IntervalEnd, "<=", quoteIdentifier, source.DefaultSQLTimeFormat)
 	if len(conditions) > 0 {
 		query += " WHERE " + strings.Join(conditions, " AND ")
 	}
@@ -412,13 +406,6 @@ func buildSelectQuery(table string, columns []schema.Column, decimalCols map[str
 	}
 
 	return query
-}
-
-func formatIntervalValue(v *time.Time) string {
-	if v == nil {
-		return ""
-	}
-	return v.Format("2006-01-02 15:04:05.999999")
 }
 
 func quoteIdentifier(name string) string {

--- a/pkg/source/vertica/vertica.go
+++ b/pkg/source/vertica/vertica.go
@@ -1,0 +1,499 @@
+package vertica
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	verticadest "github.com/bruin-data/ingestr/pkg/destination/vertica"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	_ "github.com/vertica/vertica-sql-go"
+)
+
+const defaultVerticaSchema = "public"
+
+// maxDecimal128Precision is the largest precision Arrow's Decimal128 can hold.
+// Vertica NUMERIC allows up to 1024, so anything wider is carried as exact text.
+const maxDecimal128Precision = 38
+
+// resolveDecimalType downgrades a decimal whose precision exceeds Decimal128's
+// limit to a string so the exact value survives instead of overflowing.
+func resolveDecimalType(dt schema.DataType, precision int) schema.DataType {
+	if dt == schema.TypeDecimal && precision > maxDecimal128Precision {
+		return schema.TypeString
+	}
+	return dt
+}
+
+// VerticaSource reads from Vertica over the native protocol via the
+// vertica-sql-go database/sql driver. Type mapping is shared with the Vertica
+// destination through verticadest.MapVerticaTypeToSchema.
+type VerticaSource struct {
+	db            *sql.DB
+	uri           string
+	currentSchema string
+}
+
+func NewVerticaSource() *VerticaSource {
+	return &VerticaSource{}
+}
+
+func (s *VerticaSource) Schemes() []string {
+	return []string{"vertica"}
+}
+
+func (s *VerticaSource) Connect(ctx context.Context, uri string) error {
+	db, err := sql.Open("vertica", uri)
+	if err != nil {
+		return fmt.Errorf("failed to open Vertica connection: %w", err)
+	}
+	db.SetMaxOpenConns(10)
+	db.SetMaxIdleConns(5)
+	db.SetConnMaxLifetime(5 * time.Minute)
+
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to ping Vertica: %w", err)
+	}
+
+	s.db = db
+	s.uri = uri
+	s.currentSchema = defaultVerticaSchema
+	var currentSchema sql.NullString
+	if err := db.QueryRowContext(ctx, "SELECT CURRENT_SCHEMA").Scan(&currentSchema); err == nil && currentSchema.Valid && currentSchema.String != "" {
+		s.currentSchema = currentSchema.String
+	}
+	config.Debug("[SOURCE] Vertica connected (schema: %s)", s.currentSchema)
+	return nil
+}
+
+func (s *VerticaSource) Close(ctx context.Context) error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+func (s *VerticaSource) HandlesIncrementality() bool {
+	return false
+}
+
+func (s *VerticaSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	if _, ok := source.IsCustomQuery(req.Name); ok {
+		return source.CustomQueryTable(req, s.ExecuteCustomQuery)
+	}
+
+	tableSchema, decimalCols, err := s.getSchema(ctx, req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	pks := req.PrimaryKeys
+	if len(pks) == 0 {
+		pks = tableSchema.PrimaryKeys
+	}
+
+	strategy := req.Strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+
+	tableName := req.Name
+
+	return &source.DynamicSourceTable{
+		TableName:           tableName,
+		TablePrimaryKeys:    pks,
+		TableIncrementalKey: req.IncrementalKey,
+		TableStrategy:       strategy,
+		KnownSchema:         true,
+		SchemaFn: func(ctx context.Context) (*schema.TableSchema, error) {
+			return tableSchema, nil
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			return s.read(ctx, tableName, tableSchema, decimalCols, opts)
+		},
+	}, nil
+}
+
+// getSchema returns the table schema along with the set of columns whose values
+// must be read as text (numeric columns; see buildSelectQuery).
+func (s *VerticaSource) getSchema(ctx context.Context, table string) (*schema.TableSchema, map[string]bool, error) {
+	schemaName, tableName := s.parseTableName(table)
+
+	query := `
+		SELECT column_name, data_type, is_nullable, numeric_precision, numeric_scale, character_maximum_length
+		FROM v_catalog.columns
+		WHERE table_schema = ? AND table_name = ?
+		ORDER BY ordinal_position`
+
+	rows, err := s.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to query table schema: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []schema.Column
+	decimalCols := make(map[string]bool)
+	for rows.Next() {
+		var colName, dataType string
+		var nullable bool
+		var precision, scale, charLen sql.NullInt64
+		if err := rows.Scan(&colName, &dataType, &nullable, &precision, &scale, &charLen); err != nil {
+			return nil, nil, fmt.Errorf("failed to scan column: %w", err)
+		}
+		col := schema.Column{
+			Name:     colName,
+			DataType: verticadest.MapVerticaTypeToSchema(dataType),
+			Nullable: nullable,
+		}
+		if precision.Valid {
+			col.Precision = int(precision.Int64)
+		}
+		if scale.Valid {
+			col.Scale = int(scale.Int64)
+		}
+		if charLen.Valid {
+			col.MaxLength = int(charLen.Int64)
+		}
+		// Numeric columns are read as exact text (see buildSelectQuery); wide
+		// ones that Decimal128 cannot hold are carried as strings.
+		if col.DataType == schema.TypeDecimal {
+			decimalCols[colName] = true
+			col.DataType = resolveDecimalType(col.DataType, col.Precision)
+		}
+		columns = append(columns, col)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("error iterating columns: %w", err)
+	}
+	if len(columns) == 0 {
+		return nil, nil, fmt.Errorf("table %s not found or has no columns", table)
+	}
+
+	primaryKeys, err := s.getPrimaryKeys(ctx, schemaName, tableName)
+	if err != nil {
+		return nil, nil, err
+	}
+	pkSet := make(map[string]bool, len(primaryKeys))
+	for _, pk := range primaryKeys {
+		pkSet[pk] = true
+	}
+	for i := range columns {
+		if pkSet[columns[i].Name] {
+			columns[i].IsPrimaryKey = true
+		}
+	}
+
+	return &schema.TableSchema{
+		Name:        tableName,
+		Schema:      schemaName,
+		Columns:     columns,
+		PrimaryKeys: primaryKeys,
+	}, decimalCols, nil
+}
+
+func (s *VerticaSource) getPrimaryKeys(ctx context.Context, schemaName, tableName string) ([]string, error) {
+	query := `
+		SELECT column_name
+		FROM v_catalog.primary_keys
+		WHERE table_schema = ? AND table_name = ?
+		ORDER BY ordinal_position`
+
+	rows, err := s.db.QueryContext(ctx, query, schemaName, tableName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query primary keys: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var primaryKeys []string
+	for rows.Next() {
+		var pk string
+		if err := rows.Scan(&pk); err != nil {
+			return nil, fmt.Errorf("failed to scan primary key: %w", err)
+		}
+		primaryKeys = append(primaryKeys, pk)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating primary keys: %w", err)
+	}
+	return primaryKeys, nil
+}
+
+func (s *VerticaSource) read(ctx context.Context, table string, tableSchema *schema.TableSchema, decimalCols map[string]bool, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	startTotal := time.Now()
+	config.Debug("[SOURCE] Starting read from %s", table)
+
+	columns := filterColumns(tableSchema.Columns, opts.ExcludeColumns)
+	arrowSchema := buildArrowSchema(columns)
+
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = 100000
+	}
+
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		query := buildSelectQuery(table, columns, decimalCols, opts)
+
+		rows, err := s.db.QueryContext(ctx, query)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to query: %w", err)}
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		batchNum := 0
+		totalRows := int64(0)
+		for {
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+				return
+			}
+			if count == 0 {
+				break
+			}
+			batchNum++
+			totalRows += count
+			results <- source.RecordBatchResult{Batch: record}
+		}
+		config.Debug("[SOURCE] Total: %d rows in %d batches, read time: %v", totalRows, batchNum, time.Since(startTotal))
+	}()
+
+	return results, nil
+}
+
+func (s *VerticaSource) ExecuteCustomQuery(ctx context.Context, query string, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+	batchSize := opts.PageSize
+	if batchSize <= 0 {
+		batchSize = 100000
+	}
+
+	results := make(chan source.RecordBatchResult, 8)
+
+	go func() {
+		defer close(results)
+
+		config.Debug("[SOURCE] Executing custom query: %s", query)
+		rows, err := s.db.QueryContext(ctx, query)
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to execute custom query: %w", err)}
+			return
+		}
+		defer func() { _ = rows.Close() }()
+
+		colTypes, err := rows.ColumnTypes()
+		if err != nil {
+			results <- source.RecordBatchResult{Err: fmt.Errorf("failed to get column types: %w", err)}
+			return
+		}
+
+		columns := customQueryColumns(colTypes)
+		arrowSchema := buildArrowSchema(columns)
+
+		for {
+			record, count, err := rowsToArrowRecordBatch(rows, arrowSchema, columns, batchSize, opts.MaxBatchBytes)
+			if err != nil {
+				results <- source.RecordBatchResult{Err: err}
+				return
+			}
+			if count == 0 {
+				break
+			}
+			results <- source.RecordBatchResult{Batch: record}
+		}
+	}()
+
+	return results, nil
+}
+
+// customQueryColumns infers the schema from a custom query's result columns.
+// vertica-sql-go decodes NUMERIC as float64; callers needing exact
+// high-precision decimals should CAST(... AS VARCHAR) in their query.
+func customQueryColumns(colTypes []*sql.ColumnType) []schema.Column {
+	columns := make([]schema.Column, len(colTypes))
+	for i, ct := range colTypes {
+		nullable, _ := ct.Nullable()
+		col := schema.Column{
+			Name:     ct.Name(),
+			DataType: verticadest.MapVerticaTypeToSchema(ct.DatabaseTypeName()),
+			Nullable: nullable,
+		}
+		if precision, scale, ok := ct.DecimalSize(); ok {
+			col.Precision = int(precision)
+			col.Scale = int(scale)
+		}
+		if length, ok := ct.Length(); ok {
+			col.MaxLength = int(length)
+		}
+		col.DataType = resolveDecimalType(col.DataType, col.Precision)
+		columns[i] = col
+	}
+	return columns
+}
+
+func (s *VerticaSource) parseTableName(table string) (string, string) {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return s.currentSchema, table
+}
+
+func filterColumns(columns []schema.Column, exclude []string) []schema.Column {
+	if len(exclude) == 0 {
+		return columns
+	}
+	excludeMap := make(map[string]bool)
+	for _, col := range exclude {
+		excludeMap[strings.ToLower(col)] = true
+	}
+	var filtered []schema.Column
+	for _, col := range columns {
+		if !excludeMap[strings.ToLower(col.Name)] {
+			filtered = append(filtered, col)
+		}
+	}
+	return filtered
+}
+
+func buildArrowSchema(columns []schema.Column) *arrow.Schema {
+	fields := make([]arrow.Field, len(columns))
+	for i, col := range columns {
+		fields[i] = arrow.Field{
+			Name:     col.Name,
+			Type:     schema.DataTypeToArrowType(col),
+			Nullable: col.Nullable,
+		}
+	}
+	return arrow.NewSchema(fields, nil)
+}
+
+func buildSelectQuery(table string, columns []schema.Column, decimalCols map[string]bool, opts source.ReadOptions) string {
+	colNames := make([]string, len(columns))
+	for i, col := range columns {
+		// vertica-sql-go decodes NUMERIC as float64, losing precision; casting to
+		// VARCHAR keeps the exact text for arrowconv to parse into decimal/string.
+		if decimalCols[col.Name] {
+			colNames[i] = fmt.Sprintf("CAST(%s AS VARCHAR) AS %s", quoteIdentifier(col.Name), quoteIdentifier(col.Name))
+		} else {
+			colNames[i] = quoteIdentifier(col.Name)
+		}
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM %s", strings.Join(colNames, ", "), quoteTable(table))
+
+	var conditions []string
+	if opts.IncrementalKey != "" {
+		if opts.IntervalStart != nil {
+			conditions = append(conditions, fmt.Sprintf("%s >= '%s'", quoteIdentifier(opts.IncrementalKey), formatIntervalValue(opts.IntervalStart)))
+		}
+		if opts.IntervalEnd != nil {
+			conditions = append(conditions, fmt.Sprintf("%s <= '%s'", quoteIdentifier(opts.IncrementalKey), formatIntervalValue(opts.IntervalEnd)))
+		}
+	}
+	if len(conditions) > 0 {
+		query += " WHERE " + strings.Join(conditions, " AND ")
+	}
+
+	if opts.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", opts.Limit)
+	}
+
+	return query
+}
+
+func formatIntervalValue(v *time.Time) string {
+	if v == nil {
+		return ""
+	}
+	return v.Format("2006-01-02 15:04:05.999999")
+}
+
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+func quoteTable(table string) string {
+	parts := strings.SplitN(table, ".", 2)
+	if len(parts) == 2 {
+		return quoteIdentifier(parts[0]) + "." + quoteIdentifier(parts[1])
+	}
+	return quoteIdentifier(table)
+}
+
+func rowsToArrowRecordBatch(rows *sql.Rows, arrowSchema *arrow.Schema, columns []schema.Column, batchSize int, maxBatchBytes int64) (arrow.RecordBatch, int64, error) {
+	mem := memory.NewGoAllocator()
+	builders := make([]array.Builder, len(columns))
+	for i, field := range arrowSchema.Fields() {
+		builders[i] = array.NewBuilder(mem, field.Type)
+	}
+	// Builders are always released; NewArray() copies into arrays that retain
+	// their own buffers, so releasing the builders afterward is safe.
+	defer func() {
+		for _, b := range builders {
+			b.Release()
+		}
+	}()
+
+	scanDest := make([]interface{}, len(columns))
+	for i := range columns {
+		scanDest[i] = new(interface{})
+	}
+
+	var rowCount int64
+	var accBytes int64
+	for rows.Next() {
+		if err := rows.Scan(scanDest...); err != nil {
+			return nil, 0, fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		for i, dest := range scanDest {
+			val := *dest.(*interface{})
+			arrowconv.AppendValue(builders[i], val)
+			if maxBatchBytes > 0 {
+				accBytes += arrowconv.ValueBytes(val)
+			}
+		}
+		rowCount++
+
+		if batchSize > 0 && rowCount >= int64(batchSize) {
+			break
+		}
+		if maxBatchBytes > 0 && accBytes >= maxBatchBytes {
+			break
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	if rowCount == 0 {
+		return nil, 0, nil
+	}
+
+	arrays := make([]arrow.Array, len(builders))
+	for i, b := range builders {
+		arrays[i] = b.NewArray()
+	}
+
+	record := array.NewRecordBatch(arrowSchema, arrays, rowCount)
+
+	for _, arr := range arrays {
+		arr.Release()
+	}
+
+	return record, rowCount, nil
+}

--- a/pkg/source/vertica/vertica_test.go
+++ b/pkg/source/vertica/vertica_test.go
@@ -1,0 +1,173 @@
+package vertica
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTableName(t *testing.T) {
+	s := &VerticaSource{currentSchema: "public"}
+	tests := []struct {
+		name       string
+		table      string
+		wantSchema string
+		wantTable  string
+	}{
+		{"schema and table", "sales.orders", "sales", "orders"},
+		{"table only falls back to current schema", "orders", "public", "orders"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSchema, gotTable := s.parseTableName(tt.table)
+			if gotSchema != tt.wantSchema || gotTable != tt.wantTable {
+				t.Errorf("parseTableName(%q) = (%q, %q), want (%q, %q)", tt.table, gotSchema, gotTable, tt.wantSchema, tt.wantTable)
+			}
+		})
+	}
+}
+
+func TestQuoteTable(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"orders", `"orders"`},
+		{"sales.orders", `"sales"."orders"`},
+		{`we"ird`, `"we""ird"`},
+	}
+	for _, tt := range tests {
+		if got := quoteTable(tt.input); got != tt.want {
+			t.Errorf("quoteTable(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildSelectQuery(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id"},
+		{Name: "name"},
+		{Name: "updated_at"},
+	}
+
+	t.Run("simple select", func(t *testing.T) {
+		query := buildSelectQuery("sales.orders", columns, nil, source.ReadOptions{})
+		expected := `SELECT "id", "name", "updated_at" FROM "sales"."orders"`
+		if query != expected {
+			t.Errorf("got %q, want %q", query, expected)
+		}
+	})
+
+	t.Run("decimal columns cast to varchar for exact precision", func(t *testing.T) {
+		cols := []schema.Column{
+			{Name: "id", DataType: schema.TypeInt64},
+			{Name: "amount", DataType: schema.TypeDecimal},
+		}
+		query := buildSelectQuery("orders", cols, map[string]bool{"amount": true}, source.ReadOptions{})
+		expected := `SELECT "id", CAST("amount" AS VARCHAR) AS "amount" FROM "orders"`
+		if query != expected {
+			t.Errorf("got %q, want %q", query, expected)
+		}
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		query := buildSelectQuery("orders", columns, nil, source.ReadOptions{Limit: 50})
+		expected := `SELECT "id", "name", "updated_at" FROM "orders" LIMIT 50`
+		if query != expected {
+			t.Errorf("got %q, want %q", query, expected)
+		}
+	})
+
+	t.Run("with incremental window", func(t *testing.T) {
+		start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2024, 2, 1, 12, 30, 0, 0, time.UTC)
+		query := buildSelectQuery("orders", columns, nil, source.ReadOptions{
+			IncrementalKey: "updated_at",
+			IntervalStart:  &start,
+			IntervalEnd:    &end,
+		})
+		expected := `SELECT "id", "name", "updated_at" FROM "orders" WHERE "updated_at" >= '2024-01-01 00:00:00' AND "updated_at" <= '2024-02-01 12:30:00'`
+		if query != expected {
+			t.Errorf("got %q, want %q", query, expected)
+		}
+	})
+}
+
+func TestFilterColumns(t *testing.T) {
+	columns := []schema.Column{
+		{Name: "id"},
+		{Name: "secret"},
+		{Name: "name"},
+	}
+	got := filterColumns(columns, []string{"SECRET"})
+	if len(got) != 2 || got[0].Name != "id" || got[1].Name != "name" {
+		t.Errorf("filterColumns dropped wrong columns: %+v", got)
+	}
+}
+
+func TestGetSchemaMapsCatalogTypesAndPrimaryKeys(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	s := &VerticaSource{db: db, currentSchema: "public"}
+
+	colRows := sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "numeric_precision", "numeric_scale", "character_maximum_length"}).
+		AddRow("id", "int", false, nil, nil, nil).
+		AddRow("price", "numeric(10,2)", true, 10, 2, nil).
+		AddRow("name", "varchar(255)", true, nil, nil, 255).
+		AddRow("big", "numeric(50,10)", true, 50, 10, nil).
+		AddRow("created_at", "timestamptz", true, nil, nil, nil)
+	mock.ExpectQuery("FROM v_catalog.columns").
+		WithArgs("sales", "orders").
+		WillReturnRows(colRows)
+
+	pkRows := sqlmock.NewRows([]string{"column_name"}).AddRow("id")
+	mock.ExpectQuery("FROM v_catalog.primary_keys").
+		WithArgs("sales", "orders").
+		WillReturnRows(pkRows)
+
+	ts, decimalCols, err := s.getSchema(context.Background(), "sales.orders")
+	require.NoError(t, err)
+	require.Equal(t, "orders", ts.Name)
+	require.Equal(t, "sales", ts.Schema)
+	require.Equal(t, []string{"id"}, ts.PrimaryKeys)
+	require.Len(t, ts.Columns, 5)
+
+	require.Equal(t, schema.TypeInt64, ts.Columns[0].DataType)
+	require.True(t, ts.Columns[0].IsPrimaryKey)
+
+	require.Equal(t, schema.TypeDecimal, ts.Columns[1].DataType)
+	require.Equal(t, 10, ts.Columns[1].Precision)
+	require.Equal(t, 2, ts.Columns[1].Scale)
+
+	require.Equal(t, schema.TypeString, ts.Columns[2].DataType)
+	require.Equal(t, 255, ts.Columns[2].MaxLength)
+
+	// Precision beyond Decimal128's limit is carried as text but still read via a cast.
+	require.Equal(t, schema.TypeString, ts.Columns[3].DataType)
+
+	require.Equal(t, schema.TypeTimestampTZ, ts.Columns[4].DataType)
+	require.False(t, ts.Columns[4].IsPrimaryKey)
+
+	// Both the representable and the wide numeric column must be read as text.
+	require.True(t, decimalCols["price"])
+	require.True(t, decimalCols["big"])
+	require.False(t, decimalCols["name"])
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestResolveDecimalType(t *testing.T) {
+	require.Equal(t, schema.TypeDecimal, resolveDecimalType(schema.TypeDecimal, 38))
+	require.Equal(t, schema.TypeDecimal, resolveDecimalType(schema.TypeDecimal, 10))
+	require.Equal(t, schema.TypeString, resolveDecimalType(schema.TypeDecimal, 39))
+	require.Equal(t, schema.TypeString, resolveDecimalType(schema.TypeDecimal, 1024))
+	// Non-decimal types are untouched.
+	require.Equal(t, schema.TypeString, resolveDecimalType(schema.TypeString, 100))
+}

--- a/pkg/source/vertica/vertica_test.go
+++ b/pkg/source/vertica/vertica_test.go
@@ -91,7 +91,7 @@ func TestBuildSelectQuery(t *testing.T) {
 			IntervalStart:  &start,
 			IntervalEnd:    &end,
 		})
-		expected := `SELECT "id", "name", "updated_at" FROM "orders" WHERE "updated_at" >= '2024-01-01 00:00:00' AND "updated_at" <= '2024-02-01 12:30:00'`
+		expected := `SELECT "id", "name", "updated_at" FROM "orders" WHERE "updated_at" >= '2024-01-01 00:00:00.000000+00:00' AND "updated_at" <= '2024-02-01 12:30:00.000000+00:00'`
 		if query != expected {
 			t.Errorf("got %q, want %q", query, expected)
 		}


### PR DESCRIPTION
## Summary

Adds Vertica as an ingestr **source** (it was already supported as a destination). Requested in #1131.

Implemented as a native `database/sql` source over `vertica-sql-go` (same driver the destination uses), modeled on the Oracle source.
