### PR TITLE
feat(trino): support transactional delete+insert

### DIFF
--- a/docs/getting-started/incremental-loading.md
+++ b/docs/getting-started/incremental-loading.md
@@ -266,7 +266,7 @@ A few important notes about the `delete+insert` strategy:
 - atomicity is destination-specific. Many SQL destinations wrap the delete and insert in a transaction or atomic script; ClickHouse uses an `ALTER TABLE ... DELETE` mutation followed by an insert.
 
 > [!WARNING]
-> **Breaking change:** `delete+insert` is no longer supported for **CrateDB** and **Trino** destinations. ingestr previously ran them as two non-atomic statements that could leave the table in a partially-updated state on failure or under concurrent runs. ingestr now fails this strategy up front for these destinations instead of loading data unsafely. Use `merge` or `replace` instead. See the [CrateDB](/supported-sources/cratedb) and [Trino](/supported-sources/trino) destination notes for details.
+> **Breaking change:** `delete+insert` is no longer supported for **CrateDB**. ingestr previously ran the delete and insert as two non-atomic statements that could leave the table partially updated on failure or under concurrent runs. See the [CrateDB](/supported-sources/cratedb) destination notes for details. Trino supports `delete+insert` through catalog transactions; see the [Trino](/supported-sources/trino) destination notes for connector and table restrictions.
 
 ### Example
 Let's assume you had the following source table slice:

--- a/docs/supported-sources/trino.md
+++ b/docs/supported-sources/trino.md
@@ -99,9 +99,23 @@ ingestr ingest \
 Ingestr creates new tables with `WITH (format_version = 3)` and writes JSON values as `VARIANT`. Existing tables must already use Iceberg format version 3 and their corresponding JSON columns must be `VARIANT`; ingestr does not upgrade tables or columns implicitly.
 
 ## Supported write dispositions
-When using Trino as a destination, ingestr supports `replace`, `append`, `merge`, and `scd2`.
+When using Trino as a destination, ingestr supports `replace`, `append`, `merge`, `delete+insert`, and `scd2`. For `delete+insert`, ingestr starts a Trino `READ WRITE` transaction and rolls it back if either statement fails:
 
-`delete+insert` is not supported for Trino destinations. Transaction support in Trino depends on the catalog connector, and ingestr does not expose a destination transaction for Trino. Because ingestr cannot make the delete and insert steps atomic across Trino catalogs, it fails this strategy before loading staging data.
+```bash
+ingestr ingest \
+    --source-uri 'postgresql://user:pass@localhost:5432/sourcedb' \
+    --source-table 'public.events' \
+    --dest-uri 'trino://admin@localhost:8080/hive/default' \
+    --dest-table 'default.events' \
+    --incremental-key 'partition_id' \
+    --incremental-strategy 'delete+insert'
+```
+
+Transaction and `DELETE` support depend on the Trino catalog connector and target table. ingestr enables the strategy by default and returns the error from Trino when the catalog or table does not support it. Verify compatibility for your deployment before using this strategy.
+
+The Hive connector supports multi-statement writes by default when `hive.single-statement-writes=false`. For ordinary non-transactional Hive tables, `DELETE` only works when its predicate selects complete partitions. This means the target table must already have compatible partitioning, the incremental key must be a partition column, and the interval bounds must cover complete partition values. Trino transactional Hive tables allow row-level deletes, but do not support writes in the explicit multi-statement transaction required by this strategy.
+
+The Iceberg connector does **not** support multi-statement writes in current Trino versions. Iceberg snapshot atomicity applies to each individual statement, not to a `DELETE` and `INSERT` spanning one Trino transaction. Iceberg and other unsupported connectors reject the operation with an error such as `Catalog only supports writes using autocommit`.
 
 ## Data type handling
 Trino automatically handles most SQL data type conversions. When used as a destination:

