### PR TITLE
Harden PostgreSQL CDC source correctness

### DIFF
--- a/docs/supported-sources/postgres.md
+++ b/docs/supported-sources/postgres.md
@@ -59,6 +59,8 @@ For `REPLICA IDENTITY USING INDEX`, ingestr uses the selected index's key column
 
 If you update a table's merge key, use `ALTER TABLE schema.table REPLICA IDENTITY FULL` before making those updates. PostgreSQL can omit unchanged TOAST values (large text, JSON, binary, or array values) from the new row image. ingestr preserves them from the old row image or earlier pending changes. If neither contains the value, the run fails before emitting the key move. Enable `REPLICA IDENTITY FULL` and run with `--full-refresh` to recover from an already logged incomplete key move.
 
+Publications must publish `insert`, `update`, `delete`, and `truncate`. ingestr rejects missing operations before taking a snapshot and rechecks publication coverage during replication, even when table discovery is disabled. After restoring a publication that may have skipped events, use `--full-refresh` to rebuild the destination.
+
 Stored generated columns require PostgreSQL 18 or newer and a publication with `publish_generated_columns = stored`. ingestr enables this option on publications it manages. For a custom publication, run `ALTER PUBLICATION publication_name SET (publish_generated_columns = stored)` yourself. Earlier PostgreSQL versions and virtual generated columns are rejected before the snapshot because their values cannot be kept current through logical replication. See [PostgreSQL's generated-column replication documentation](https://www.postgresql.org/docs/18/logical-replication-gencols.html).
 
 ### Tutorial

--- a/docs/supported-sources/postgres.md
+++ b/docs/supported-sources/postgres.md
@@ -55,6 +55,9 @@ With a user-managed publication (`publication=` supplied), ingestr never alters 
 
 The backfill-plus-stream handoff is safe under the `merge` strategy: changes that fall in the overlap between the snapshot and the WAL stream are applied idempotently by primary key. Tables without a primary key (or replica identity) cannot be part of logical replication and are skipped with a warning.
 
+If you update a table's merge key, use `ALTER TABLE schema.table REPLICA IDENTITY FULL` before making those updates. PostgreSQL can omit unchanged TOAST values (large text, JSON, binary, or array values) from the new row image. ingestr preserves them from the old row image or earlier pending changes. If neither contains the value, the run fails before emitting the key move. Enable `REPLICA IDENTITY FULL` and run with `--full-refresh` to recover from an already logged incomplete key move.
+
+
 ### Tutorial
 
 For a step-by-step walkthrough — from enabling logical replication to streaming live inserts, updates, and deletes into DuckDB — see [Replicate PostgreSQL to DuckDB with CDC](/tutorials/cdc-postgres-duckdb.md).

--- a/docs/supported-sources/postgres.md
+++ b/docs/supported-sources/postgres.md
@@ -55,8 +55,9 @@ With a user-managed publication (`publication=` supplied), ingestr never alters 
 
 The backfill-plus-stream handoff is safe under the `merge` strategy: changes that fall in the overlap between the snapshot and the WAL stream are applied idempotently by primary key. Tables without a primary key (or replica identity) cannot be part of logical replication and are skipped with a warning.
 
-If you update a table's merge key, use `ALTER TABLE schema.table REPLICA IDENTITY FULL` before making those updates. PostgreSQL can omit unchanged TOAST values (large text, JSON, binary, or array values) from the new row image. ingestr preserves them from the old row image or earlier pending changes. If neither contains the value, the run fails before emitting the key move. Enable `REPLICA IDENTITY FULL` and run with `--full-refresh` to recover from an already logged incomplete key move.
+For `REPLICA IDENTITY USING INDEX`, ingestr uses the selected index's key columns for merging, even when the table also has a primary key. Index `INCLUDE` columns are not merge keys. Explicit `--primary-key` columns must match that identity unless the table uses `REPLICA IDENTITY FULL`. If identity keys change during a stream, restart with `--full-refresh` so the destination and decoder use the same keys.
 
+If you update a table's merge key, use `ALTER TABLE schema.table REPLICA IDENTITY FULL` before making those updates. PostgreSQL can omit unchanged TOAST values (large text, JSON, binary, or array values) from the new row image. ingestr preserves them from the old row image or earlier pending changes. If neither contains the value, the run fails before emitting the key move. Enable `REPLICA IDENTITY FULL` and run with `--full-refresh` to recover from an already logged incomplete key move.
 
 ### Tutorial
 

--- a/docs/supported-sources/postgres.md
+++ b/docs/supported-sources/postgres.md
@@ -59,6 +59,8 @@ For `REPLICA IDENTITY USING INDEX`, ingestr uses the selected index's key column
 
 If you update a table's merge key, use `ALTER TABLE schema.table REPLICA IDENTITY FULL` before making those updates. PostgreSQL can omit unchanged TOAST values (large text, JSON, binary, or array values) from the new row image. ingestr preserves them from the old row image or earlier pending changes. If neither contains the value, the run fails before emitting the key move. Enable `REPLICA IDENTITY FULL` and run with `--full-refresh` to recover from an already logged incomplete key move.
 
+Stored generated columns require PostgreSQL 18 or newer and a publication with `publish_generated_columns = stored`. ingestr enables this option on publications it manages. For a custom publication, run `ALTER PUBLICATION publication_name SET (publish_generated_columns = stored)` yourself. Earlier PostgreSQL versions and virtual generated columns are rejected before the snapshot because their values cannot be kept current through logical replication. See [PostgreSQL's generated-column replication documentation](https://www.postgresql.org/docs/18/logical-replication-gencols.html).
+
 ### Tutorial
 
 For a step-by-step walkthrough — from enabling logical replication to streaming live inserts, updates, and deletes into DuckDB — see [Replicate PostgreSQL to DuckDB with CDC](/tutorials/cdc-postgres-duckdb.md).

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/bruin-data/ingestr/pkg/schemaevolution"
 	"github.com/bruin-data/ingestr/pkg/source"
+	_ "github.com/bruin-data/ingestr/pkg/source/mongodb"
+	_ "github.com/bruin-data/ingestr/pkg/source/postgres_cdc"
 	"github.com/bruin-data/ingestr/pkg/tablename"
 	"github.com/bruin-data/ingestr/pkg/transformer"
 	"github.com/stretchr/testify/require"

--- a/pkg/source/postgres_cdc/batch_accumulator.go
+++ b/pkg/source/postgres_cdc/batch_accumulator.go
@@ -26,6 +26,8 @@ var (
 // builders, schema construction, or batch concatenation.
 type batchAccumulator struct {
 	schemas map[string]*schema.TableSchema
+	toast   *toastState
+	durable func() pglogrepl.LSN
 	changes map[string][]Change
 	// minLSN tracks the lowest (oldest) transaction LSN still buffered per
 	// table. Changes are added in non-decreasing LSN order, so the first group
@@ -41,6 +43,7 @@ type batchAccumulator struct {
 func newBatchAccumulator(threshold int, schemas map[string]*schema.TableSchema) *batchAccumulator {
 	return &batchAccumulator{
 		schemas:   schemas,
+		toast:     newToastState(),
 		changes:   make(map[string][]Change),
 		minLSN:    make(map[string]pglogrepl.LSN),
 		bytes:     make(map[string]int64),
@@ -231,8 +234,16 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 	}
 	delete(a.bytes, tableName)
 
+	if a.durable != nil {
+		if err := a.toast.prune(ctx, a.durable()); err != nil {
+			return fmt.Errorf("failed to prune TOAST state: %w", err)
+		}
+	}
 	truncateIndex := lastTruncateIndex(changes)
 	if truncateIndex >= 0 {
+		if err := a.toast.truncate(ctx, tableName); err != nil {
+			return fmt.Errorf("failed to reset TOAST state: %w", err)
+		}
 		changes = changes[truncateIndex+1:]
 	}
 
@@ -249,7 +260,9 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 	// omitted column (the merge falls back to a target row that doesn't exist
 	// yet).
 	if len(changes) > 0 {
-		applyIntraBatchFill(changes, tableSchema)
+		if err := fillUnchangedColumns(ctx, changes, tableSchema, tableName, a.toast); err != nil {
+			return fmt.Errorf("failed to fill unchanged TOAST columns: %w", err)
+		}
 		changes = expandUpdates(changes, tableSchema)
 	}
 

--- a/pkg/source/postgres_cdc/cdc_fill_test.go
+++ b/pkg/source/postgres_cdc/cdc_fill_test.go
@@ -1,6 +1,7 @@
 package postgres_cdc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -356,4 +357,11 @@ func TestFlushWindowCompaction(t *testing.T) {
 		assert.Equal(t, int64(1), idCol.Value(0))
 		assert.Equal(t, int64(2), idCol.Value(1))
 	})
+}
+
+// applyIntraBatchFill is also used for standalone change windows in tests.
+func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
+	state := newToastState()
+	state.limit = 1<<63 - 1
+	_ = fillUnchangedColumns(context.Background(), changes, tableSchema, "", state)
 }

--- a/pkg/source/postgres_cdc/commit_state.go
+++ b/pkg/source/postgres_cdc/commit_state.go
@@ -144,17 +144,27 @@ func safeCommitLSN(repl lowWaterReporter, accum *batchAccumulator) pglogrepl.LSN
 // still pending in the replicator or accumulator, and the pipeline writes
 // buffered batches durably before committing, so confirming it cannot discard
 // un-emitted WAL. Returns the LSN to treat as the new lastEmitted; the caller
-// must only call this when streaming. The send respects ctx so a cancelled run
-// shutting down cannot wedge the reader on a channel the pipeline stopped draining.
-func emitIdleCommitToken(ctx context.Context, repl lowWaterReporter, accum *batchAccumulator, results chan<- source.RecordBatchResult, lastEmitted pglogrepl.LSN) pglogrepl.LSN {
+// must only call this when streaming. Publication coverage is revalidated
+// immediately before advancing so a cached check cannot skip unpublished
+// events. The send respects ctx so a cancelled run shutting down cannot wedge
+// the reader on a channel the pipeline stopped draining.
+func emitIdleCommitToken(ctx context.Context, repl lowWaterReporter, accum *batchAccumulator, results chan<- source.RecordBatchResult, lastEmitted pglogrepl.LSN) (pglogrepl.LSN, error) {
 	safe := safeCommitLSN(repl, accum)
 	if safe <= lastEmitted {
-		return lastEmitted
+		return lastEmitted, nil
+	}
+	if validator, ok := repl.(interface {
+		ValidateIdleCheckpoint(context.Context) error
+	}); ok {
+		if err := validator.ValidateIdleCheckpoint(ctx); err != nil {
+			return lastEmitted, err
+		}
 	}
 	if err := sendResult(ctx, results, source.RecordBatchResult{CommitToken: checkpointCommitToken(safe)}); err == nil {
-		return safe
+		return safe, nil
+	} else {
+		return lastEmitted, err
 	}
-	return lastEmitted
 }
 
 type streamHeartbeatEmitter interface {

--- a/pkg/source/postgres_cdc/commit_state_test.go
+++ b/pkg/source/postgres_cdc/commit_state_test.go
@@ -1,6 +1,8 @@
 package postgres_cdc
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -9,6 +11,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type guardedIdleReporter struct {
+	*fakeReplicator
+	err   error
+	calls int
+}
+
+func (r *guardedIdleReporter) ValidateIdleCheckpoint(context.Context) error {
+	r.calls++
+	return r.err
+}
 
 func TestStreamPosition_MonotonicMax(t *testing.T) {
 	p := newStreamPosition()
@@ -213,6 +226,27 @@ func TestSafeCommitLSN(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestIdleCommitTokenRequiresFreshPublicationValidation(t *testing.T) {
+	checkErr := errors.New("publication stopped publishing deletes")
+	repl := &guardedIdleReporter{fakeReplicator: &fakeReplicator{lsn: 500}, err: checkErr}
+	accum := testAccumulator(10000, "t")
+	results := make(chan source.RecordBatchResult, 1)
+
+	last, err := emitIdleCommitToken(t.Context(), repl, accum, results, 100)
+	require.ErrorIs(t, err, checkErr)
+	require.Equal(t, pglogrepl.LSN(100), last)
+	require.Empty(t, results)
+	require.Equal(t, 1, repl.calls)
+
+	repl.err = nil
+	last, err = emitIdleCommitToken(t.Context(), repl, accum, results, last)
+	require.NoError(t, err)
+	require.Equal(t, pglogrepl.LSN(500), last)
+	require.Equal(t, 2, repl.calls)
+	result := <-results
+	require.Equal(t, FormatLSN(500), result.CommitToken.(source.CDCStateCommitToken).Position)
 }
 
 // TestStreamLoopCumulativeTokens verifies that when a small transaction is

--- a/pkg/source/postgres_cdc/decoder.go
+++ b/pkg/source/postgres_cdc/decoder.go
@@ -51,18 +51,19 @@ type Change struct {
 }
 
 type Decoder struct {
-	tableSchema    *schema.TableSchema
-	targetSchema   string
-	targetTable    string
-	relations      map[uint32]*RelationInfo
-	targetRelID    uint32
-	expectedRelID  uint32
-	pendingChanges *changeSpool[Change]
-	committed      *changeSpool[Change]
-	currentTxLSN   pglogrepl.LSN
-	typeMap        *pgtype.Map
-	allowedUnknown map[string]struct{}
-	memoryBudget   *byteBudget
+	tableSchema      *schema.TableSchema
+	generatedColumns []string
+	targetSchema     string
+	targetTable      string
+	relations        map[uint32]*RelationInfo
+	targetRelID      uint32
+	expectedRelID    uint32
+	pendingChanges   *changeSpool[Change]
+	committed        *changeSpool[Change]
+	currentTxLSN     pglogrepl.LSN
+	typeMap          *pgtype.Map
+	allowedUnknown   map[string]struct{}
+	memoryBudget     *byteBudget
 }
 
 func NewDecoder(tableSchema *schema.TableSchema, schemaName, tableName string) *Decoder {
@@ -189,6 +190,9 @@ func (d *Decoder) handleRelation(data []byte) error {
 		if err := mapRelationToSchema(rel, prev, d.tableSchema, d.targetSchema+"."+d.targetTable, d.allowedUnknown); err != nil {
 			// Do not store rel on error: a rebuilt stream must retry against the
 			// last accepted relation so schema-change detection remains stable.
+			return err
+		}
+		if err := validateGeneratedRelation(rel, d.generatedColumns); err != nil {
 			return err
 		}
 	}

--- a/pkg/source/postgres_cdc/generated_columns.go
+++ b/pkg/source/postgres_cdc/generated_columns.go
@@ -1,0 +1,81 @@
+package postgres_cdc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+)
+
+func (s *PostgresCDCSource) getTableSchema(ctx context.Context, table string) (*schema.TableSchema, error) {
+	if err := s.validateGeneratedColumns(ctx, table); err != nil {
+		return nil, err
+	}
+	return getTableSchema(ctx, s.queryPool, table)
+}
+
+func (s *PostgresCDCSource) validateGeneratedColumns(ctx context.Context, table string) error {
+	if s.serverVersion < 120000 {
+		return nil
+	}
+	schemaName, tableName := parseTableName(table)
+	rows, err := s.queryPool.Query(ctx, `
+  SELECT a.attname, a.attgenerated::text
+  FROM pg_attribute a
+  JOIN pg_class c ON c.oid = a.attrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = $1 AND c.relname = $2
+    AND a.attnum > 0 AND NOT a.attisdropped AND a.attgenerated <> ''
+  ORDER BY a.attnum`, schemaName, tableName)
+	if err != nil {
+		return fmt.Errorf("failed to inspect generated columns for %s: %w", table, err)
+	}
+	defer rows.Close()
+	var columns []string
+	for rows.Next() {
+		var column, kind string
+		if err := rows.Scan(&column, &kind); err != nil {
+			return fmt.Errorf("failed to read generated column for %s: %w", table, err)
+		}
+		if s.serverVersion < 180000 || kind != "s" {
+			return fmt.Errorf("cannot replicate generated column %q on %s: postgres+cdc requires PostgreSQL 18 or newer and a stored generated column published with publish_generated_columns = stored; materialize it as an ordinary column to use older servers or virtual expressions", column, table)
+		}
+		columns = append(columns, column)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to read generated columns for %s: %w", table, err)
+	}
+	rows.Close()
+	if len(columns) > 0 {
+		var mode string
+		if err := s.queryPool.QueryRow(ctx, `SELECT pubgencols::text FROM pg_publication WHERE pubname = $1`, s.cdcConfig.Publication).Scan(&mode); err != nil {
+			return fmt.Errorf("failed to inspect generated-column publication coverage: %w", err)
+		}
+		if mode != "s" {
+			return fmt.Errorf("publication %q does not publish generated columns %v on %s; set publish_generated_columns = stored so the snapshot and WAL contain the same columns", s.cdcConfig.Publication, columns, table)
+		}
+	}
+	s.generatedColumns.Store(schemaName+"."+tableName, columns)
+	return nil
+}
+
+func (s *PostgresCDCSource) generatedColumnsFor(table string) []string {
+	schemaName, tableName := parseTableName(table)
+	value, ok := s.generatedColumns.Load(schemaName + "." + tableName)
+	if !ok {
+		return nil
+	}
+	return value.([]string)
+}
+
+func validateGeneratedRelation(rel *RelationInfo, columns []string) error {
+	if rel.Stale {
+		return nil
+	}
+	for _, column := range columns {
+		if !rel.hasColumn(column) {
+			return fmt.Errorf("generated column %q is missing from the WAL relation for %s.%s; ensure the publication still uses publish_generated_columns = stored and restart with --full-refresh", column, rel.Namespace, rel.Name)
+		}
+	}
+	return nil
+}

--- a/pkg/source/postgres_cdc/generated_columns_test.go
+++ b/pkg/source/postgres_cdc/generated_columns_test.go
@@ -1,0 +1,33 @@
+package postgres_cdc
+
+import (
+	"testing"
+
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedColumnCoverageInRelation(t *testing.T) {
+	sc := addCDCColumns(&schema.TableSchema{Name: "items", Schema: "public", PrimaryKeys: []string{"id"}, Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt32}, {Name: "computed", DataType: schema.TypeInt32}}})
+	missing := pgoRelationMsg(1, "public", "items")
+	complete := pgoRelationMsgWithCols(1, "public", "items", pgoCol{"id", 23}, pgoCol{"computed", 23})
+	single := NewDecoder(sc, "public", "items")
+	single.generatedColumns = []string{"computed"}
+	_, err := single.Decode(missing, 1)
+	require.ErrorContains(t, err, "generated column \"computed\" is missing")
+	require.Empty(t, single.relations)
+	_, err = single.Decode(complete, 2)
+	require.NoError(t, err)
+	// Publication changes must be checked on every relation announcement.
+	_, err = single.Decode(missing, 3)
+	require.ErrorContains(t, err, "publish_generated_columns")
+	multi := NewMultiTableDecoder([]source.SourceTableInfo{{Name: "public.items", Schema: sc}})
+	multi.generatedColumns = map[string][]string{"public.items": {"computed"}}
+	_, err = multi.Decode(missing, 1)
+	require.ErrorContains(t, err, "generated column \"computed\" is missing")
+	_, err = multi.Decode(complete, 2)
+	require.NoError(t, err)
+	_, err = multi.Decode(missing, 3)
+	require.ErrorContains(t, err, "publish_generated_columns")
+}

--- a/pkg/source/postgres_cdc/multitable_decoder.go
+++ b/pkg/source/postgres_cdc/multitable_decoder.go
@@ -35,18 +35,19 @@ func streamedChangeXID(change streamedChange) uint32 { return change.XID }
 // (Stream Start/Stop/Commit/Abort) and, when the stream runs with the
 // `binary 'true'` option, binary-format tuple data.
 type MultiTableDecoder struct {
-	tableSchemas   map[string]*schema.TableSchema // schema name.table name -> schema
-	expectedRelIDs map[string]uint32              // full table name -> connect-time relation ID
-	relations      map[uint32]*RelationInfo
-	targetRelIDs   map[uint32]string // relation ID -> full table name
-	pendingChanges *changeSpool[streamedChange]
-	committed      *changeSpool[streamedChange]
-	committedLSN   pglogrepl.LSN
-	currentTxLSN   pglogrepl.LSN
-	typeMap        *pgtype.Map
-	allowedUnknown map[string]map[string]struct{}
-	historicalIDs  map[string]map[uint32]struct{}
-	memoryBudget   *byteBudget
+	generatedColumns map[string][]string
+	tableSchemas     map[string]*schema.TableSchema // schema name.table name -> schema
+	expectedRelIDs   map[string]uint32              // full table name -> connect-time relation ID
+	relations        map[uint32]*RelationInfo
+	targetRelIDs     map[uint32]string // relation ID -> full table name
+	pendingChanges   *changeSpool[streamedChange]
+	committed        *changeSpool[streamedChange]
+	committedLSN     pglogrepl.LSN
+	currentTxLSN     pglogrepl.LSN
+	typeMap          *pgtype.Map
+	allowedUnknown   map[string]map[string]struct{}
+	historicalIDs    map[string]map[uint32]struct{}
+	memoryBudget     *byteBudget
 
 	// Protocol v2 streaming state. Between Stream Start and Stream Stop,
 	// change messages carry a subtransaction xid and are buffered per
@@ -337,6 +338,9 @@ func (d *MultiTableDecoder) handleRelation(data []byte) error {
 				// last accepted relation so schema-change detection remains stable.
 				return err
 			}
+		}
+		if err := validateGeneratedRelation(rel, d.generatedColumns[tableName]); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -195,8 +195,13 @@ func (r *MultiTableCDCReader) Read(ctx context.Context, opts source.MultiTableRe
 			}
 			signal, err := r.streamChanges(ctx, startLSN, barrierNonce, sqlBarrierLSN, slotName, results, opts)
 			if err != nil {
-				_ = sendResult(ctx, results, source.RecordBatchResult{Err: fmt.Errorf("streaming failed: %w", err)})
-				return
+				var schemaErr *SchemaChangedError
+				if !opts.Streaming || !errors.As(err, &schemaErr) {
+					_ = sendResult(ctx, results, source.RecordBatchResult{Err: fmt.Errorf("streaming failed: %w", err)})
+					return
+				}
+				output.Statusf("Schema change detected on table %s (column %q %s); rebuilding stream around the new schema\n", schemaErr.Table, schemaErr.Column, schemaErr.Reason)
+				signal = &streamSignal{changedTables: []string{schemaErr.Table}, schemaErrors: []*SchemaChangedError{schemaErr}}
 			}
 			if signal == nil {
 				return
@@ -971,7 +976,10 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 			// carried no rows for us; otherwise an idle stream's lag grows forever.
 			if opts.Streaming {
 				lastHeartbeat = maybeEmitStreamHeartbeat(ctx, repl, lastHeartbeat)
-				lastIdleToken = emitIdleCommitToken(ctx, repl, accum, results, lastIdleToken)
+				lastIdleToken, err = emitIdleCommitToken(ctx, repl, accum, results, lastIdleToken)
+				if err != nil {
+					return nil, err
+				}
 			}
 			time.Sleep(100 * time.Millisecond)
 		}

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -821,6 +821,10 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 		schemas[t.Name] = t.Schema
 	}
 	accum := newBatchAccumulator(batchSize, schemas)
+	defer func() { retErr = errors.Join(retErr, accum.toast.close()) }()
+	if opts.Streaming {
+		accum.durable = r.source.pos.Committed
+	}
 
 	// In streaming mode, batches carry a CommitToken (safe LSN) so the pipeline
 	// confirms the slot only after the data is durable. barrierNonce is empty in

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -393,6 +393,11 @@ func (r *MultiTableCDCReader) rebuildStream(ctx context.Context, slotName string
 		prevSchemas[t.Name] = t.Schema
 		prevIncarnations[t.Name] = t.Incarnation
 	}
+	for _, table := range tables {
+		if previous, ok := prevSchemas[table.Name]; ok && !sameKeyColumns(previous.PrimaryKeys, table.PrimaryKeys) {
+			return 0, fmt.Errorf("replica identity keys changed for %s; restart with --full-refresh to rebuild using keys %v", table.Name, table.PrimaryKeys)
+		}
+	}
 	var added []source.SourceTableInfo
 	for _, t := range tables {
 		if _, ok := prevSchemas[t.Name]; !ok {

--- a/pkg/source/postgres_cdc/multitable_replicator.go
+++ b/pkg/source/postgres_cdc/multitable_replicator.go
@@ -186,6 +186,10 @@ func (r *MultiTableReplicator) EmitStreamHeartbeat(ctx context.Context) error {
 	return emitStreamHeartbeat(ctx, r.source.queryPool)
 }
 
+func (r *MultiTableReplicator) ValidateIdleCheckpoint(ctx context.Context) error {
+	return r.publicationGuard.validate(ctx, true)
+}
+
 func (r *MultiTableReplicator) handleLogicalMessage(data []byte) (bool, error) {
 	message, err := parseLogicalDecodingMessage(data, r.protocolV2, r.decoder.InStream())
 	if err != nil || message == nil {

--- a/pkg/source/postgres_cdc/multitable_replicator.go
+++ b/pkg/source/postgres_cdc/multitable_replicator.go
@@ -54,6 +54,10 @@ type MultiTableReplicator struct {
 func NewMultiTableReplicator(src *PostgresCDCSource, tables []source.SourceTableInfo, cdcConfig CDCConfig, startLSN pglogrepl.LSN, lsnFilter LSNUpdater, streaming bool, barrierNonce string) (*MultiTableReplicator, error) {
 	decoderBudget := newByteBudget(defaultDecoderMemoryBytes)
 	decoder := newMultiTableDecoderWithBudget(tables, decoderBudget)
+	decoder.generatedColumns = make(map[string][]string, len(tables))
+	for _, table := range tables {
+		decoder.generatedColumns[table.Name] = src.generatedColumnsFor(table.Name)
+	}
 	if reader, ok := lsnFilter.(*MultiTableCDCReader); ok {
 		decoder.AllowUnknownRelationColumns(reader.allowedUnknown)
 		decoder.AllowHistoricalRelationIDs(reader.historicalRelIDs)

--- a/pkg/source/postgres_cdc/multitable_replicator.go
+++ b/pkg/source/postgres_cdc/multitable_replicator.go
@@ -30,22 +30,23 @@ type LSNUpdater interface {
 // channel, so batch mode's target check and safeCommitLSN never move past WAL
 // that is received but not yet decoded.
 type MultiTableReplicator struct {
-	source        *PostgresCDCSource
-	tables        []source.SourceTableInfo
-	cdcConfig     CDCConfig
-	startLSN      pglogrepl.LSN
-	decoder       *MultiTableDecoder
-	lsnFilter     LSNUpdater
-	clientXLogPos pglogrepl.LSN
-	barrierNonce  string
-	barrierSeen   bool
-	barrierLSN    pglogrepl.LSN
-	protocolV2    bool
-	started       bool
-	streaming     bool
-	recv          *walReceiver
-	decoderBudget *byteBudget
-	walBudget     *byteBudget
+	publicationGuard publicationGuard
+	source           *PostgresCDCSource
+	tables           []source.SourceTableInfo
+	cdcConfig        CDCConfig
+	startLSN         pglogrepl.LSN
+	decoder          *MultiTableDecoder
+	lsnFilter        LSNUpdater
+	clientXLogPos    pglogrepl.LSN
+	barrierNonce     string
+	barrierSeen      bool
+	barrierLSN       pglogrepl.LSN
+	protocolV2       bool
+	started          bool
+	streaming        bool
+	recv             *walReceiver
+	decoderBudget    *byteBudget
+	walBudget        *byteBudget
 
 	filterLSN       pglogrepl.LSN
 	filterDecisions map[string]bool
@@ -66,19 +67,20 @@ func NewMultiTableReplicator(src *PostgresCDCSource, tables []source.SourceTable
 	src.lag.streaming.Store(streaming)
 
 	return &MultiTableReplicator{
-		source:        src,
-		tables:        tables,
-		cdcConfig:     cdcConfig,
-		startLSN:      startLSN,
-		decoder:       decoder,
-		lsnFilter:     lsnFilter,
-		clientXLogPos: startLSN,
-		barrierNonce:  barrierNonce,
-		protocolV2:    streaming && src.serverVersion >= 140000,
-		started:       false,
-		streaming:     streaming,
-		decoderBudget: decoderBudget,
-		walBudget:     newByteBudget(defaultWALBufferBytes),
+		source:           src,
+		publicationGuard: newPublicationGuard(src),
+		tables:           tables,
+		cdcConfig:        cdcConfig,
+		startLSN:         startLSN,
+		decoder:          decoder,
+		lsnFilter:        lsnFilter,
+		clientXLogPos:    startLSN,
+		barrierNonce:     barrierNonce,
+		protocolV2:       streaming && src.serverVersion >= 140000,
+		started:          false,
+		streaming:        streaming,
+		decoderBudget:    decoderBudget,
+		walBudget:        newByteBudget(defaultWALBufferBytes),
 	}, nil
 }
 
@@ -208,6 +210,9 @@ func (r *MultiTableReplicator) handleLogicalMessage(data []byte) (bool, error) {
 // Returns (nil, true, nil) when WAL data was received but no commit completed
 // yet (e.g. buffering a transaction) or the commit was filtered.
 func (r *MultiTableReplicator) NextChanges(ctx context.Context) ([]DecodedChanges, bool, error) {
+	if err := r.publicationGuard.validate(ctx, false); err != nil {
+		return nil, false, err
+	}
 	if r.decoder.HasCommitted() {
 		groups, err := r.decoder.DrainCommitted(defaultCommittedDrainChanges)
 		if err != nil {
@@ -234,6 +239,9 @@ func (r *MultiTableReplicator) NextChanges(ctx context.Context) ([]DecodedChange
 
 	config.Debug("[CDC] Processing XLogData at LSN %s, data len=%d, first byte=%x", m.walStart, len(m.data), m.data[0])
 
+	if err := r.publicationGuard.validate(ctx, publicationCheckRequired(m.data)); err != nil {
+		return nil, true, err
+	}
 	handledLogicalMessage, err := r.handleLogicalMessage(m.data)
 	if err != nil {
 		return nil, true, err

--- a/pkg/source/postgres_cdc/publication_guard.go
+++ b/pkg/source/postgres_cdc/publication_guard.go
@@ -1,0 +1,38 @@
+package postgres_cdc
+
+import (
+	"context"
+	"time"
+)
+
+// Periodic checks also cover publications that stop sending all row events.
+// Relation and logical-message checks catch changes before decoding new row
+// shapes or acknowledging a batch barrier or stream heartbeat.
+type publicationGuard struct {
+	check    func(context.Context) error
+	last     time.Time
+	interval time.Duration
+}
+
+func newPublicationGuard(src *PostgresCDCSource) publicationGuard {
+	guard := publicationGuard{interval: 10 * time.Second}
+	if src.queryPool != nil {
+		guard.check = src.validatePublicationShape
+	}
+	return guard
+}
+
+func (g *publicationGuard) validate(ctx context.Context, force bool) error {
+	if g.check == nil || !force && time.Since(g.last) < g.interval {
+		return nil
+	}
+	if err := g.check(ctx); err != nil {
+		return err
+	}
+	g.last = time.Now()
+	return nil
+}
+
+func publicationCheckRequired(data []byte) bool {
+	return len(data) > 0 && (data[0] == msgTypeRelation || data[0] == 'M')
+}

--- a/pkg/source/postgres_cdc/publication_guard_test.go
+++ b/pkg/source/postgres_cdc/publication_guard_test.go
@@ -1,0 +1,26 @@
+package postgres_cdc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicationGuardRechecksCoverage(t *testing.T) {
+	calls := 0
+	var checkErr error
+	guard := publicationGuard{interval: time.Hour, check: func(context.Context) error { calls++; return checkErr }}
+	require.NoError(t, guard.validate(t.Context(), false))
+	require.Equal(t, 1, calls)
+	require.NoError(t, guard.validate(t.Context(), publicationCheckRequired([]byte{'I'})))
+	require.Equal(t, 1, calls, "ordinary row events must not query the catalog")
+	require.NoError(t, guard.validate(t.Context(), publicationCheckRequired([]byte{'R'})))
+	require.Equal(t, 2, calls)
+	checkErr = errors.New("publication stopped publishing deletes")
+	require.ErrorIs(t, guard.validate(t.Context(), publicationCheckRequired([]byte{'M'})), checkErr)
+	guard.last = time.Now().Add(-2 * time.Hour)
+	require.ErrorIs(t, guard.validate(t.Context(), false), checkErr, "quiet streams must also notice lost coverage")
+}

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -497,7 +497,10 @@ func streamLoop(ctx context.Context, repl batchReplicator, batchSize int, accum 
 			// carried no rows for us; otherwise an idle stream's lag grows forever.
 			if streaming {
 				lastHeartbeat = maybeEmitStreamHeartbeat(ctx, repl, lastHeartbeat)
-				lastIdleToken = emitIdleCommitToken(ctx, repl, accum, results, lastIdleToken)
+				lastIdleToken, err = emitIdleCommitToken(ctx, repl, accum, results, lastIdleToken)
+				if err != nil {
+					return err
+				}
 			}
 			time.Sleep(100 * time.Millisecond)
 		}

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -61,7 +61,7 @@ func (r *CDCReader) Read(ctx context.Context, opts source.ReadOptions) (<-chan s
 			config.Debug("[CDC] Resume metadata changed for %s; replacing its snapshot", r.tableName)
 			opts.CDCResumeLSN = ""
 			replacementSnapshot = true
-			tableSchema, err := getTableSchema(ctx, r.source.queryPool, r.tableName)
+			tableSchema, err := r.source.getTableSchema(ctx, r.tableName)
 			if err != nil {
 				_ = sendResult(ctx, results, source.RecordBatchResult{Err: err})
 				return
@@ -278,7 +278,7 @@ func (r *CDCReader) rebuildForTableChange(ctx context.Context, slotName string, 
 			return 0, fmt.Errorf("failed to reconcile publication after table recreation: %w", err)
 		}
 	}
-	tableSchema, err := getTableSchema(ctx, r.source.queryPool, r.tableName)
+	tableSchema, err := r.source.getTableSchema(ctx, r.tableName)
 	if err != nil {
 		return 0, fmt.Errorf("failed to refresh schema for table %s: %w", r.tableName, err)
 	}

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -246,6 +246,10 @@ func (r *CDCReader) runStream(ctx context.Context, startLSN pglogrepl.LSN, slotN
 	}
 
 	accum := newBatchAccumulator(batchSize, map[string]*schema.TableSchema{"": r.tableSchema})
+	defer func() { retErr = errors.Join(retErr, accum.toast.close()) }()
+	if opts.Streaming {
+		accum.durable = r.source.pos.Committed
+	}
 
 	err = streamLoop(ctx, repl, batchSize, accum, results, opts.Streaming)
 	if err == nil && !opts.Streaming {

--- a/pkg/source/postgres_cdc/reader.go
+++ b/pkg/source/postgres_cdc/reader.go
@@ -67,9 +67,11 @@ func (r *CDCReader) Read(ctx context.Context, opts source.ReadOptions) (<-chan s
 				return
 			}
 			tableSchema = addCDCColumns(tableSchema)
-			if len(r.tableSchema.PrimaryKeys) > 0 {
-				tableSchema.PrimaryKeys = r.tableSchema.PrimaryKeys
+			if err := validateConfiguredKeys(ctx, r.source.queryPool, r.tableName, tableSchema, r.tableSchema.PrimaryKeys); err != nil {
+				_ = sendResult(ctx, results, source.RecordBatchResult{Err: err})
+				return
 			}
+			tableSchema.PrimaryKeys = r.tableSchema.PrimaryKeys
 			r.tableSchema = tableSchema
 		}
 
@@ -284,9 +286,10 @@ func (r *CDCReader) rebuildForTableChange(ctx context.Context, slotName string, 
 	// Keep the merge keys the run started with: they may carry user-provided
 	// keys that re-detection would drop, and the decoder, compaction, and
 	// unchanged-TOAST fill must keep keying off the same columns.
-	if len(r.tableSchema.PrimaryKeys) > 0 {
-		tableSchema.PrimaryKeys = r.tableSchema.PrimaryKeys
+	if err := validateConfiguredKeys(ctx, r.source.queryPool, r.tableName, tableSchema, r.tableSchema.PrimaryKeys); err != nil {
+		return 0, err
 	}
+	tableSchema.PrimaryKeys = r.tableSchema.PrimaryKeys
 	r.tableSchema = tableSchema
 	if schemaErr != nil {
 		if r.allowedUnknown == nil {

--- a/pkg/source/postgres_cdc/relation.go
+++ b/pkg/source/postgres_cdc/relation.go
@@ -68,10 +68,11 @@ func (e *SchemaChangedError) Columns() []string {
 }
 
 type RelationInfo struct {
-	RelationID uint32
-	Namespace  string
-	Name       string
-	Columns    []RelationColumn
+	RelationID      uint32
+	ReplicaIdentity byte
+	Namespace       string
+	Name            string
+	Columns         []RelationColumn
 	// SchemaIndex maps each relation column to its index in the connect-time
 	// schema's source columns, resolved by name (-1 when the schema has no such
 	// column). Nil means no mapping was built and tuples decode positionally.
@@ -120,10 +121,11 @@ func parseRelationMessage(data []byte) (*RelationInfo, error) {
 	name, n := readString(data)
 	data = data[n:]
 
-	// Skip replica identity
+	// Replica identity determines which old-tuple columns can identify a row.
 	if len(data) < 1 {
 		return nil, fmt.Errorf("relation message missing replica identity")
 	}
+	identity := data[0]
 	data = data[1:]
 
 	if len(data) < 2 {
@@ -164,10 +166,11 @@ func parseRelationMessage(data []byte) (*RelationInfo, error) {
 	}
 
 	return &RelationInfo{
-		RelationID: relID,
-		Namespace:  namespace,
-		Name:       name,
-		Columns:    columns,
+		RelationID:      relID,
+		ReplicaIdentity: identity,
+		Namespace:       namespace,
+		Name:            name,
+		Columns:         columns,
 	}, nil
 }
 
@@ -283,6 +286,18 @@ func mapRelationToSchema(rel, prev *RelationInfo, tableSchema *schema.TableSchem
 	for i := 0; i < nSource; i++ {
 		if !mapped[i] {
 			config.Debug("[CDC] Table %s: column %q is missing from the replicated relation; its values will be NULL", tableName, tableSchema.Columns[i].Name)
+		}
+	}
+
+	if !rel.Stale && rel.ReplicaIdentity != 0 && rel.ReplicaIdentity != 'f' {
+		var identityKeys []string
+		for _, col := range rel.Columns {
+			if col.Flags&1 != 0 {
+				identityKeys = append(identityKeys, col.Name)
+			}
+		}
+		if len(tableSchema.PrimaryKeys) > 0 && !sameKeyColumns(tableSchema.PrimaryKeys, identityKeys) {
+			return fmt.Errorf("replica identity keys %v for %s do not match merge keys %v; restart with --full-refresh using the current replica identity, or configure REPLICA IDENTITY FULL", identityKeys, tableName, tableSchema.PrimaryKeys)
 		}
 	}
 

--- a/pkg/source/postgres_cdc/relation.go
+++ b/pkg/source/postgres_cdc/relation.go
@@ -80,6 +80,8 @@ type RelationInfo struct {
 	// Stale marks historical pre-DDL relation metadata replayed after the table
 	// was resnapshotted at a newer shape.
 	Stale bool
+	// MissingFromRelation marks schema columns with no value in this relation.
+	MissingFromRelation []bool
 }
 
 type RelationColumn struct {
@@ -274,6 +276,10 @@ func mapRelationToSchema(rel, prev *RelationInfo, tableSchema *schema.TableSchem
 		}
 		rel.SchemaIndex[i] = idx
 		mapped[idx] = true
+	}
+	rel.MissingFromRelation = make([]bool, nSource)
+	for i := 0; i < nSource; i++ {
+		rel.MissingFromRelation[i] = !mapped[i]
 	}
 	if len(mismatches) > 0 {
 		return newSchemaChangedError(tableName, mismatches)
@@ -484,6 +490,9 @@ func markMissingRelationColumnsUnchanged(values []interface{}, rel *RelationInfo
 	for i := range values {
 		if !mapped[i] {
 			values[i] = tupleUnchangedMarker
+			if i < len(rel.MissingFromRelation) && rel.MissingFromRelation[i] {
+				values[i] = tupleRelationMissingMarker
+			}
 		}
 	}
 }

--- a/pkg/source/postgres_cdc/replicator.go
+++ b/pkg/source/postgres_cdc/replicator.go
@@ -91,6 +91,7 @@ func NewReplicator(src *PostgresCDCSource, tableName string, tableSchema *schema
 	schemaName, tblName := parseTableName(tableName)
 
 	decoder := NewDecoder(tableSchema, schemaName, tblName)
+	decoder.generatedColumns = src.generatedColumnsFor(tableName)
 
 	src.lag.streaming.Store(streaming)
 

--- a/pkg/source/postgres_cdc/replicator.go
+++ b/pkg/source/postgres_cdc/replicator.go
@@ -183,6 +183,10 @@ func (r *Replicator) EmitStreamHeartbeat(ctx context.Context) error {
 	return emitStreamHeartbeat(ctx, r.source.queryPool)
 }
 
+func (r *Replicator) ValidateIdleCheckpoint(ctx context.Context) error {
+	return r.publicationGuard.validate(ctx, true)
+}
+
 func (r *Replicator) handleLogicalMessage(data []byte) (bool, error) {
 	message, err := parseLogicalDecodingMessage(data, false, false)
 	if err != nil || message == nil {

--- a/pkg/source/postgres_cdc/replicator.go
+++ b/pkg/source/postgres_cdc/replicator.go
@@ -14,6 +14,7 @@ import (
 
 type Replicator struct {
 	source                    *PostgresCDCSource
+	publicationGuard          publicationGuard
 	tableName                 string
 	tableSchema               *schema.TableSchema
 	cdcConfig                 CDCConfig
@@ -96,18 +97,19 @@ func NewReplicator(src *PostgresCDCSource, tableName string, tableSchema *schema
 	src.lag.streaming.Store(streaming)
 
 	return &Replicator{
-		source:        src,
-		tableName:     tableName,
-		tableSchema:   tableSchema,
-		cdcConfig:     cdcConfig,
-		startLSN:      startLSN,
-		decoder:       decoder,
-		clientXLogPos: startLSN,
-		barrierNonce:  barrierNonce,
-		standbyTimer:  time.Now(),
-		lastMessageAt: time.Now(),
-		started:       false,
-		streaming:     streaming,
+		source:           src,
+		publicationGuard: newPublicationGuard(src),
+		tableName:        tableName,
+		tableSchema:      tableSchema,
+		cdcConfig:        cdcConfig,
+		startLSN:         startLSN,
+		decoder:          decoder,
+		clientXLogPos:    startLSN,
+		barrierNonce:     barrierNonce,
+		standbyTimer:     time.Now(),
+		lastMessageAt:    time.Now(),
+		started:          false,
+		streaming:        streaming,
 		incarnationLookup: func(ctx context.Context) (string, error) {
 			return src.TableIncarnation(ctx, tableName)
 		},
@@ -214,6 +216,9 @@ func (r *Replicator) standbyStatus() pglogrepl.StandbyStatusUpdate {
 // Begin/Insert/Update/Delete messages awaiting a Commit). Callers use it to
 // avoid flushing the batch accumulator after every transaction.
 func (r *Replicator) NextChanges(ctx context.Context) ([]Change, pglogrepl.LSN, bool, error) {
+	if err := r.publicationGuard.validate(ctx, false); err != nil {
+		return nil, 0, false, err
+	}
 	if r.decoder.HasCommitted() {
 		changes, err := r.decoder.DrainCommitted(defaultCommittedDrainChanges)
 		return changes, r.decoder.CurrentTxLSN(), true, err
@@ -297,6 +302,9 @@ func (r *Replicator) NextChanges(ctx context.Context) ([]Change, pglogrepl.LSN, 
 				return nil, 0, true, fmt.Errorf("failed to parse xlog data: %w", err)
 			}
 
+			if err := r.publicationGuard.validate(ctx, publicationCheckRequired(xld.WALData)); err != nil {
+				return nil, 0, true, err
+			}
 			handledLogicalMessage, err := r.handleLogicalMessage(xld.WALData)
 			if err != nil {
 				return nil, 0, true, err

--- a/pkg/source/postgres_cdc/schema_change_test.go
+++ b/pkg/source/postgres_cdc/schema_change_test.go
@@ -204,7 +204,28 @@ func TestUpdateTreatsColumnsMissingFromPublicationTupleAsUnchanged(t *testing.T)
 	changes, err := d.Decode(pgoCommitMsg(100), 100)
 	require.NoError(t, err)
 	require.Len(t, changes, 1)
-	require.Equal(t, tupleUnchangedMarker, changes[0].Values[1])
+	require.Equal(t, tupleRelationMissingMarker, changes[0].Values[1])
+	require.True(t, isTupleUnchanged(changes[0].Values[1]))
+}
+
+func TestUpdateMarksColumnRemovedFromRelationAsChanged(t *testing.T) {
+	tableSchema := schemaChangeTestSchema(
+		schema.Column{Name: "id", DataType: schema.TypeInt32},
+		schema.Column{Name: "legacy", DataType: schema.TypeString},
+	)
+	d := NewDecoder(tableSchema, "public", "t")
+	_, err := d.Decode(pgoRelationMsgWithCols(1, "public", "t", pgoCol{"id", 23}, pgoCol{"legacy", 25}), 10)
+	require.NoError(t, err)
+	_, err = d.Decode(pgoRelationMsgWithCols(1, "public", "t", pgoCol{"id", 23}), 11)
+	require.NoError(t, err)
+	_, err = d.Decode(pgoBeginMsg(100), 12)
+	require.NoError(t, err)
+	_, err = d.Decode(pgoUpdateMsgWithVals(1, "7"), 13)
+	require.NoError(t, err)
+	changes, err := d.Decode(pgoCommitMsg(100), 100)
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	require.Equal(t, tupleRelationMissingMarker, changes[0].Values[1])
 }
 
 func TestDecoderRejectsColumnAddedMidStream(t *testing.T) {

--- a/pkg/source/postgres_cdc/schema_change_test.go
+++ b/pkg/source/postgres_cdc/schema_change_test.go
@@ -41,7 +41,11 @@ func pgoRelationMsgWithTypeMods(relID uint32, namespace, table string, cols ...p
 	data = append(data, 'd')
 	data = binary.BigEndian.AppendUint16(data, uint16(len(cols)))
 	for _, c := range cols {
-		data = append(data, 0x00)
+		flags := byte(0)
+		if c.name == "id" {
+			flags = 1
+		}
+		data = append(data, flags)
 		data = append(data, []byte(c.name+"\x00")...)
 		data = binary.BigEndian.AppendUint32(data, c.oid)
 		data = binary.BigEndian.AppendUint32(data, uint32(c.typemod))

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -72,7 +72,8 @@ type PostgresCDCSource struct {
 	cdcConfig CDCConfig
 	// serverVersion is the source's server_version_num, used to gate pgoutput
 	// options added in newer PostgreSQL releases.
-	serverVersion int
+	serverVersion    int
+	generatedColumns sync.Map
 	// pos holds the LSN the pipeline has confirmed durable in streaming mode.
 	// It is shared between the pipeline goroutine (CommitStream) and the
 	// replication goroutine (standby status updates).
@@ -263,6 +264,7 @@ func (s *PostgresCDCSource) Connect(ctx context.Context, uri string) error {
 	s.managedPublication = managedPublication
 	s.cdcConfig = cdcConfig
 	s.serverVersion = serverVersion
+	s.generatedColumns.Clear()
 	s.connectorIdentity = resolvedConnectorIdentity(system.SystemID, database, cdcConfig)
 
 	return nil
@@ -337,6 +339,11 @@ func (s *PostgresCDCSource) reconcileManagedPublication(ctx context.Context) err
 	}
 	if err := ensureManagedPublication(ctx, s.queryPool, s.cdcConfig.Publication, lockMigration); err != nil {
 		return fmt.Errorf("failed to ensure publication: %w", err)
+	}
+	if s.serverVersion >= 180000 {
+		if _, err := s.queryPool.Exec(ctx, "ALTER PUBLICATION "+quoteIdentifier(s.cdcConfig.Publication)+" SET (publish_generated_columns = stored)"); err != nil {
+			return fmt.Errorf("failed to enable generated columns for managed publication: %w", err)
+		}
 	}
 	return nil
 }
@@ -1302,7 +1309,7 @@ func (s *PostgresCDCSource) getTables(ctx context.Context, validateSelection boo
 		fullName, incarnation := entry.fullName, entry.incarnation
 
 		// Get schema for this table
-		tableSchema, err := getTableSchema(ctx, s.queryPool, fullName)
+		tableSchema, err := s.getTableSchema(ctx, fullName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get schema for table %s: %w", fullName, err)
 		}

--- a/pkg/source/postgres_cdc/source.go
+++ b/pkg/source/postgres_cdc/source.go
@@ -144,11 +144,39 @@ func (s *PostgresCDCSource) ValidateConnectorPreflight(ctx context.Context, opts
 			return err
 		}
 	}
-	return s.validatePublicationShape(ctx)
+	err := s.validatePublicationShape(ctx)
+	if s.managedPublication && errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	return err
 }
 
 func (s *PostgresCDCSource) validatePublicationShape(ctx context.Context) error {
-	if s.managedPublication || s.serverVersion < 150000 {
+	if s.queryPool == nil {
+		return fmt.Errorf("postgres CDC source is not connected")
+	}
+	truncateExpr := "pubtruncate"
+	if s.serverVersion < 110000 {
+		truncateExpr = "true"
+	}
+	var insert, update, deleteRows, truncate bool
+	err := s.queryPool.QueryRow(ctx, "SELECT pubinsert, pubupdate, pubdelete, "+truncateExpr+" FROM pg_publication WHERE pubname = $1", s.cdcConfig.Publication).Scan(&insert, &update, &deleteRows, &truncate)
+	if err != nil {
+		return fmt.Errorf("failed to validate PostgreSQL publication %q: %w", s.cdcConfig.Publication, err)
+	}
+	var missing []string
+	for _, operation := range []struct {
+		name    string
+		enabled bool
+	}{{"insert", insert}, {"update", update}, {"delete", deleteRows}, {"truncate", truncate}} {
+		if !operation.enabled {
+			missing = append(missing, operation.name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("PostgreSQL publication %q does not publish %s; postgres+cdc requires insert, update, delete, and truncate coverage; set publish = 'insert, update, delete, truncate' and use --full-refresh if events may already have been missed", s.cdcConfig.Publication, strings.Join(missing, ", "))
+	}
+	if s.serverVersion < 150000 {
 		return nil
 	}
 	rows, err := s.queryPool.Query(ctx, `
@@ -345,7 +373,7 @@ func (s *PostgresCDCSource) reconcileManagedPublication(ctx context.Context) err
 			return fmt.Errorf("failed to enable generated columns for managed publication: %w", err)
 		}
 	}
-	return nil
+	return s.validatePublicationShape(ctx)
 }
 
 // openReplicationConn opens an additional replication connection, e.g. for a
@@ -1223,6 +1251,9 @@ func (s *PostgresCDCSource) GetTables(ctx context.Context) ([]source.SourceTable
 // false so a selected table disappearing at the source keeps its existing
 // coverage-gap handling instead of failing the stream.
 func (s *PostgresCDCSource) getTables(ctx context.Context, validateSelection bool) ([]source.SourceTableInfo, error) {
+	if err := s.validatePublicationShape(ctx); err != nil {
+		return nil, err
+	}
 	// Check if this is a "FOR ALL TABLES" publication
 	var pubAllTables bool
 	err := s.queryPool.QueryRow(ctx, "SELECT puballtables FROM pg_publication WHERE pubname = $1", s.cdcConfig.Publication).Scan(&pubAllTables)
@@ -1508,6 +1539,9 @@ func (s *PostgresCDCSource) validateTablePublished(ctx context.Context, table st
 		if err := s.reconcileManagedPublication(ctx); err != nil {
 			return fmt.Errorf("failed to reconcile managed publication before validating table %q: %w", table, err)
 		}
+	}
+	if err := s.validatePublicationShape(ctx); err != nil {
+		return err
 	}
 	names, err := s.listEligibleTableNames(ctx)
 	if err != nil {

--- a/pkg/source/postgres_cdc/table.go
+++ b/pkg/source/postgres_cdc/table.go
@@ -47,7 +47,7 @@ func NewCDCTable(src *PostgresCDCSource, req source.TableRequest) (*CDCTable, er
 	}
 
 	// Fetch schema from database
-	tableSchema, err := getTableSchema(ctx, src.queryPool, req.Name)
+	tableSchema, err := src.getTableSchema(ctx, req.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get schema: %w", err)
 	}

--- a/pkg/source/postgres_cdc/table.go
+++ b/pkg/source/postgres_cdc/table.go
@@ -59,6 +59,8 @@ func NewCDCTable(src *PostgresCDCSource, req source.TableRequest) (*CDCTable, er
 	pks := req.PrimaryKeys
 	if len(pks) == 0 {
 		pks = tableSchema.PrimaryKeys
+	} else if err := validateConfiguredKeys(ctx, src.queryPool, req.Name, tableSchema, pks); err != nil {
+		return nil, err
 	}
 	// Reconcile the effective merge keys into the schema so the decoder,
 	// compaction, and unchanged-TOAST fill all key off the same keys the
@@ -270,14 +272,14 @@ func getTableSchema(ctx context.Context, pool *pgxpool.Pool, table string) (*sch
 		return nil, fmt.Errorf("error iterating primary key rows: %w", err)
 	}
 
-	// A table without a primary key can still declare row identity via
-	// REPLICA IDENTITY USING INDEX. Those columns are what pgoutput keys old
-	// tuples by, so they serve as merge keys exactly like a primary key would.
-	if len(primaryKeys) == 0 {
-		primaryKeys, err = replicaIdentityIndexColumns(ctx, pool, schemaName, tableName)
-		if err != nil {
-			return nil, err
-		}
+	// An explicitly selected replica identity overrides the primary key:
+	// only its key columns are guaranteed in old tuples from pgoutput.
+	identityKeys, err := replicaIdentityIndexColumns(ctx, pool, schemaName, tableName)
+	if err != nil {
+		return nil, err
+	}
+	if len(identityKeys) > 0 {
+		primaryKeys = identityKeys
 	}
 
 	for i := range columns {
@@ -309,7 +311,8 @@ func replicaIdentityIndexColumns(ctx context.Context, pool *pgxpool.Pool, schema
 		JOIN unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
 		JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = k.attnum
 		WHERE n.nspname = $1 AND c.relname = $2
-		  AND i.indisreplident AND i.indisvalid
+		  AND c.relreplident = 'i' AND i.indisreplident AND i.indisvalid
+ AND k.ord <= COALESCE((to_jsonb(i)->>'indnkeyatts')::int, i.indnatts)
 		ORDER BY k.ord
 	`
 	rows, err := pool.Query(ctx, q, schemaName, tableName)
@@ -392,3 +395,49 @@ func buildArrowSchema(columns []schema.Column) *arrow.Schema {
 }
 
 var _ source.SourceTable = (*CDCTable)(nil)
+
+func sameKeyColumns(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	keys := make(map[string]bool, len(a))
+	for _, key := range a {
+		keys[key] = true
+	}
+	for _, key := range b {
+		if !keys[key] {
+			return false
+		}
+		delete(keys, key)
+	}
+	return len(keys) == 0
+}
+
+func validateConfiguredKeys(ctx context.Context, pool *pgxpool.Pool, table string, tableSchema *schema.TableSchema, keys []string) error {
+	if sameKeyColumns(keys, tableSchema.PrimaryKeys) {
+		return nil
+	}
+	schemaName, tableName := parseTableName(table)
+	var identity string
+	if err := pool.QueryRow(ctx, `SELECT c.relreplident::text FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE n.nspname = $1 AND c.relname = $2`, schemaName, tableName).Scan(&identity); err != nil {
+		return fmt.Errorf("failed to validate replica identity for %s: %w", table, err)
+	}
+	if identity != "f" {
+		return fmt.Errorf("merge keys %v for %s do not match its replica identity keys %v; use the replica identity keys or set REPLICA IDENTITY FULL and restart with --full-refresh", keys, table, tableSchema.PrimaryKeys)
+	}
+	seen := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		found := false
+		for _, col := range tableSchema.Columns[:sourceColumnCount(tableSchema)] {
+			if col.Name == key {
+				found = true
+				break
+			}
+		}
+		if !found || seen[key] {
+			return fmt.Errorf("invalid merge key %q for %s: keys must be distinct source columns", key, table)
+		}
+		seen[key] = true
+	}
+	return nil
+}

--- a/pkg/source/postgres_cdc/table_test.go
+++ b/pkg/source/postgres_cdc/table_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bruin-data/ingestr/pkg/schema"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseTableName(t *testing.T) {
@@ -111,4 +112,25 @@ func TestBuildArrowSchema(t *testing.T) {
 	assert.Equal(t, CDCDeletedColumn, arrowSchema.Field(3).Name)
 	assert.Equal(t, CDCSyncedAtColumn, arrowSchema.Field(4).Name)
 	assert.Equal(t, CDCUnchangedColsColumn, arrowSchema.Field(5).Name)
+}
+
+func TestReplicaIdentityRelationKeys(t *testing.T) {
+	tableSchema := addCDCColumns(&schema.TableSchema{Columns: []schema.Column{{Name: "id", DataType: schema.TypeInt32}, {Name: "code", DataType: schema.TypeString}}, PrimaryKeys: []string{"id"}})
+	relation := &RelationInfo{ReplicaIdentity: 'i', Columns: []RelationColumn{{Name: "id", DataType: 23, TypeMod: -1}, {Name: "code", DataType: 25, TypeMod: -1, Flags: 1}}}
+	err := mapRelationToSchema(relation, nil, tableSchema, "public.items")
+	require.ErrorContains(t, err, "do not match merge keys")
+	tableSchema.PrimaryKeys = []string{"code"}
+	require.NoError(t, mapRelationToSchema(relation, nil, tableSchema, "public.items"))
+	relation.ReplicaIdentity = 'f'
+	tableSchema.PrimaryKeys = []string{"id"}
+	require.NoError(t, mapRelationToSchema(relation, nil, tableSchema, "public.items"))
+	parsed, err := parseRelationMessage(pgoRelationMsg(1, "public", "items")[1:])
+	require.NoError(t, err)
+	require.Equal(t, byte('d'), parsed.ReplicaIdentity)
+}
+
+func TestSameKeyColumns(t *testing.T) {
+	require.True(t, sameKeyColumns([]string{"a", "b"}, []string{"b", "a"}))
+	require.False(t, sameKeyColumns([]string{"a", "b"}, []string{"a", "a"}))
+	require.False(t, sameKeyColumns([]string{"a"}, []string{"a", "b"}))
 }

--- a/pkg/source/postgres_cdc/toast_spill_test.go
+++ b/pkg/source/postgres_cdc/toast_spill_test.go
@@ -1,0 +1,41 @@
+package postgres_cdc
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pglogrepl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToastStateSurvivesDiskCacheEviction(t *testing.T) {
+	state := newToastState()
+	state.limit = 64 << 10
+	t.Cleanup(func() { require.NoError(t, state.close()) })
+	ctx := t.Context()
+	payload := strings.Repeat("x", 128<<10)
+	for i := range 200 {
+		key := fmt.Sprint(i)
+		require.NoError(t, state.put(ctx, "items", key, []interface{}{key + payload, []byte{0, 1, 255}, nil, tupleUnchangedMarker}, pglogrepl.LSN(i+1)))
+	}
+	require.Nil(t, state.memory)
+	require.Zero(t, state.bytes)
+	info, err := os.Stat(state.path)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(8<<20), "dirty pages must spill beyond SQLite's bounded cache")
+	for _, i := range []int{0, 100, 199} {
+		key := fmt.Sprint(i)
+		values, err := state.get(ctx, "items", key)
+		require.NoError(t, err)
+		require.Equal(t, []interface{}{key + payload, []byte{0, 1, 255}, nil, tupleUnchangedMarker}, values)
+	}
+	require.NoError(t, state.prune(ctx, 100))
+	values, err := state.get(ctx, "items", "0")
+	require.NoError(t, err)
+	require.Nil(t, values)
+	values, err = state.get(ctx, "items", "199")
+	require.NoError(t, err)
+	require.Equal(t, "199"+payload, values[0])
+}

--- a/pkg/source/postgres_cdc/toast_state.go
+++ b/pkg/source/postgres_cdc/toast_state.go
@@ -1,0 +1,177 @@
+package postgres_cdc
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pglogrepl"
+	_ "modernc.org/sqlite"
+)
+
+type toastStateRow struct {
+	table, key string
+	values     []interface{}
+	lsn        pglogrepl.LSN
+	bytes      int64
+}
+
+// toastState retains values until their destination merge is durable. Evicting
+// on Arrow batch boundaries would lose values when staging deduplicates batches.
+// The spill file is disposable: a restart reconstructs it by replaying WAL.
+type toastState struct {
+	memory       map[string]toastStateRow
+	bytes, limit int64
+	pruned       pglogrepl.LSN
+	db           *sql.DB
+	tx           *sql.Tx
+	path         string
+}
+
+func newToastState() *toastState {
+	return &toastState{memory: make(map[string]toastStateRow), limit: defaultTransactionMemoryBytes}
+}
+
+func (s *toastState) get(ctx context.Context, table, key string) ([]interface{}, error) {
+	if s.tx == nil {
+		return s.memory[encodeKeyParts([]string{table, key})].values, nil
+	}
+	var data []byte
+	err := s.tx.QueryRowContext(ctx, `SELECT value FROM toast_state WHERE table_name = ? AND row_key = ?`, table, key).Scan(&data)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var values []interface{}
+	err = gob.NewDecoder(bytes.NewReader(data)).Decode(&values)
+	return values, err
+}
+
+func (s *toastState) put(ctx context.Context, table, key string, values []interface{}, lsn pglogrepl.LSN) error {
+	if s.tx == nil {
+		mapKey := encodeKeyParts([]string{table, key})
+		size := int64(len(mapKey)+len(table)+len(key)+128) + estimateChangeBytes(Change{Values: values})
+		s.bytes += size - s.memory[mapKey].bytes
+		s.memory[mapKey] = toastStateRow{table: table, key: key, values: values, lsn: lsn, bytes: size}
+		if s.bytes <= s.limit {
+			return nil
+		}
+		return s.spill(ctx)
+	}
+	var data bytes.Buffer
+	if err := gob.NewEncoder(&data).Encode(values); err != nil {
+		return err
+	}
+	_, err := s.tx.ExecContext(ctx, `INSERT INTO toast_state VALUES (?, ?, ?, ?) ON CONFLICT(table_name, row_key) DO UPDATE SET value = excluded.value, lsn = excluded.lsn`, table, key, data.Bytes(), FormatLSN(lsn))
+	return err
+}
+
+func (s *toastState) delete(ctx context.Context, table, key string) error {
+	if s.tx == nil {
+		mapKey := encodeKeyParts([]string{table, key})
+		s.bytes -= s.memory[mapKey].bytes
+		delete(s.memory, mapKey)
+		return nil
+	}
+	_, err := s.tx.ExecContext(ctx, `DELETE FROM toast_state WHERE table_name = ? AND row_key = ?`, table, key)
+	return err
+}
+
+func (s *toastState) truncate(ctx context.Context, table string) error {
+	if s.tx == nil {
+		for key, row := range s.memory {
+			if row.table == table {
+				s.bytes -= row.bytes
+				delete(s.memory, key)
+			}
+		}
+		return nil
+	}
+	_, err := s.tx.ExecContext(ctx, `DELETE FROM toast_state WHERE table_name = ?`, table)
+	return err
+}
+
+func (s *toastState) prune(ctx context.Context, durable pglogrepl.LSN) error {
+	if durable <= s.pruned {
+		return nil
+	}
+	if s.tx == nil {
+		for key, row := range s.memory {
+			if row.lsn <= durable {
+				s.bytes -= row.bytes
+				delete(s.memory, key)
+			}
+		}
+	} else if _, err := s.tx.ExecContext(ctx, `DELETE FROM toast_state WHERE lsn <= ?`, FormatLSN(durable)); err != nil {
+		return err
+	}
+	s.pruned = durable
+	return nil
+}
+
+func (s *toastState) spill(ctx context.Context) error {
+	file, err := os.CreateTemp("", "ingestr-postgres-toast-*.sqlite")
+	if err != nil {
+		return err
+	}
+	s.path = file.Name()
+	if err := file.Close(); err != nil {
+		return err
+	}
+	s.db, err = sql.Open("sqlite", s.path)
+	if err != nil {
+		return err
+	}
+	s.db.SetMaxOpenConns(1)
+	// WAL is the durable copy. Keep SQLite's cache bounded and avoid a second
+	// journal or fsync for this private scratch database.
+	for _, query := range []string{
+		`PRAGMA journal_mode = OFF`, `PRAGMA synchronous = OFF`,
+		`PRAGMA cache_size = -8192`, `PRAGMA mmap_size = 0`,
+		`CREATE TABLE toast_state (table_name TEXT, row_key TEXT, value BLOB, lsn TEXT, PRIMARY KEY(table_name, row_key)) WITHOUT ROWID`,
+		`CREATE INDEX toast_state_lsn ON toast_state(lsn)`,
+	} {
+		if _, err := s.db.ExecContext(ctx, query); err != nil {
+			return err
+		}
+	}
+	s.tx, err = s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, row := range s.memory {
+		if err := s.put(ctx, row.table, row.key, row.values, row.lsn); err != nil {
+			return err
+		}
+	}
+	s.memory = nil
+	s.bytes = 0
+	return nil
+}
+
+func (s *toastState) close() error {
+	var err error
+	if s.tx != nil {
+		rollbackErr := s.tx.Rollback()
+		if !errors.Is(rollbackErr, sql.ErrTxDone) {
+			err = rollbackErr
+		}
+	}
+	if s.db != nil {
+		err = errors.Join(err, s.db.Close())
+	}
+	if s.path != "" {
+		err = errors.Join(err, os.Remove(s.path))
+		s.path = ""
+	}
+	if err != nil {
+		return fmt.Errorf("failed to close PostgreSQL TOAST state: %w", err)
+	}
+	return nil
+}

--- a/pkg/source/postgres_cdc/toast_state_test.go
+++ b/pkg/source/postgres_cdc/toast_state_test.go
@@ -1,6 +1,7 @@
 package postgres_cdc
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -104,5 +105,41 @@ func TestToastStateDeleteTruncateAndCleanup(t *testing.T) {
 				require.True(t, os.IsNotExist(err))
 			}
 		})
+	}
+}
+
+func TestToastKeyMoveRequiresCompleteImage(t *testing.T) {
+	for _, fullOld := range []bool{false, true} {
+		for _, earlierBatch := range []bool{false, true} {
+			t.Run(fmt.Sprintf("full_old=%v/earlier_batch=%v", fullOld, earlierBatch), func(t *testing.T) {
+				a := newBatchAccumulator(1, map[string]*schema.TableSchema{"a": fillTestSchema()})
+				t.Cleanup(func() { require.NoError(t, a.toast.close()) })
+				out := make(chan source.RecordBatchResult, 1)
+				if earlierBatch {
+					a.add("a", []Change{{Operation: "INSERT", LSN: 1, Values: []interface{}{int64(1), "payload", "first"}}}, 1)
+					require.NoError(t, a.flushAll(out, nil))
+					(<-out).Batch.Release()
+				}
+				old := []interface{}{int64(1), nil, nil}
+				if fullOld {
+					old[1] = "payload"
+				}
+				a.add("a", []Change{{Operation: "UPDATE", LSN: 2, Sequence: 2, Values: []interface{}{int64(2), tupleUnchangedMarker, "moved"}, OldValues: old}}, 2)
+				err := a.flushAll(out, nil)
+				if !fullOld && !earlierBatch {
+					require.ErrorContains(t, err, "REPLICA IDENTITY FULL")
+					require.ErrorContains(t, err, "config_data")
+					require.Empty(t, out, "neither the old-key delete nor the new-key row may escape")
+					return
+				}
+				require.NoError(t, err)
+				res := <-out
+				defer res.Batch.Release()
+				require.EqualValues(t, 2, res.Batch.NumRows())
+				require.Equal(t, int64(2), res.Batch.Column(0).(*array.Int64).Value(1))
+				require.Equal(t, "payload", res.Batch.Column(1).(*array.String).Value(1))
+				require.Equal(t, "[]", unchangedValueAt(t, res.Batch, 1))
+			})
+		}
 	}
 }

--- a/pkg/source/postgres_cdc/toast_state_test.go
+++ b/pkg/source/postgres_cdc/toast_state_test.go
@@ -143,3 +143,21 @@ func TestToastKeyMoveRequiresCompleteImage(t *testing.T) {
 		}
 	}
 }
+
+func TestToastKeyMoveAfterRelationChangeRequestsSchemaRebuild(t *testing.T) {
+	a := newBatchAccumulator(1, map[string]*schema.TableSchema{"public.t": fillTestSchema()})
+	t.Cleanup(func() { require.NoError(t, a.toast.close()) })
+	a.add("public.t", []Change{{
+		Operation: "UPDATE",
+		LSN:       2,
+		Sequence:  2,
+		Values:    []interface{}{int64(2), tupleRelationMissingMarker, "moved"},
+		OldValues: []interface{}{int64(1), nil, nil},
+	}}, 2)
+
+	err := a.flushAll(make(chan source.RecordBatchResult, 1), nil)
+	var schemaErr *SchemaChangedError
+	require.ErrorAs(t, err, &schemaErr)
+	require.Equal(t, "public.t", schemaErr.Table)
+	require.Equal(t, "config_data", schemaErr.Column)
+}

--- a/pkg/source/postgres_cdc/toast_state_test.go
+++ b/pkg/source/postgres_cdc/toast_state_test.go
@@ -1,0 +1,108 @@
+package postgres_cdc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/jackc/pglogrepl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToastAcrossSourceBatches(t *testing.T) {
+	for _, spill := range []bool{false, true} {
+		for _, initial := range []interface{}{"large payload", nil} {
+			t.Run(fmtToastCase(spill, initial), func(t *testing.T) {
+				a := newBatchAccumulator(1, map[string]*schema.TableSchema{"a": fillTestSchema(), "b": fillTestSchema()})
+				if spill {
+					a.toast.limit = 1
+				}
+				t.Cleanup(func() { require.NoError(t, a.toast.close()) })
+				out := make(chan source.RecordBatchResult, 1)
+				flush := func(table string, c Change) source.RecordBatchResult {
+					t.Helper()
+					a.add(table, []Change{c}, c.LSN)
+					require.NoError(t, a.flushReadyContext(t.Context(), out, nil))
+					res := <-out
+					t.Cleanup(res.Batch.Release)
+					return res
+				}
+				flush("a", Change{Operation: "INSERT", LSN: 1, Values: []interface{}{int64(1), initial, "first"}})
+				// No old tuple is sent for a normal UPDATE under default replica identity.
+				update := func(lsn pglogrepl.LSN) Change {
+					return Change{Operation: "UPDATE", LSN: lsn, Values: []interface{}{int64(1), tupleUnchangedMarker, "later"}}
+				}
+				other := flush("b", update(2))
+				require.Equal(t, `["config_data"]`, unchangedValueAt(t, other.Batch, 0), "table identities must not share cached rows")
+				filled := flush("a", update(3))
+				require.Equal(t, `[]`, unchangedValueAt(t, filled.Batch, 0))
+				col := filled.Batch.Column(1).(*array.String)
+				if initial == nil {
+					require.True(t, col.IsNull(0))
+				} else {
+					require.Equal(t, initial, col.Value(0))
+				}
+				require.Equal(t, spill, a.toast.tx != nil)
+				if spill {
+					path := a.toast.path
+					require.FileExists(t, path)
+				}
+				a.durable = func() pglogrepl.LSN { return 3 }
+				afterAck := flush("a", update(4))
+				require.Equal(t, `["config_data"]`, unchangedValueAt(t, afterAck.Batch, 0), "durable values can fall back to the destination")
+			})
+		}
+	}
+}
+
+func fmtToastCase(spill bool, value interface{}) string {
+	mode := "memory"
+	if spill {
+		mode = "disk"
+	}
+	if value == nil {
+		return mode + "/null"
+	}
+	return mode + "/value"
+}
+
+func TestToastStateDeleteTruncateAndCleanup(t *testing.T) {
+	for _, spill := range []bool{false, true} {
+		t.Run(fmtToastCase(spill, "value"), func(t *testing.T) {
+			s := newToastState()
+			if spill {
+				s.limit = 1
+			}
+			t.Cleanup(func() { require.NoError(t, s.close()) })
+			ctx := t.Context()
+			for _, table := range []string{"a", "b"} {
+				for _, key := range []string{"1", "2"} {
+					require.NoError(t, s.put(ctx, table, key, []interface{}{"payload", nil, tupleUnchangedMarker}, 7))
+				}
+			}
+			require.NoError(t, s.delete(ctx, "a", "1"))
+			values, err := s.get(ctx, "a", "1")
+			require.NoError(t, err)
+			require.Nil(t, values)
+			require.NoError(t, s.truncate(ctx, "a"))
+			values, err = s.get(ctx, "a", "2")
+			require.NoError(t, err)
+			require.Nil(t, values)
+			values, err = s.get(ctx, "b", "2")
+			require.NoError(t, err)
+			require.Equal(t, []interface{}{"payload", nil, tupleUnchangedMarker}, values)
+			require.NoError(t, s.prune(ctx, 6))
+			values, err = s.get(ctx, "b", "2")
+			require.NoError(t, err)
+			require.NotEmpty(t, values, "unacknowledged changes must survive")
+			path := s.path
+			require.NoError(t, s.close())
+			if path != "" {
+				_, err := os.Stat(path)
+				require.True(t, os.IsNotExist(err))
+			}
+		})
+	}
+}

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -11,13 +11,23 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
-type tupleUnchanged struct{}
+type tupleUnchanged struct {
+	RelationMissing bool
+}
 
-var tupleUnchangedMarker = tupleUnchanged{}
+var (
+	tupleUnchangedMarker       = tupleUnchanged{}
+	tupleRelationMissingMarker = tupleUnchanged{RelationMissing: true}
+)
 
 func isTupleUnchanged(v interface{}) bool {
 	_, ok := v.(tupleUnchanged)
 	return ok
+}
+
+func isRelationMissingMarker(v interface{}) bool {
+	marker, ok := v.(tupleUnchanged)
+	return ok && marker.RelationMissing
 }
 
 func resolveColumnValue(change Change, colIdx int) interface{} {
@@ -82,6 +92,19 @@ func fillUnchangedColumns(ctx context.Context, changes []Change, tableSchema *sc
 		if pkValueChanged(*change, pkIndices) {
 			for colIdx := 0; colIdx < nSource; colIdx++ {
 				if columnIsUnchanged(*change, colIdx) {
+					if isRelationMissingMarker(change.Values[colIdx]) {
+						tableName := table
+						if tableName == "" {
+							tableName = tableSchema.Name
+							if tableSchema.Schema != "" {
+								tableName = tableSchema.Schema + "." + tableSchema.Name
+							}
+						}
+						return newSchemaChangedError(tableName, []SchemaMismatch{{
+							Column: tableSchema.Columns[colIdx].Name,
+							Reason: "is missing from the current replication relation",
+						}})
+					}
 					return fmt.Errorf("cannot replicate key change on %s.%s: unchanged TOAST column %q has no full row image; set REPLICA IDENTITY FULL before changing keys and use --full-refresh to rebuild from a fresh snapshot", quoteIdentifier(tableSchema.Schema), quoteIdentifier(tableSchema.Name), tableSchema.Columns[colIdx].Name)
 				}
 			}

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -79,6 +79,13 @@ func fillUnchangedColumns(ctx context.Context, changes []Change, tableSchema *sc
 				setColumnValue(change, colIdx, prior[colIdx])
 			}
 		}
+		if pkValueChanged(*change, pkIndices) {
+			for colIdx := 0; colIdx < nSource; colIdx++ {
+				if columnIsUnchanged(*change, colIdx) {
+					return fmt.Errorf("cannot replicate key change on %s.%s: unchanged TOAST column %q has no full row image; set REPLICA IDENTITY FULL before changing keys and use --full-refresh to rebuild from a fresh snapshot", quoteIdentifier(tableSchema.Schema), quoteIdentifier(tableSchema.Name), tableSchema.Columns[colIdx].Name)
+				}
+			}
+		}
 		if lookupKey != storeKey {
 			if err := state.delete(ctx, table, lookupKey); err != nil {
 				return err

--- a/pkg/source/postgres_cdc/values.go
+++ b/pkg/source/postgres_cdc/values.go
@@ -1,6 +1,7 @@
 package postgres_cdc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -40,93 +41,75 @@ func resolveColumnValueBase(change Change, colIdx int) interface{} {
 	return nil
 }
 
-// knownValue is a column value tracked during within-commit fill. known
-// distinguishes an authoritative NULL (an explicit SET col = NULL, which must be
-// propagated) from a column we have no information about (which must stay
-// unchanged so the destination uses its target value).
-type knownValue struct {
-	val   interface{}
-	known bool
-}
-
-// applyIntraBatchFill coalesces unchanged TOAST columns across a window of
-// changes: an INSERT (or full-value row) followed by a partial UPDATE of the
-// same primary key, where the UPDATE omits the unchanged TOAST value.
-// Compaction keeps only the latest row per key, so without this the earlier
-// value would be lost. State is local to the window it is called on: a single
-// commit in the single-table decoder (whose compaction runs per commit), and
-// the accumulator's whole flush window at materialization time (see
-// batchAccumulator.flushTable), which is where separate transactions merge —
-// cross-commit coalescing falls out of the same logic applied to the wider
-// window.
-//
-// A filled column's value is written directly into change.Values, replacing the
-// unchanged marker. That makes columnIsUnchanged report false for it, so it is
-// emitted with its (possibly NULL) value and excluded from _cdc_unchanged_cols —
-// which is exactly what we want, including when the known value is NULL.
-func applyIntraBatchFill(changes []Change, tableSchema *schema.TableSchema) {
+func fillUnchangedColumns(ctx context.Context, changes []Change, tableSchema *schema.TableSchema, table string, state *toastState) error {
 	if len(changes) == 0 || tableSchema == nil {
-		return
+		return nil
 	}
-
 	pkIndices := pkColumnIndices(tableSchema.Columns, tableSchema.PrimaryKeys)
 	if len(pkIndices) == 0 {
-		return
+		return nil
 	}
-
 	nSource := sourceColumnCount(tableSchema)
-	state := make(map[string][]knownValue)
-
+	toastable := make([]bool, nSource)
+	hasToast := false
+	for i, col := range tableSchema.Columns[:nSource] {
+		switch col.DataType {
+		case schema.TypeString, schema.TypeBinary, schema.TypeJSON, schema.TypeArray, schema.TypeDecimal, schema.TypeUnknown:
+			toastable[i] = true
+			hasToast = true
+		}
+	}
+	if !hasToast {
+		return nil
+	}
 	for i := range changes {
 		change := &changes[i]
 		lookupKey, storeKey := fillStateKeys(*change, pkIndices, i)
-		prior := state[lookupKey]
-
+		prior, err := state.get(ctx, table, lookupKey)
+		if err != nil {
+			return err
+		}
 		for colIdx := 0; colIdx < nSource; colIdx++ {
 			if !columnIsUnchanged(*change, colIdx) {
 				continue
 			}
 			if base := resolveColumnValueBase(*change, colIdx); base != nil {
-				// Authoritative old-tuple value (REPLICA IDENTITY FULL). Clear
-				// the marker so the column is emitted with its value and not
-				// reported as unchanged; otherwise a matched merge falls back to
-				// the target and discards a value set earlier in the same batch.
 				setColumnValue(change, colIdx, base)
-				continue
-			}
-			if prior != nil && colIdx < len(prior) && prior[colIdx].known {
-				setColumnValue(change, colIdx, prior[colIdx].val)
-			}
-		}
-
-		if change.Operation == "DELETE" {
-			delete(state, storeKey)
-			if lookupKey != storeKey {
-				delete(state, lookupKey)
-			}
-			continue
-		}
-
-		// Carry forward prior known values, then overwrite with the columns this
-		// change resolves authoritatively (a real value, an explicit NULL, or a
-		// fill applied above).
-		next := make([]knownValue, nSource)
-		copy(next, prior)
-		for colIdx := 0; colIdx < nSource; colIdx++ {
-			if columnIsAuthoritative(*change, colIdx) {
-				next[colIdx] = knownValue{val: resolveColumnValue(*change, colIdx), known: true}
+			} else if colIdx < len(prior) && !isTupleUnchanged(prior[colIdx]) {
+				setColumnValue(change, colIdx, prior[colIdx])
 			}
 		}
 		if lookupKey != storeKey {
-			delete(state, lookupKey)
+			if err := state.delete(ctx, table, lookupKey); err != nil {
+				return err
+			}
 		}
-		state[storeKey] = next
+		if change.Operation == "DELETE" {
+			if err := state.delete(ctx, table, storeKey); err != nil {
+				return err
+			}
+			continue
+		}
+		next := make([]interface{}, nSource)
+		for colIdx := range next {
+			next[colIdx] = tupleUnchangedMarker
+			if colIdx < len(prior) {
+				next[colIdx] = prior[colIdx]
+			}
+			if toastable[colIdx] && columnIsAuthoritative(*change, colIdx) {
+				next[colIdx] = resolveColumnValue(*change, colIdx)
+			}
+		}
+		if err := state.put(ctx, table, storeKey, next, change.LSN); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // expandUpdates rewrites UPDATE changes whose row identity moved or is absent,
 // so the emitted stream stays applicable at the destination. It runs after
-// applyIntraBatchFill (which may still need the original UPDATE shape) and
+// fillUnchangedColumns (which may still need the original UPDATE shape) and
 // before compaction.
 //
 // Keyed tables: an UPDATE that changes a key column would merge under the new
@@ -286,7 +269,7 @@ func fillStateKeys(change Change, pkIndices []int, changeIndex int) (lookupKey, 
 }
 
 func pkValueChanged(change Change, pkIndices []int) bool {
-	if change.Operation != "UPDATE" {
+	if change.Operation != "UPDATE" || change.OldValues == nil {
 		return false
 	}
 	for _, idx := range pkIndices {
@@ -375,7 +358,7 @@ func unchangedColumnsJSON(change Change, columns []schema.Column, nSourceCols in
 	}
 	names := make([]string, 0)
 	for i := 0; i < nSourceCols && i < len(columns); i++ {
-		// applyIntraBatchFill overwrites the unchanged marker of any column it
+		// fillUnchangedColumns overwrites the unchanged marker of any column it
 		// resolves (including to NULL), so columnIsUnchanged already excludes
 		// filled columns here; a column still marked unchanged is one we have no
 		// staging value for and the destination must fall back to its target.

--- a/tests/integration/postgres_cdc_accuracy_test.go
+++ b/tests/integration/postgres_cdc_accuracy_test.go
@@ -1,0 +1,73 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresCDCToastAcrossBatches(t *testing.T) {
+	for _, multi := range []bool{false, true} {
+		for _, streaming := range []bool{false, true} {
+			t.Run(fmt.Sprintf("multi=%v/streaming=%v", multi, streaming), func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+				defer cancel()
+				container, uri := setupPostgresCDCContainer(t, ctx)
+				defer func() { _ = container.Terminate(context.Background()) }()
+				pool, err := pgxpool.New(ctx, uri)
+				require.NoError(t, err)
+				defer pool.Close()
+				_, err = pool.Exec(ctx, `CREATE TABLE items (id bigint PRIMARY KEY, payload text, n int);
+      ALTER TABLE items ALTER COLUMN payload SET STORAGE EXTERNAL;
+      CREATE PUBLICATION items_pub FOR TABLE items; CREATE SCHEMA warehouse`)
+				require.NoError(t, err)
+				cfg := &config.IngestConfig{SourceURI: strings.Replace(uri, "postgres://", "postgres+cdc://", 1) + "&publication=items_pub", SourceTable: "public.items", DestURI: uri, DestTable: "warehouse.items", IncrementalStrategy: config.StrategyMerge, PageSize: 1}
+				if multi {
+					cfg.SourceTable = ""
+					cfg.DestTable = ""
+					cfg.SourceURI += "&dest_schema=warehouse"
+				}
+				require.NoError(t, pipeline.New(cfg).Run(ctx))
+				payload := strings.Repeat("abcdefghij", 5000)
+				// Separate commits and PageSize=1 force separate source Arrow batches,
+				// while the destination stages both before one merge.
+				_, err = pool.Exec(ctx, `INSERT INTO items VALUES (1, $1, 0)`, payload)
+				require.NoError(t, err)
+				_, err = pool.Exec(ctx, `UPDATE items SET n=1 WHERE id=1`)
+				require.NoError(t, err)
+				if streaming {
+					cfg.Stream = true
+					cfg.FlushInterval = time.Second
+					cfg.FlushRecords = 10000
+					streamCtx, stop := context.WithCancel(ctx)
+					defer stop()
+					done := make(chan error, 1)
+					go func() { done <- pipeline.New(cfg).Run(streamCtx) }()
+					require.Eventually(t, func() bool {
+						var n int
+						return pool.QueryRow(ctx, `SELECT n FROM warehouse.items WHERE id=1`).Scan(&n) == nil && n == 1
+					}, 30*time.Second, 100*time.Millisecond)
+					stop()
+					if err := <-done; err != nil {
+						require.ErrorIs(t, err, context.Canceled)
+					}
+				} else {
+					require.NoError(t, pipeline.New(cfg).Run(ctx))
+				}
+				var actual *string
+				require.NoError(t, pool.QueryRow(ctx, `SELECT payload FROM warehouse.items WHERE id=1 AND NOT _cdc_deleted`).Scan(&actual))
+				require.NotNil(t, actual)
+				require.Equal(t, payload, *actual)
+			})
+		}
+	}
+}

--- a/tests/integration/postgres_cdc_accuracy_test.go
+++ b/tests/integration/postgres_cdc_accuracy_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/bruin-data/ingestr/internal/config"
 	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/source"
+	"github.com/bruin-data/ingestr/pkg/source/postgres_cdc"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 )
@@ -118,4 +120,58 @@ func TestPostgresCDCToastKeyMove(t *testing.T) {
 			require.Equal(t, 1, active)
 		})
 	}
+}
+
+func TestPostgresCDCReplicaIdentityKeys(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	container, uri := setupPostgresCDCContainer(t, ctx)
+	defer func() { _ = container.Terminate(context.Background()) }()
+	pool, err := pgxpool.New(ctx, uri)
+	require.NoError(t, err)
+	defer pool.Close()
+	_, err = pool.Exec(ctx, `CREATE TABLE items (id bigint PRIMARY KEY, code text NOT NULL, payload text NOT NULL);
+  CREATE UNIQUE INDEX items_identity ON items(code) INCLUDE (payload);
+  ALTER TABLE items REPLICA IDENTITY USING INDEX items_identity;
+  INSERT INTO items VALUES (1, 'a', 'payload');
+  CREATE PUBLICATION items_pub FOR TABLE items; CREATE SCHEMA warehouse`)
+	require.NoError(t, err)
+	cdcURI := strings.Replace(uri, "postgres://", "postgres+cdc://", 1) + "&publication=items_pub"
+	src := postgres_cdc.NewPostgresCDCSource()
+	require.NoError(t, src.Connect(ctx, cdcURI))
+	defer func() { _ = src.Close(ctx) }()
+	table, err := src.GetTable(ctx, source.TableRequest{Name: "public.items"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"code"}, table.PrimaryKeys(), "replica identity overrides PK and excludes INCLUDE columns")
+	tables, err := src.GetTables(ctx)
+	require.NoError(t, err)
+	require.Len(t, tables, 1)
+	require.Equal(t, []string{"code"}, tables[0].PrimaryKeys)
+	for _, keys := range [][]string{{"id"}, {"code", "payload"}} {
+		_, err = src.GetTable(ctx, source.TableRequest{Name: "public.items", PrimaryKeys: keys})
+		require.ErrorContains(t, err, "do not match its replica identity")
+	}
+	require.NoError(t, src.Close(ctx))
+	cfg := &config.IngestConfig{SourceURI: cdcURI, SourceTable: "public.items", DestURI: uri, DestTable: "warehouse.items", IncrementalStrategy: config.StrategyMerge}
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	_, err = pool.Exec(ctx, `UPDATE items SET id=2 WHERE code='a'`)
+	require.NoError(t, err)
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	var id, count int
+	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*), min(id) FROM warehouse.items WHERE NOT _cdc_deleted`).Scan(&count, &id))
+	require.Equal(t, 1, count)
+	require.Equal(t, 2, id)
+	_, err = pool.Exec(ctx, `DELETE FROM items WHERE code='a'`)
+	require.NoError(t, err)
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM warehouse.items WHERE NOT _cdc_deleted`).Scan(&count))
+	require.Zero(t, count)
+	_, err = pool.Exec(ctx, `ALTER TABLE items REPLICA IDENTITY FULL`)
+	require.NoError(t, err)
+	src = postgres_cdc.NewPostgresCDCSource()
+	require.NoError(t, src.Connect(ctx, cdcURI))
+	defer func() { _ = src.Close(ctx) }()
+	table, err = src.GetTable(ctx, source.TableRequest{Name: "public.items", PrimaryKeys: []string{"code"}})
+	require.NoError(t, err, "FULL identity supports an explicitly selected unique key")
+	require.Equal(t, []string{"code"}, table.PrimaryKeys())
 }

--- a/tests/integration/postgres_cdc_accuracy_test.go
+++ b/tests/integration/postgres_cdc_accuracy_test.go
@@ -71,3 +71,51 @@ func TestPostgresCDCToastAcrossBatches(t *testing.T) {
 		}
 	}
 }
+
+func TestPostgresCDCToastKeyMove(t *testing.T) {
+	for _, fullIdentity := range []bool{false, true} {
+		t.Run(fmt.Sprintf("full_identity=%v", fullIdentity), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer cancel()
+			container, uri := setupPostgresCDCContainer(t, ctx)
+			defer func() { _ = container.Terminate(context.Background()) }()
+			pool, err := pgxpool.New(ctx, uri)
+			require.NoError(t, err)
+			defer pool.Close()
+			_, err = pool.Exec(ctx, `CREATE TABLE items (id bigint PRIMARY KEY, payload text);
+     ALTER TABLE items ALTER COLUMN payload SET STORAGE EXTERNAL;
+     CREATE PUBLICATION items_pub FOR TABLE items; CREATE SCHEMA warehouse`)
+			require.NoError(t, err)
+			if fullIdentity {
+				_, err = pool.Exec(ctx, `ALTER TABLE items REPLICA IDENTITY FULL`)
+				require.NoError(t, err)
+			}
+			payload := strings.Repeat("abcdefghij", 5000)
+			_, err = pool.Exec(ctx, `INSERT INTO items VALUES (1, $1)`, payload)
+			require.NoError(t, err)
+			cfg := &config.IngestConfig{SourceURI: strings.Replace(uri, "postgres://", "postgres+cdc://", 1) + "&publication=items_pub", SourceTable: "public.items", DestURI: uri, DestTable: "warehouse.items", IncrementalStrategy: config.StrategyMerge, PageSize: 1}
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			_, err = pool.Exec(ctx, `UPDATE items SET id=2 WHERE id=1`)
+			require.NoError(t, err)
+			err = pipeline.New(cfg).Run(ctx)
+			if !fullIdentity {
+				require.ErrorContains(t, err, "REPLICA IDENTITY FULL")
+				var oldPayload string
+				require.NoError(t, pool.QueryRow(ctx, `SELECT payload FROM warehouse.items WHERE id=1 AND NOT _cdc_deleted`).Scan(&oldPayload))
+				require.Equal(t, payload, oldPayload, "an incomplete key move must leave the destination intact")
+				_, err = pool.Exec(ctx, `ALTER TABLE items REPLICA IDENTITY FULL`)
+				require.NoError(t, err)
+				cfg.FullRefresh = true
+				require.NoError(t, pipeline.New(cfg).Run(ctx))
+			} else {
+				require.NoError(t, err)
+			}
+			var actual string
+			require.NoError(t, pool.QueryRow(ctx, `SELECT payload FROM warehouse.items WHERE id=2 AND NOT _cdc_deleted`).Scan(&actual))
+			require.Equal(t, payload, actual)
+			var active int
+			require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM warehouse.items WHERE NOT _cdc_deleted`).Scan(&active))
+			require.Equal(t, 1, active)
+		})
+	}
+}

--- a/tests/integration/postgres_cdc_accuracy_test.go
+++ b/tests/integration/postgres_cdc_accuracy_test.go
@@ -175,3 +175,80 @@ func TestPostgresCDCReplicaIdentityKeys(t *testing.T) {
 	require.NoError(t, err, "FULL identity supports an explicitly selected unique key")
 	require.Equal(t, []string{"code"}, table.PrimaryKeys())
 }
+
+func TestPostgresCDCGeneratedColumns(t *testing.T) {
+	for _, version := range []int{16, 18} {
+		t.Run(fmt.Sprint(version), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			defer cancel()
+			container, uri := setupPostgresCDCContainerImage(t, ctx, fmt.Sprintf("postgres:%d-alpine", version))
+			defer func() { _ = container.Terminate(context.Background()) }()
+			pool, err := pgxpool.New(ctx, uri)
+			require.NoError(t, err)
+			defer pool.Close()
+			_, err = pool.Exec(ctx, `CREATE TABLE items (id int PRIMARY KEY, n int, computed int GENERATED ALWAYS AS (n*2) STORED);
+    INSERT INTO items(id,n) VALUES (1,10); CREATE PUBLICATION items_pub FOR TABLE items; CREATE SCHEMA warehouse`)
+			require.NoError(t, err)
+			cdcURI := strings.Replace(uri, "postgres://", "postgres+cdc://", 1)
+			cfg := &config.IngestConfig{SourceURI: cdcURI + "&publication=items_pub&dest_schema=warehouse", DestURI: uri, IncrementalStrategy: config.StrategyMerge}
+			err = pipeline.New(cfg).Run(ctx)
+			require.ErrorContains(t, err, "generated column")
+			var absent bool
+			require.NoError(t, pool.QueryRow(ctx, `SELECT to_regclass('warehouse.items') IS NULL`).Scan(&absent))
+			require.True(t, absent, "coverage must be validated before taking a snapshot")
+			if version < 18 {
+				return
+			}
+
+			managed := postgres_cdc.NewPostgresCDCSource()
+			require.NoError(t, managed.Connect(ctx, cdcURI))
+			require.NoError(t, managed.PrepareConnector(ctx))
+			_, err = managed.GetTable(ctx, source.TableRequest{Name: "public.items"})
+			require.NoError(t, err, "managed PostgreSQL 18 publications must include stored generated columns")
+			require.NoError(t, managed.Close(ctx))
+			var mode string
+			require.NoError(t, pool.QueryRow(ctx, `SELECT pubgencols::text FROM pg_publication WHERE pubname='ingestr_publication'`).Scan(&mode))
+			require.Equal(t, "s", mode)
+
+			_, err = pool.Exec(ctx, `ALTER PUBLICATION items_pub SET (publish_generated_columns = stored)`)
+			require.NoError(t, err)
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			_, err = pool.Exec(ctx, `UPDATE items SET n=11 WHERE id=1; INSERT INTO items(id,n) VALUES (2,12)`)
+			require.NoError(t, err)
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			var mismatches int
+			require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM warehouse.items WHERE computed IS DISTINCT FROM n*2`).Scan(&mismatches))
+			require.Zero(t, mismatches)
+			var count int
+			require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM warehouse.items`).Scan(&count))
+			require.Equal(t, 2, count)
+			cfg.Stream = true
+			cfg.FlushInterval = time.Second
+			cfg.FlushRecords = 10000
+			streamCtx, stop := context.WithCancel(ctx)
+			defer stop()
+			done := make(chan error, 1)
+			go func() { done <- pipeline.New(cfg).Run(streamCtx) }()
+			require.Eventually(t, func() bool {
+				var active bool
+				return pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE active AND NOT temporary)`).Scan(&active) == nil && active
+			}, 30*time.Second, 100*time.Millisecond)
+			_, err = pool.Exec(ctx, `ALTER PUBLICATION items_pub SET (publish_generated_columns = none); UPDATE items SET n=13 WHERE id=1`)
+			require.NoError(t, err)
+			select {
+			case err := <-done:
+				require.ErrorContains(t, err, "generated column \"computed\" is missing")
+			case <-time.After(30 * time.Second):
+				t.Fatal("stream did not reject lost generated-column coverage")
+			}
+			cfg.Stream = false
+			require.ErrorContains(t, pipeline.New(cfg).Run(ctx), "does not publish generated columns")
+
+			_, err = pool.Exec(ctx, `CREATE TABLE virtual_items (id int PRIMARY KEY, n int, computed int GENERATED ALWAYS AS (n*2) VIRTUAL);
+    CREATE PUBLICATION virtual_pub FOR TABLE virtual_items WITH (publish_generated_columns = stored)`)
+			require.NoError(t, err)
+			cfg.SourceURI = cdcURI + "&publication=virtual_pub&dest_schema=warehouse"
+			require.ErrorContains(t, pipeline.New(cfg).Run(ctx), "stored generated column")
+		})
+	}
+}

--- a/tests/integration/postgres_cdc_accuracy_test.go
+++ b/tests/integration/postgres_cdc_accuracy_test.go
@@ -252,3 +252,116 @@ func TestPostgresCDCGeneratedColumns(t *testing.T) {
 		})
 	}
 }
+
+func TestPostgresCDCPublicationOperations(t *testing.T) {
+	for _, version := range []int{14, 16} {
+		t.Run(fmt.Sprint(version), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+			defer cancel()
+			container, uri := setupPostgresCDCContainerImage(t, ctx, fmt.Sprintf("postgres:%d-alpine", version))
+			defer func() { _ = container.Terminate(context.Background()) }()
+			pool, err := pgxpool.New(ctx, uri)
+			require.NoError(t, err)
+			defer pool.Close()
+			_, err = pool.Exec(ctx, `CREATE TABLE items (id int PRIMARY KEY); INSERT INTO items VALUES (1);
+    CREATE PUBLICATION items_pub FOR TABLE items; CREATE SCHEMA warehouse`)
+			require.NoError(t, err)
+			cdcURI := strings.Replace(uri, "postgres://", "postgres+cdc://", 1)
+			src := postgres_cdc.NewPostgresCDCSource()
+			require.NoError(t, src.Connect(ctx, cdcURI+"&publication=items_pub"))
+			defer func() { _ = src.Close(ctx) }()
+			operations := []string{"insert", "update", "delete", "truncate"}
+			for _, omitted := range operations {
+				t.Run("missing_"+omitted, func(t *testing.T) {
+					var enabled []string
+					for _, op := range operations {
+						if op != omitted {
+							enabled = append(enabled, op)
+						}
+					}
+					_, err := pool.Exec(ctx, "ALTER PUBLICATION items_pub SET (publish = '"+strings.Join(enabled, ", ")+"')")
+					require.NoError(t, err)
+					for _, streaming := range []bool{false, true} {
+						require.ErrorContains(t, src.ValidateConnectorPreflight(ctx, source.ConnectorPreflightOptions{Streaming: streaming}), "does not publish "+omitted)
+					}
+					_, err = src.GetTable(ctx, source.TableRequest{Name: "public.items"})
+					require.ErrorContains(t, err, "does not publish "+omitted)
+					_, err = src.GetTables(ctx)
+					require.ErrorContains(t, err, "does not publish "+omitted)
+				})
+			}
+			cfg := &config.IngestConfig{SourceURI: cdcURI + "&publication=items_pub", SourceTable: "public.items", DestURI: uri, DestTable: "warehouse.items", IncrementalStrategy: config.StrategyMerge}
+			require.ErrorContains(t, pipeline.New(cfg).Run(ctx), "does not publish truncate")
+			var absent bool
+			require.NoError(t, pool.QueryRow(ctx, `SELECT to_regclass('warehouse.items') IS NULL`).Scan(&absent))
+			require.True(t, absent)
+			var slots int
+			require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM pg_replication_slots`).Scan(&slots))
+			require.Zero(t, slots)
+			_, err = pool.Exec(ctx, `ALTER PUBLICATION items_pub SET (publish = 'insert, update, delete, truncate')`)
+			require.NoError(t, err)
+			require.NoError(t, src.ValidateConnectorPreflight(ctx, source.ConnectorPreflightOptions{}))
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			_, err = pool.Exec(ctx, `DELETE FROM items WHERE id=1`)
+			require.NoError(t, err)
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			var active int
+			require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM warehouse.items WHERE NOT _cdc_deleted`).Scan(&active))
+			require.Zero(t, active)
+
+			managed := postgres_cdc.NewPostgresCDCSource()
+			require.NoError(t, managed.Connect(ctx, cdcURI))
+			defer func() { _ = managed.Close(ctx) }()
+			require.NoError(t, managed.ValidateConnectorPreflight(ctx, source.ConnectorPreflightOptions{}), "an absent managed publication is created during preparation")
+			require.NoError(t, managed.PrepareConnector(ctx))
+			_, err = pool.Exec(ctx, `ALTER PUBLICATION ingestr_publication SET (publish = 'insert')`)
+			require.NoError(t, err)
+			require.ErrorContains(t, managed.ValidateConnectorPreflight(ctx, source.ConnectorPreflightOptions{}), "does not publish update, delete, truncate")
+		})
+	}
+}
+
+func TestPostgresCDCPublicationLosesDeletesWhileStreaming(t *testing.T) {
+	for _, multi := range []bool{false, true} {
+		t.Run(fmt.Sprintf("multi=%v", multi), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer cancel()
+			container, uri := setupPostgresCDCContainer(t, ctx)
+			defer func() { _ = container.Terminate(context.Background()) }()
+			pool, err := pgxpool.New(ctx, uri)
+			require.NoError(t, err)
+			defer pool.Close()
+			_, err = pool.Exec(ctx, `CREATE TABLE items (id int PRIMARY KEY); INSERT INTO items VALUES (1);
+    CREATE PUBLICATION items_pub FOR TABLE items; CREATE SCHEMA warehouse`)
+			require.NoError(t, err)
+			cfg := &config.IngestConfig{SourceURI: strings.Replace(uri, "postgres://", "postgres+cdc://", 1) + "&publication=items_pub&discover_interval=off", SourceTable: "public.items", DestURI: uri, DestTable: "warehouse.items", IncrementalStrategy: config.StrategyMerge}
+			if multi {
+				cfg.SourceTable = ""
+				cfg.DestTable = ""
+				cfg.SourceURI += "&dest_schema=warehouse"
+			}
+			require.NoError(t, pipeline.New(cfg).Run(ctx))
+			cfg.Stream = true
+			cfg.FlushInterval = time.Second
+			cfg.FlushRecords = 10000
+			streamCtx, stop := context.WithCancel(ctx)
+			defer stop()
+			done := make(chan error, 1)
+			go func() { done <- pipeline.New(cfg).Run(streamCtx) }()
+			require.Eventually(t, func() bool {
+				var active bool
+				return pool.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE active AND NOT temporary)`).Scan(&active) == nil && active
+			}, 30*time.Second, 100*time.Millisecond)
+			// No row event will be sent for this delete. The coverage guard must
+			// still fail before treating an idle heartbeat as a valid checkpoint.
+			_, err = pool.Exec(ctx, `ALTER PUBLICATION items_pub SET (publish = 'insert, update, truncate'); DELETE FROM items`)
+			require.NoError(t, err)
+			select {
+			case err := <-done:
+				require.ErrorContains(t, err, "does not publish delete")
+			case <-time.After(30 * time.Second):
+				t.Fatal("stream did not reject missing delete coverage")
+			}
+		})
+	}
+}

--- a/tests/integration/postgres_cdc_test.go
+++ b/tests/integration/postgres_cdc_test.go
@@ -31,9 +31,13 @@ import (
 
 // setupPostgresCDCContainer creates a PostgreSQL container configured for logical replication
 func setupPostgresCDCContainer(t *testing.T, ctx context.Context) (testcontainers.Container, string) {
+	return setupPostgresCDCContainerImage(t, ctx, "postgres:16-alpine")
+}
+
+func setupPostgresCDCContainerImage(t *testing.T, ctx context.Context, image string) (testcontainers.Container, string) {
 	requireDocker(t)
 	req := testcontainers.ContainerRequest{
-		Image: "postgres:16-alpine",
+		Image: image,
 		Env: map[string]string{
 			"POSTGRES_USER":     "testuser",
 			"POSTGRES_PASSWORD": "testpass",


### PR DESCRIPTION
## What
Harden PostgreSQL CDC correctness around partial TOAST values, replica identities, schema changes, generated columns, and publication settings.

## Changes
- Preserve TOAST values across batches, reject unsafe key moves, and rebuild safely when relation columns disappear
- Use active replica identity keys and require fresh publication validation before idle checkpoints
- Expand CDC docs, unit tests, integration coverage, and stress regressions

## How to test
1. `make format`
2. `make lint`
3. `make test`
4. `go test -tags integration -v -run 'TestPostgresCDC(ToastAcrossBatches|ToastKeyMove|ReplicaIdentityKeys|GeneratedColumns|PublicationOperations|PublicationLosesDeletesWhileStreaming|MultiTableNamingPreservesPartialTOASTAndExplicitNull)$' ./tests/integration/...`\n5. `STRESS_OPS_PER_SEC=300 STRESS_LOAD_DURATION=1m STRESS_SCHEMA_CHANGE_EVERY=5s STRESS_NEW_TABLE_EVERY=20s make cdc-postgres-stress-test`\n\n## Risk & rollback\n- **Risk:** Medium — CDC decoding, schema recovery, and checkpoint validation behavior changes for affected schemas and publications\n- **Rollback:** Revert the merge commit\n\n## Checklist\n- [x] Unit tests added or updated (`make test`)\n- [x] Format and lint pass (`make format`, `make lint`)\n- [x] Integration tests pass if affected (`make test-integration`)\n- [x] No unrelated changes included\n- [x] Tested locally\n\n## Security\n- [x] No secrets, credentials, or PII in this change\n- [x] No new dependencies with known vulnerabilities\n- [x] Security implications considered (if applicable)\n\n## Related issues\nNone.