--- a/pkg/destination/trino/auth.go
+++ b/pkg/destination/trino/auth.go
@@ -3,8 +3,10 @@ package trino
 import (
 	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -54,14 +56,16 @@ func isVerifyBool(v string) bool {
 	return false
 }
 
-// buildAndRegisterCustomClient builds an *http.Client from cert/key,
-// http_headers, and verify=false query parameters, registers it with
-// trino-go-client, and returns the registration key. Empty string means no
-// custom client is needed.
-func buildAndRegisterCustomClient(q url.Values) (string, error) {
+// buildAndRegisterCustomClient builds an *http.Client from the connection
+// options, adds transaction tracking, and registers it with trino-go-client.
+func buildAndRegisterCustomClient(q url.Values) (string, *transactionRegistry, error) {
 	certPath := q.Get("cert")
 	keyPath := q.Get("key")
 	headersRaw := q.Get("http_headers")
+	caCertPath := q.Get("SSLCertPath")
+	caCertBytes := []byte(q.Get("SSLCert"))
+	q.Del("SSLCertPath")
+	q.Del("SSLCert")
 
 	insecureSkipVerify := false
 	if vals := q["verify"]; len(vals) > 0 {
@@ -72,18 +76,15 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 		q.Del("verify")
 	}
 
-	if certPath == "" && keyPath == "" && headersRaw == "" && !insecureSkipVerify {
-		return "", nil
-	}
 	if (certPath == "") != (keyPath == "") {
-		return "", fmt.Errorf("trino uri: cert and key must be provided together")
+		return "", nil, fmt.Errorf("trino uri: cert and key must be provided together")
 	}
 
 	var headers http.Header
 	if headersRaw != "" {
 		var parsed map[string]string
 		if err := json.Unmarshal([]byte(headersRaw), &parsed); err != nil {
-			return "", fmt.Errorf("trino uri: invalid http_headers JSON: %w", err)
+			return "", nil, fmt.Errorf("trino uri: invalid http_headers JSON: %w", err)
 		}
 		headers = make(http.Header, len(parsed))
 		for k, v := range parsed {
@@ -102,16 +103,33 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 	if certPath != "" {
 		var err error
 		if certBytes, err = os.ReadFile(certPath); err != nil {
-			return "", fmt.Errorf("trino uri: failed to read client certificate: %w", err)
+			return "", nil, fmt.Errorf("trino uri: failed to read client certificate: %w", err)
 		}
 		if keyBytes, err = os.ReadFile(keyPath); err != nil {
-			return "", fmt.Errorf("trino uri: failed to read client key: %w", err)
+			return "", nil, fmt.Errorf("trino uri: failed to read client key: %w", err)
 		}
 		cert, err := tls.X509KeyPair(certBytes, keyBytes)
 		if err != nil {
-			return "", fmt.Errorf("trino uri: failed to parse client certificate: %w", err)
+			return "", nil, fmt.Errorf("trino uri: failed to parse client certificate: %w", err)
 		}
 		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+	if caCertPath != "" {
+		var err error
+		caCertBytes, err = os.ReadFile(caCertPath)
+		if err != nil {
+			return "", nil, fmt.Errorf("trino uri: failed to read CA certificate: %w", err)
+		}
+	}
+	if len(caCertBytes) > 0 {
+		if tlsCfg == nil {
+			tlsCfg = &tls.Config{MinVersion: tls.VersionTLS12}
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(caCertBytes) {
+			return "", nil, errors.New("trino uri: failed to parse CA certificate")
+		}
+		tlsCfg.RootCAs = certPool
 	}
 
 	// Cache key hashes contents (not paths) so rotated certs get a fresh client.
@@ -120,16 +138,19 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 	h.Write([]byte{0})
 	h.Write(keyBytes)
 	h.Write([]byte{0})
+	h.Write(caCertBytes)
+	h.Write([]byte{0})
 	h.Write([]byte(headersRaw))
 	if insecureSkipVerify {
 		h.Write([]byte("\x00insecure"))
 	}
+	h.Write([]byte("\x00transactions-v1"))
 	name := "ingestr-trino-" + hex.EncodeToString(h.Sum(nil)[:8])
 
 	clientRegistryMu.Lock()
 	defer clientRegistryMu.Unlock()
-	if _, ok := registeredClients[name]; ok {
-		return name, nil
+	if client, ok := registeredClients[name]; ok {
+		return name, client.transactions, nil
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
@@ -137,20 +158,26 @@ func buildAndRegisterCustomClient(q url.Values) (string, error) {
 		transport.TLSClientConfig = tlsCfg
 	}
 	var rt http.RoundTripper = transport
+	transactions := newTransactionRegistry()
+	rt = &transactionRoundTripper{base: rt, registry: transactions}
 	if headers != nil {
-		rt = &headerRoundTripper{base: transport, headers: headers}
+		rt = &headerRoundTripper{base: rt, headers: headers}
 	}
 
 	if err := trino.RegisterCustomClient(name, &http.Client{Transport: rt}); err != nil {
-		return "", fmt.Errorf("trino uri: failed to register custom http client: %w", err)
+		return "", nil, fmt.Errorf("trino uri: failed to register custom http client: %w", err)
 	}
-	registeredClients[name] = struct{}{}
-	return name, nil
+	registeredClients[name] = registeredClient{transactions: transactions}
+	return name, transactions, nil
+}
+
+type registeredClient struct {
+	transactions *transactionRegistry
 }
 
 var (
 	clientRegistryMu  sync.Mutex
-	registeredClients = map[string]struct{}{}
+	registeredClients = map[string]registeredClient{}
 )
 
 type headerRoundTripper struct {

--- a/pkg/destination/trino/transaction.go
+++ b/pkg/destination/trino/transaction.go
@@ -1,0 +1,178 @@
+package trino
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+)
+
+const (
+	transactionIDHeader        = "X-Trino-Transaction-Id"
+	startedTransactionIDHeader = "X-Trino-Started-Transaction-Id"
+	clearTransactionIDHeader   = "X-Trino-Clear-Transaction-Id"
+	noTransactionID            = "NONE"
+)
+
+type transactionToken uint64
+
+type transactionContextKey struct{}
+
+type transactionRegistry struct {
+	mu      sync.RWMutex
+	next    transactionToken
+	entries map[transactionToken]string
+}
+
+func newTransactionRegistry() *transactionRegistry {
+	return &transactionRegistry{entries: make(map[transactionToken]string)}
+}
+
+func (r *transactionRegistry) begin(ctx context.Context) (context.Context, transactionToken) {
+	r.mu.Lock()
+	r.next++
+	token := r.next
+	r.entries[token] = noTransactionID
+	r.mu.Unlock()
+	return r.withToken(ctx, token), token
+}
+
+func (r *transactionRegistry) withToken(ctx context.Context, token transactionToken) context.Context {
+	return context.WithValue(ctx, transactionContextKey{}, token)
+}
+
+func (r *transactionRegistry) transactionID(token transactionToken) (string, bool) {
+	r.mu.RLock()
+	id, ok := r.entries[token]
+	r.mu.RUnlock()
+	return id, ok
+}
+
+func (r *transactionRegistry) setTransactionID(token transactionToken, id string) {
+	r.mu.Lock()
+	if _, ok := r.entries[token]; ok {
+		r.entries[token] = id
+	}
+	r.mu.Unlock()
+}
+
+func (r *transactionRegistry) remove(token transactionToken) {
+	r.mu.Lock()
+	delete(r.entries, token)
+	r.mu.Unlock()
+}
+
+type transactionRoundTripper struct {
+	base     http.RoundTripper
+	registry *transactionRegistry
+}
+
+// trino-go-client does not propagate Trino transaction headers. The context
+// token keeps concurrent logical transactions isolated on the shared client.
+func (t *transactionRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, transactional := req.Context().Value(transactionContextKey{}).(transactionToken)
+	if transactional {
+		if id, ok := t.registry.transactionID(token); ok {
+			req = req.Clone(req.Context())
+			req.Header.Set(transactionIDHeader, id)
+		}
+	}
+
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || !transactional {
+		return resp, err
+	}
+	if id := resp.Header.Get(startedTransactionIDHeader); id != "" {
+		t.registry.setTransactionID(token, id)
+	}
+	if resp.Header.Get(clearTransactionIDHeader) != "" {
+		t.registry.remove(token)
+	}
+	return resp, nil
+}
+
+type trinoTransaction struct {
+	mu       sync.Mutex
+	conn     *sql.Conn
+	registry *transactionRegistry
+	token    transactionToken
+	done     bool
+}
+
+func (t *trinoTransaction) Exec(ctx context.Context, query string, args ...interface{}) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.done {
+		return sql.ErrTxDone
+	}
+	_, err := t.conn.ExecContext(t.registry.withToken(ctx, t.token), query, args...)
+	if err != nil {
+		config.LogFailedQuery(query, err)
+	}
+	return err
+}
+
+func (t *trinoTransaction) Commit(ctx context.Context) error {
+	return t.finish(ctx, "COMMIT")
+}
+
+func (t *trinoTransaction) Rollback(ctx context.Context) error {
+	return t.finish(ctx, "ROLLBACK")
+}
+
+func (t *trinoTransaction) finish(ctx context.Context, query string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.done {
+		return sql.ErrTxDone
+	}
+
+	_, execErr := t.conn.ExecContext(t.registry.withToken(ctx, t.token), query)
+	t.done = true
+	t.registry.remove(t.token)
+	closeErr := t.conn.Close()
+	if execErr != nil {
+		config.LogFailedQuery(query, execErr)
+		return execErr
+	}
+	if closeErr != nil {
+		return fmt.Errorf("failed to release Trino transaction connection: %w", closeErr)
+	}
+	return nil
+}
+
+func (d *TrinoDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
+	if d.db == nil {
+		return nil, errors.New("trino destination is not connected")
+	}
+	if d.transactions == nil {
+		return nil, errors.New("trino transaction tracking is not configured")
+	}
+
+	conn, err := d.db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire Trino transaction connection: %w", err)
+	}
+	txCtx, token := d.transactions.begin(ctx)
+	if _, err := conn.ExecContext(txCtx, "START TRANSACTION READ WRITE"); err != nil {
+		d.transactions.remove(token)
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to start Trino transaction: %w", err)
+	}
+	if id, ok := d.transactions.transactionID(token); !ok || id == noTransactionID {
+		d.transactions.remove(token)
+		_ = conn.Close()
+		return nil, errors.New("failed to start Trino transaction: server did not return a transaction ID")
+	}
+
+	return &trinoTransaction{
+		conn:     conn,
+		registry: d.transactions,
+		token:    token,
+	}, nil
+}

--- a/pkg/destination/trino/transaction_integration_test.go
+++ b/pkg/destination/trino/transaction_integration_test.go
@@ -1,0 +1,248 @@
+//go:build integration
+
+package trino
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/source/adbc"
+	"github.com/bruin-data/ingestr/pkg/source/duckdb"
+	"github.com/bruin-data/ingestr/pkg/strategy"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	hiveCatalogProperties = `connector.name=hive
+hive.metastore.uri=thrift://hadoop-master:9083
+fs.hadoop.enabled=true
+hive.config.resources=/etc/trino/hdfs-site.xml
+hive.metastore-cache-ttl=0s
+hive.single-statement-writes=false
+`
+	hdfsSiteXML = `<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://hadoop-master:9000</value>
+  </property>
+  <property>
+    <name>dfs.client.use.datanode.hostname</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>dfs.datanode.use.datanode.hostname</name>
+    <value>true</value>
+  </property>
+  <property>
+    <name>dfs.replication</name>
+    <value>1</value>
+  </property>
+  <property>
+    <name>dfs.client.read.shortcircuit</name>
+    <value>false</value>
+  </property>
+</configuration>
+`
+)
+
+type hiveTransactionTestRow struct {
+	id          int64
+	value       string
+	partitionID int64
+}
+
+func TestDeleteInsertStrategyHiveTransaction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Trino integration test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	testNetwork, err := network.New(ctx)
+	require.NoError(t, err)
+	defer func() { _ = testNetwork.Remove(context.Background()) }()
+
+	hadoop, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "ghcr.io/trinodb/testing/hive3.1:129",
+			Hostname:     "hadoop-master",
+			Env:          map[string]string{"TZ": "UTC"},
+			ExposedPorts: []string{"9083/tcp"},
+			Networks:     []string{testNetwork.Name},
+			NetworkAliases: map[string][]string{
+				testNetwork.Name: {"hadoop-master"},
+			},
+			WaitingFor: wait.ForLog("success: hive-metastore entered RUNNING state").
+				WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = hadoop.Terminate(context.Background()) }()
+
+	trinoContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "trinodb/trino:483",
+			ExposedPorts: []string{"8080/tcp"},
+			Networks:     []string{testNetwork.Name},
+			Files: []testcontainers.ContainerFile{
+				{
+					Reader:            strings.NewReader(hiveCatalogProperties),
+					ContainerFilePath: "/etc/trino/catalog/hive.properties",
+					FileMode:          0o644,
+				},
+				{
+					Reader:            strings.NewReader(hdfsSiteXML),
+					ContainerFilePath: "/etc/trino/hdfs-site.xml",
+					FileMode:          0o644,
+				},
+			},
+			WaitingFor: wait.ForLog("======== SERVER STARTED ========").
+				WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	defer func() { _ = trinoContainer.Terminate(context.Background()) }()
+
+	host, err := trinoContainer.Host(ctx)
+	require.NoError(t, err)
+	port, err := trinoContainer.MappedPort(ctx, "8080/tcp")
+	require.NoError(t, err)
+
+	dest := NewTrinoDestination()
+	require.NoError(t, dest.Connect(ctx, fmt.Sprintf("trino://test@%s:%s/hive/ingestr_it", host, port.Port())))
+	defer func() { _ = dest.Close(context.Background()) }()
+	require.True(t, dest.SupportsDeleteInsertStrategy())
+
+	statements := []string{
+		"CREATE SCHEMA hive.ingestr_it",
+		"CREATE TABLE hive.ingestr_it.target (id BIGINT, value VARCHAR, partition_id BIGINT) WITH (format = 'ORC', partitioned_by = ARRAY['partition_id'])",
+		"INSERT INTO hive.ingestr_it.target VALUES (1, 'keep', 1), (2, 'old', 2)",
+		"CREATE TABLE hive.ingestr_it.stage_bad (id BIGINT, value ARRAY(VARCHAR), partition_id BIGINT) WITH (format = 'ORC')",
+		"INSERT INTO hive.ingestr_it.stage_bad VALUES (20, ARRAY['invalid'], 2)",
+	}
+	for _, statement := range statements {
+		require.NoError(t, dest.Exec(ctx, statement))
+	}
+
+	// A non-transactional Hive table can only delete complete partitions.
+	opts := destination.DeleteInsertOptions{
+		StagingTable:   "hive.ingestr_it.stage_bad",
+		TargetTable:    "hive.ingestr_it.target",
+		IncrementalKey: "partition_id",
+		IntervalStart:  int64(2),
+		IntervalEnd:    int64(2),
+		Columns:        []string{"id", "value", "partition_id"},
+		PrimaryKeys:    []string{"id"},
+	}
+	err = dest.DeleteInsertTable(ctx, opts)
+	require.ErrorContains(t, err, "failed to insert records")
+	require.ErrorContains(t, err, "mismatched column types")
+	require.Equal(t, []hiveTransactionTestRow{
+		{id: 1, value: "keep", partitionID: 1},
+		{id: 2, value: "old", partitionID: 2},
+	}, readHiveTransactionTestRows(t, ctx, dest))
+
+	require.NoError(t, dest.Exec(ctx, "CREATE TABLE hive.ingestr_it.stage_good (id BIGINT, value VARCHAR, partition_id BIGINT) WITH (format = 'ORC')"))
+	require.NoError(t, dest.Exec(ctx, "INSERT INTO hive.ingestr_it.stage_good VALUES (20, 'new', 2)"))
+	opts.StagingTable = "hive.ingestr_it.stage_good"
+	require.NoError(t, dest.DeleteInsertTable(ctx, opts))
+	require.Equal(t, []hiveTransactionTestRow{
+		{id: 1, value: "keep", partitionID: 1},
+		{id: 20, value: "new", partitionID: 2},
+	}, readHiveTransactionTestRows(t, ctx, dest))
+
+	sourcePath := filepath.Join(t.TempDir(), "source.duckdb")
+	sourceDialect := duckdb.NewDialect()
+	require.NoError(t, sourceDialect.EnsureDriver(ctx))
+	sourceDB, err := sql.Open("adbc_generic", fmt.Sprintf("driver=duckdb;path=%s", sourcePath))
+	require.NoError(t, err)
+	require.NoError(t, sourceDB.PingContext(ctx))
+	_, err = sourceDB.ExecContext(ctx, "CREATE TABLE events (id BIGINT, value VARCHAR, partition_id BIGINT)")
+	require.NoError(t, err)
+	_, err = sourceDB.ExecContext(ctx, "INSERT INTO events VALUES (30, 'materialized', 2)")
+	require.NoError(t, err)
+	require.NoError(t, sourceDB.Close())
+
+	require.NoError(t, dest.Exec(ctx, "CREATE TABLE hive.ingestr_it.materialized_target (id BIGINT, value VARCHAR, partition_id BIGINT) WITH (format = 'ORC', partitioned_by = ARRAY['partition_id'])"))
+	require.NoError(t, dest.Exec(ctx, "INSERT INTO hive.ingestr_it.materialized_target VALUES (1, 'outside-interval', 1), (2, 'replace-me', 2)"))
+
+	cfg := &config.IngestConfig{
+		SourceURI:           fmt.Sprintf("duckdb:///%s", sourcePath),
+		SourceTable:         "events",
+		DestURI:             fmt.Sprintf("trino://test@%s:%s/hive/ingestr_it", host, port.Port()),
+		DestTable:           "ingestr_it.materialized_target",
+		IncrementalStrategy: config.StrategyDeleteInsert,
+		IncrementalKey:      "partition_id",
+		PrimaryKeys:         []string{"id"},
+		NoLoadTimestamp:     true,
+		NoRunID:             true,
+	}
+	sourceConnector := adbc.NewADBCSource(sourceDialect)
+	require.NoError(t, sourceConnector.Connect(ctx, cfg.SourceURI))
+	defer func() { _ = sourceConnector.Close(context.Background()) }()
+	sourceTable, err := sourceConnector.GetTable(ctx, source.TableRequest{
+		Name:           cfg.SourceTable,
+		Strategy:       cfg.IncrementalStrategy,
+		IncrementalKey: cfg.IncrementalKey,
+		PrimaryKeys:    cfg.PrimaryKeys,
+	})
+	require.NoError(t, err)
+	sourceSchema, err := sourceTable.GetSchema(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, (&strategy.DeleteInsertStrategy{}).Execute(ctx, &strategy.IngestionJob{
+		Config:       cfg,
+		Table:        sourceTable,
+		Destination:  dest,
+		Schema:       sourceSchema,
+		SourceSchema: sourceSchema,
+	}))
+	require.Equal(t, []hiveTransactionTestRow{
+		{id: 1, value: "outside-interval", partitionID: 1},
+		{id: 30, value: "materialized", partitionID: 2},
+	}, readHiveTransactionTestTableRows(t, ctx, dest, "materialized_target"))
+	var stagingTableCount int
+	require.NoError(t, dest.db.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM hive.information_schema.tables
+		WHERE table_schema = '_bruin_staging'
+		  AND table_name LIKE 'ingestr_it__materialized_target_di_%'
+	`).Scan(&stagingTableCount))
+	require.Zero(t, stagingTableCount)
+}
+
+func readHiveTransactionTestRows(t *testing.T, ctx context.Context, dest *TrinoDestination) []hiveTransactionTestRow {
+	return readHiveTransactionTestTableRows(t, ctx, dest, "target")
+}
+
+func readHiveTransactionTestTableRows(t *testing.T, ctx context.Context, dest *TrinoDestination, table string) []hiveTransactionTestRow {
+	t.Helper()
+
+	rows, err := dest.db.QueryContext(ctx, fmt.Sprintf("SELECT id, value, partition_id FROM hive.ingestr_it.%s ORDER BY partition_id", quoteIdentifier(table)))
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var result []hiveTransactionTestRow
+	for rows.Next() {
+		var row hiveTransactionTestRow
+		require.NoError(t, rows.Scan(&row.id, &row.value, &row.partitionID))
+		result = append(result, row)
+	}
+	require.NoError(t, rows.Err())
+	return result
+}

--- a/pkg/destination/trino/transaction_test.go
+++ b/pkg/destination/trino/transaction_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/bruin-data/ingestr/pkg/destination"
+	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
 type recordedTrinoRequest struct {
@@ -24,13 +25,24 @@ type recordedTrinoRequest struct {
 
 func TestDeleteInsertTransactional(t *testing.T) {
 	tests := []struct {
-		name         string
-		failInsert   bool
-		cancelInsert bool
+		name               string
+		failInsert         bool
+		cancelInsert       bool
+		incrementalKeyType schema.DataType
+		intervalStart      interface{}
+		intervalEnd        interface{}
+		wantDeleteContains []string
 	}{
 		{name: "commit"},
 		{name: "rollback after insert failure", failInsert: true},
 		{name: "rollback after cancellation", cancelInsert: true},
+		{
+			name:               "date incremental key casts bounds",
+			incrementalKeyType: schema.TypeDate,
+			intervalStart:      "2024-01-01",
+			intervalEnd:        "2024-01-02",
+			wantDeleteContains: []string{`"updated_at" >= CAST(? AS DATE)`, `"updated_at" <= CAST(? AS DATE)`, "USING '2024-01-01', '2024-01-02'"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -109,14 +121,19 @@ func TestDeleteInsertTransactional(t *testing.T) {
 				t.Fatal("SupportsDeleteInsertStrategy() = false, want true")
 			}
 
+			intervalStart, intervalEnd := interface{}(10), interface{}(20)
+			if tt.intervalStart != nil {
+				intervalStart, intervalEnd = tt.intervalStart, tt.intervalEnd
+			}
 			err = dest.DeleteInsertTable(callCtx, destination.DeleteInsertOptions{
-				StagingTable:   "stage.events",
-				TargetTable:    "prod.events",
-				IncrementalKey: "updated_at",
-				IntervalStart:  10,
-				IntervalEnd:    20,
-				Columns:        []string{"id", "updated_at", "value"},
-				PrimaryKeys:    []string{"id"},
+				StagingTable:       "stage.events",
+				TargetTable:        "prod.events",
+				IncrementalKey:     "updated_at",
+				IncrementalKeyType: tt.incrementalKeyType,
+				IntervalStart:      intervalStart,
+				IntervalEnd:        intervalEnd,
+				Columns:            []string{"id", "updated_at", "value"},
+				PrimaryKeys:        []string{"id"},
 			})
 			if tt.cancelInsert {
 				if err == nil || !errors.Is(err, context.Canceled) {
@@ -155,10 +172,15 @@ func TestDeleteInsertTransactional(t *testing.T) {
 			if got[1].method != http.MethodGet || got[1].path != "/start/1" {
 				t.Errorf("start follow-up request = %+v", got[1])
 			}
-			if !strings.Contains(got[2].body, `DELETE FROM "hive"."prod"."events"`) ||
-				!strings.Contains(got[2].body, `"updated_at" >= ?`) ||
-				!strings.Contains(got[2].body, "USING 10, 20") {
-				t.Errorf("delete request body = %q", got[2].body)
+			wantDeleteContains := tt.wantDeleteContains
+			if wantDeleteContains == nil {
+				wantDeleteContains = []string{`"updated_at" >= ?`, "USING 10, 20"}
+			}
+			wantDeleteContains = append(wantDeleteContains, `DELETE FROM "hive"."prod"."events"`)
+			for _, want := range wantDeleteContains {
+				if !strings.Contains(got[2].body, want) {
+					t.Errorf("delete request body = %q, want substring %q", got[2].body, want)
+				}
 			}
 			if !strings.Contains(got[3].body, `INSERT INTO "hive"."prod"."events"`) ||
 				!strings.Contains(got[3].body, `PARTITION BY "id" ORDER BY "updated_at" DESC`) {

--- a/pkg/destination/trino/transaction_test.go
+++ b/pkg/destination/trino/transaction_test.go
@@ -1,6 +1,8 @@
 package trino
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,15 +24,24 @@ type recordedTrinoRequest struct {
 
 func TestDeleteInsertTransactional(t *testing.T) {
 	tests := []struct {
-		name       string
-		failInsert bool
+		name         string
+		failInsert   bool
+		cancelInsert bool
 	}{
 		{name: "commit"},
 		{name: "rollback after insert failure", failInsert: true},
+		{name: "rollback after cancellation", cancelInsert: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			callCtx := t.Context()
+			cancelQuery := func() {}
+			if tt.cancelInsert {
+				callCtx, cancelQuery = context.WithCancel(callCtx)
+			}
+			defer cancelQuery()
+
 			var (
 				mu       sync.Mutex
 				requests []recordedTrinoRequest
@@ -58,13 +69,18 @@ func TestDeleteInsertTransactional(t *testing.T) {
 				case 2:
 					_, _ = io.WriteString(w, `{"id":"delete","stats":{"state":"FINISHED"},"updateType":"DELETE","updateCount":2}`)
 				case 3:
+					if tt.cancelInsert {
+						cancelQuery()
+						<-r.Context().Done()
+						return
+					}
 					if tt.failInsert {
 						_, _ = io.WriteString(w, `{"id":"insert","stats":{"state":"FAILED"},"error":{"message":"insert failed","errorName":"GENERIC_INTERNAL_ERROR","errorType":"INTERNAL_ERROR"}}`)
 						return
 					}
 					_, _ = io.WriteString(w, `{"id":"insert","stats":{"state":"FINISHED"},"updateType":"INSERT","updateCount":2}`)
 				case 4:
-					if tt.failInsert {
+					if tt.failInsert || tt.cancelInsert {
 						w.Header().Set(clearTransactionIDHeader, "true")
 						_, _ = io.WriteString(w, `{"id":"rollback","stats":{"state":"FINISHED"},"updateType":"ROLLBACK"}`)
 						return
@@ -93,7 +109,7 @@ func TestDeleteInsertTransactional(t *testing.T) {
 				t.Fatal("SupportsDeleteInsertStrategy() = false, want true")
 			}
 
-			err = dest.DeleteInsertTable(t.Context(), destination.DeleteInsertOptions{
+			err = dest.DeleteInsertTable(callCtx, destination.DeleteInsertOptions{
 				StagingTable:   "stage.events",
 				TargetTable:    "prod.events",
 				IncrementalKey: "updated_at",
@@ -102,7 +118,11 @@ func TestDeleteInsertTransactional(t *testing.T) {
 				Columns:        []string{"id", "updated_at", "value"},
 				PrimaryKeys:    []string{"id"},
 			})
-			if tt.failInsert {
+			if tt.cancelInsert {
+				if err == nil || !errors.Is(err, context.Canceled) {
+					t.Fatalf("DeleteInsertTable() error = %v, want context cancellation", err)
+				}
+			} else if tt.failInsert {
 				if err == nil || !strings.Contains(err.Error(), "failed to insert records") {
 					t.Fatalf("DeleteInsertTable() error = %v, want insert failure", err)
 				}
@@ -114,7 +134,7 @@ func TestDeleteInsertTransactional(t *testing.T) {
 			got := append([]recordedTrinoRequest(nil), requests...)
 			mu.Unlock()
 			wantCount := 6
-			if tt.failInsert {
+			if tt.failInsert || tt.cancelInsert {
 				wantCount = 5
 			}
 			if len(got) != wantCount {
@@ -145,7 +165,7 @@ func TestDeleteInsertTransactional(t *testing.T) {
 				t.Errorf("insert request body = %q", got[3].body)
 			}
 			wantFinish := "COMMIT"
-			if tt.failInsert {
+			if tt.failInsert || tt.cancelInsert {
 				wantFinish = "ROLLBACK"
 			}
 			if got[4].body != wantFinish {

--- a/pkg/destination/trino/transaction_test.go
+++ b/pkg/destination/trino/transaction_test.go
@@ -1,0 +1,156 @@
+package trino
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/destination"
+)
+
+type recordedTrinoRequest struct {
+	method        string
+	path          string
+	transactionID string
+	body          string
+}
+
+func TestDeleteInsertTransactional(t *testing.T) {
+	tests := []struct {
+		name       string
+		failInsert bool
+	}{
+		{name: "commit"},
+		{name: "rollback after insert failure", failInsert: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				mu       sync.Mutex
+				requests []recordedTrinoRequest
+				server   *httptest.Server
+			)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				mu.Lock()
+				requestIndex := len(requests)
+				requests = append(requests, recordedTrinoRequest{
+					method:        r.Method,
+					path:          r.URL.Path,
+					transactionID: r.Header.Get(transactionIDHeader),
+					body:          string(body),
+				})
+				mu.Unlock()
+
+				w.Header().Set("Content-Type", "application/json")
+				switch requestIndex {
+				case 0:
+					_, _ = fmt.Fprintf(w, `{"id":"start","nextUri":%q,"stats":{"state":"QUEUED"}}`, server.URL+"/start/1")
+				case 1:
+					w.Header().Set(startedTransactionIDHeader, "tx-123")
+					_, _ = io.WriteString(w, `{"id":"start","stats":{"state":"FINISHED"},"updateType":"START TRANSACTION"}`)
+				case 2:
+					_, _ = io.WriteString(w, `{"id":"delete","stats":{"state":"FINISHED"},"updateType":"DELETE","updateCount":2}`)
+				case 3:
+					if tt.failInsert {
+						_, _ = io.WriteString(w, `{"id":"insert","stats":{"state":"FAILED"},"error":{"message":"insert failed","errorName":"GENERIC_INTERNAL_ERROR","errorType":"INTERNAL_ERROR"}}`)
+						return
+					}
+					_, _ = io.WriteString(w, `{"id":"insert","stats":{"state":"FINISHED"},"updateType":"INSERT","updateCount":2}`)
+				case 4:
+					if tt.failInsert {
+						w.Header().Set(clearTransactionIDHeader, "true")
+						_, _ = io.WriteString(w, `{"id":"rollback","stats":{"state":"FINISHED"},"updateType":"ROLLBACK"}`)
+						return
+					}
+					_, _ = fmt.Fprintf(w, `{"id":"commit","nextUri":%q,"stats":{"state":"RUNNING"}}`, server.URL+"/commit/1")
+				case 5:
+					w.Header().Set(clearTransactionIDHeader, "true")
+					_, _ = io.WriteString(w, `{"id":"commit","stats":{"state":"FINISHED"},"updateType":"COMMIT"}`)
+				default:
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			serverURL, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dest := NewTrinoDestination()
+			uri := fmt.Sprintf("trino://user@%s/hive/default?explicitPrepare=false", serverURL.Host)
+			if err := dest.Connect(t.Context(), uri); err != nil {
+				t.Fatalf("Connect() error = %v", err)
+			}
+			defer func() { _ = dest.Close(t.Context()) }()
+			if !dest.SupportsDeleteInsertStrategy() {
+				t.Fatal("SupportsDeleteInsertStrategy() = false, want true")
+			}
+
+			err = dest.DeleteInsertTable(t.Context(), destination.DeleteInsertOptions{
+				StagingTable:   "stage.events",
+				TargetTable:    "prod.events",
+				IncrementalKey: "updated_at",
+				IntervalStart:  10,
+				IntervalEnd:    20,
+				Columns:        []string{"id", "updated_at", "value"},
+				PrimaryKeys:    []string{"id"},
+			})
+			if tt.failInsert {
+				if err == nil || !strings.Contains(err.Error(), "failed to insert records") {
+					t.Fatalf("DeleteInsertTable() error = %v, want insert failure", err)
+				}
+			} else if err != nil {
+				t.Fatalf("DeleteInsertTable() error = %v", err)
+			}
+
+			mu.Lock()
+			got := append([]recordedTrinoRequest(nil), requests...)
+			mu.Unlock()
+			wantCount := 6
+			if tt.failInsert {
+				wantCount = 5
+			}
+			if len(got) != wantCount {
+				t.Fatalf("request count = %d, want %d: %+v", len(got), wantCount, got)
+			}
+			for i, request := range got {
+				wantTransactionID := "tx-123"
+				if i < 2 {
+					wantTransactionID = noTransactionID
+				}
+				if request.transactionID != wantTransactionID {
+					t.Errorf("request %d transaction ID = %q, want %q", i, request.transactionID, wantTransactionID)
+				}
+			}
+			if got[0].method != http.MethodPost || got[0].body != "START TRANSACTION READ WRITE" {
+				t.Errorf("start request = %+v", got[0])
+			}
+			if got[1].method != http.MethodGet || got[1].path != "/start/1" {
+				t.Errorf("start follow-up request = %+v", got[1])
+			}
+			if !strings.Contains(got[2].body, `DELETE FROM "hive"."prod"."events"`) ||
+				!strings.Contains(got[2].body, `"updated_at" >= ?`) ||
+				!strings.Contains(got[2].body, "USING 10, 20") {
+				t.Errorf("delete request body = %q", got[2].body)
+			}
+			if !strings.Contains(got[3].body, `INSERT INTO "hive"."prod"."events"`) ||
+				!strings.Contains(got[3].body, `PARTITION BY "id" ORDER BY "updated_at" DESC`) {
+				t.Errorf("insert request body = %q", got[3].body)
+			}
+			wantFinish := "COMMIT"
+			if tt.failInsert {
+				wantFinish = "ROLLBACK"
+			}
+			if got[4].body != wantFinish {
+				t.Errorf("finish request body = %q, want %q", got[4].body, wantFinish)
+			}
+		})
+	}
+}

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -21,10 +21,11 @@ import (
 )
 
 type TrinoDestination struct {
-	db       *sql.DB
-	catalog  string
-	schema   string
-	jsonType jsonTypeMode
+	db           *sql.DB
+	catalog      string
+	schema       string
+	jsonType     jsonTypeMode
+	transactions *transactionRegistry
 }
 
 func NewTrinoDestination() *TrinoDestination {
@@ -55,6 +56,7 @@ func (d *TrinoDestination) Connect(ctx context.Context, uri string) error {
 	d.catalog = connectionConfig.catalog
 	d.schema = connectionConfig.schema
 	d.jsonType = connectionConfig.jsonType
+	d.transactions = connectionConfig.transactions
 	config.Debug("[TRINO] Connected to catalog: %s, schema: %s, JSON type: %s", d.catalog, d.schema, d.jsonType)
 	return nil
 }
@@ -372,7 +374,44 @@ WHEN NOT MATCHED THEN INSERT (%s) VALUES (%s)`,
 }
 
 func (d *TrinoDestination) DeleteInsertTable(ctx context.Context, opts destination.DeleteInsertOptions) error {
-	return errors.New("delete+insert strategy is not supported for trino destination")
+	stagingCatalog, stagingSchema, stagingName := d.parseTableName(opts.StagingTable)
+	targetCatalog, targetSchema, targetName := d.parseTableName(opts.TargetTable)
+	stagingFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(stagingCatalog), quoteIdentifier(stagingSchema), quoteIdentifier(stagingName))
+	targetFQN := fmt.Sprintf("%s.%s.%s", quoteIdentifier(targetCatalog), quoteIdentifier(targetSchema), quoteIdentifier(targetName))
+	quotedIncrementalKey := quoteIdentifier(opts.IncrementalKey)
+
+	tx, err := d.BeginTransaction(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	deleteSQL := fmt.Sprintf(
+		"DELETE FROM %s WHERE %s >= ? AND %s <= ?",
+		targetFQN, quotedIncrementalKey, quotedIncrementalKey,
+	)
+	config.Debug("[TRINO DELETE+INSERT] Executing DELETE: %s", deleteSQL)
+	if err := tx.Exec(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {
+		return fmt.Errorf("failed to delete records: %w", err)
+	}
+
+	columnList := strings.Join(quoteColumns(opts.Columns), ", ")
+	selectClause := destination.DedupStagingSelect(
+		columnList,
+		strings.Join(quoteColumns(opts.PrimaryKeys), ", "),
+		stagingFQN,
+		quotedIncrementalKey,
+	)
+	insertSQL := fmt.Sprintf("INSERT INTO %s (%s) %s", targetFQN, columnList, selectClause)
+	config.Debug("[TRINO DELETE+INSERT] Executing INSERT: %s", insertSQL)
+	if err := tx.Exec(ctx, insertSQL); err != nil {
+		return fmt.Errorf("failed to insert records: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+	return nil
 }
 
 func (d *TrinoDestination) SCD2Table(ctx context.Context, opts destination.SCD2Options) error {
@@ -489,16 +528,11 @@ func (d *TrinoDestination) Exec(ctx context.Context, sqlStr string, args ...inte
 	return err
 }
 
-func (d *TrinoDestination) BeginTransaction(ctx context.Context) (destination.Transaction, error) {
-	_ = ctx
-	return nil, errors.New("trino destination does not support transactions")
-}
-
 func (d *TrinoDestination) SupportsReplaceStrategy() bool      { return true }
 func (d *TrinoDestination) SupportsAppendStrategy() bool       { return true }
 func (d *TrinoDestination) SupportsMergeStrategy() bool        { return true }
 func (d *TrinoDestination) SupportsIncrementalPredicate() bool { return true }
-func (d *TrinoDestination) SupportsDeleteInsertStrategy() bool { return false }
+func (d *TrinoDestination) SupportsDeleteInsertStrategy() bool { return true }
 func (d *TrinoDestination) SupportsSCD2Strategy() bool         { return true }
 func (d *TrinoDestination) SupportsAtomicSwap() bool           { return false }
 
@@ -516,10 +550,11 @@ const (
 )
 
 type trinoConnectionConfig struct {
-	dsn      string
-	catalog  string
-	schema   string
-	jsonType jsonTypeMode
+	dsn          string
+	catalog      string
+	schema       string
+	jsonType     jsonTypeMode
+	transactions *transactionRegistry
 }
 
 func (m jsonTypeMode) normalized() jsonTypeMode {
@@ -578,7 +613,7 @@ func parseTrinoURI(uri string) (trinoConnectionConfig, error) {
 
 	translateAliases(query)
 
-	customClient, err := buildAndRegisterCustomClient(query)
+	customClient, transactions, err := buildAndRegisterCustomClient(query)
 	if err != nil {
 		return trinoConnectionConfig{}, err
 	}
@@ -605,10 +640,11 @@ func parseTrinoURI(uri string) (trinoConnectionConfig, error) {
 	}
 
 	return trinoConnectionConfig{
-		dsn:      dsn,
-		catalog:  catalog,
-		schema:   schemaName,
-		jsonType: jsonType,
+		dsn:          dsn,
+		catalog:      catalog,
+		schema:       schemaName,
+		jsonType:     jsonType,
+		transactions: transactions,
 	}, nil
 }
 

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -384,7 +384,11 @@ func (d *TrinoDestination) DeleteInsertTable(ctx context.Context, opts destinati
 	if err != nil {
 		return err
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
+	defer func() {
+		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+		defer cancel()
+		_ = tx.Rollback(rollbackCtx)
+	}()
 
 	deleteSQL := fmt.Sprintf(
 		"DELETE FROM %s WHERE %s >= ? AND %s <= ?",

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -390,9 +390,15 @@ func (d *TrinoDestination) DeleteInsertTable(ctx context.Context, opts destinati
 		_ = tx.Rollback(rollbackCtx)
 	}()
 
+	// DATE bounds arrive as date-only strings, which trino-go-client serializes as
+	// varchar; cast them so Trino can compare against a DATE column.
+	boundPlaceholder := "?"
+	if opts.IncrementalKeyType == schema.TypeDate {
+		boundPlaceholder = "CAST(? AS DATE)"
+	}
 	deleteSQL := fmt.Sprintf(
-		"DELETE FROM %s WHERE %s >= ? AND %s <= ?",
-		targetFQN, quotedIncrementalKey, quotedIncrementalKey,
+		"DELETE FROM %s WHERE %s >= %s AND %s <= %s",
+		targetFQN, quotedIncrementalKey, boundPlaceholder, quotedIncrementalKey, boundPlaceholder,
 	)
 	config.Debug("[TRINO DELETE+INSERT] Executing DELETE: %s", deleteSQL)
 	if err := tx.Exec(ctx, deleteSQL, opts.IntervalStart, opts.IntervalEnd); err != nil {

--- a/pkg/destination/trino/trino_test.go
+++ b/pkg/destination/trino/trino_test.go
@@ -2,13 +2,23 @@ package trino
 
 import (
 	"context"
+	"encoding/pem"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/bruin-data/ingestr/pkg/destination"
 )
 
 func TestParseTrinoURI(t *testing.T) {
+	tlsServer := httptest.NewTLSServer(nil)
+	t.Cleanup(tlsServer.Close)
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: tlsServer.Certificate().Raw})
+	if err := os.WriteFile(caPath, caPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		uri          string
 		wantCatalog  string
@@ -72,11 +82,10 @@ func TestParseTrinoURI(t *testing.T) {
 		},
 		{
 			// verify=<path> → SSLCertPath; verify=true silently dropped
-			uri:          "trino://host:443/cat?http_scheme=https&verify=%2Fetc%2Fssl%2Fca.pem",
+			uri:          "trino://host:443/cat?http_scheme=https&verify=" + caPath,
 			wantCatalog:  "cat",
 			wantSchema:   "default",
-			wantInDSN:    []string{"SSLCertPath=%2Fetc%2Fssl%2Fca.pem"},
-			wantNotInDSN: []string{"verify="},
+			wantNotInDSN: []string{"verify=", "SSLCertPath="},
 		},
 		{
 			// http_headers triggers custom-client registration
@@ -123,6 +132,12 @@ func TestParseTrinoURI(t *testing.T) {
 			if connectionConfig.jsonType != wantJSONType {
 				t.Errorf("json type mismatch: got %q want %q", connectionConfig.jsonType, wantJSONType)
 			}
+			if connectionConfig.transactions == nil {
+				t.Error("transaction registry is nil")
+			}
+			if !strings.Contains(connectionConfig.dsn, "custom_client=ingestr-trino-") {
+				t.Errorf("dsn %q missing transaction-aware custom client", connectionConfig.dsn)
+			}
 			for _, want := range tt.wantInDSN {
 				if !strings.Contains(connectionConfig.dsn, want) {
 					t.Errorf("dsn %q missing %q", connectionConfig.dsn, want)
@@ -158,32 +173,27 @@ func TestParseTrinoURI_InvalidJSONType(t *testing.T) {
 	}
 }
 
-func TestDeleteInsertUnsupported(t *testing.T) {
+func TestDeleteInsertSupportedByDefault(t *testing.T) {
 	t.Parallel()
 
 	dest := NewTrinoDestination()
-	if dest.SupportsDeleteInsertStrategy() {
-		t.Fatal("SupportsDeleteInsertStrategy() = true, want false")
-	}
-
-	err := dest.DeleteInsertTable(context.Background(), destination.DeleteInsertOptions{})
-	if err == nil || !strings.Contains(err.Error(), "delete+insert strategy is not supported") {
-		t.Fatalf("DeleteInsertTable() error = %v, want unsupported error", err)
+	if !dest.SupportsDeleteInsertStrategy() {
+		t.Fatal("SupportsDeleteInsertStrategy() = false, want true")
 	}
 }
 
-func TestBeginTransactionUnsupported(t *testing.T) {
+func TestBeginTransactionNotConnected(t *testing.T) {
 	t.Parallel()
 
 	dest := NewTrinoDestination()
 	tx, err := dest.BeginTransaction(context.Background())
 	if err == nil {
-		t.Fatal("BeginTransaction() error = nil, want unsupported error")
+		t.Fatal("BeginTransaction() error = nil, want not connected error")
 	}
 	if tx != nil {
 		t.Fatalf("BeginTransaction() tx = %#v, want nil", tx)
 	}
-	if !strings.Contains(err.Error(), "does not support transactions") {
-		t.Fatalf("BeginTransaction() error = %v, want transaction unsupported error", err)
+	if !strings.Contains(err.Error(), "not connected") {
+		t.Fatalf("BeginTransaction() error = %v, want not connected error", err)
 	}
 }


### PR DESCRIPTION
## What

Enable `delete+insert` for Trino destinations by executing the delete and staged insert in an explicit Trino transaction. Catalogs and tables that do not support multi-statement writes return their native Trino error.

## Changes

- propagate Trino transaction IDs across all statement protocol responses while pinning each transaction to one SQL connection
- execute interval deletion and deduplicated staged insertion atomically, committing on success and rolling back on failure
- enable Trino `delete+insert` support by default while preserving custom headers, mTLS, CA certificates, and TLS verification options
- add protocol-level commit/rollback tests and a Docker integration test against Trino 483 with Hive Metastore/HDFS
- exercise the real delete+insert strategy from DuckDB extraction through Trino staging, interval detection, finalization, and cleanup
- document Hive partition requirements and current Iceberg autocommit limitations

## How to test

1. `make format LINT_CONCURRENCY=1`
2. `make lint LINT_CONCURRENCY=1`
3. `make test TEST_CONCURRENCY=1`
4. `go test -race ./pkg/destination/trino -count=1`
5. `go test -tags integration ./pkg/destination/trino -run '^TestDeleteInsertStrategyHiveTransaction$' -count=1 -v`

The Docker test verifies that a failed insert rolls back a preceding whole-partition Hive delete, a valid replacement commits, rows outside the interval remain unchanged, and managed staging is cleaned up.

## Risk & rollback

- **Risk:** Medium. Every Trino destination connection now uses the transaction-aware HTTP transport. URI parsing tests cover existing authentication/TLS client options, and unsupported catalog transaction modes fail before modifying target data.
- **Rollback:** Revert the merge commit.

## Checklist

- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [x] Targeted Docker integration test passes
- [x] No unrelated changes included
- [x] Tested locally

## Security

- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

Closes #1169