### PR TITLE
Fix high-precision decimals (precision > 38) by using Arrow Decimal256

### DIFF
--- a/internal/arrowutil/value.go
+++ b/internal/arrowutil/value.go
@@ -40,6 +40,10 @@ func Value(arr interface {
 		v := a.Value(idx)
 		dt := a.DataType().(*arrow.Decimal128Type)
 		return v.ToFloat64(dt.Scale)
+	case *array.Decimal256:
+		v := a.Value(idx)
+		dt := a.DataType().(*arrow.Decimal256Type)
+		return v.ToString(dt.Scale)
 	case *array.Date32:
 		v := a.Value(idx)
 		return v.ToTime()

--- a/internal/arrowutil/value.go
+++ b/internal/arrowutil/value.go
@@ -43,7 +43,7 @@ func Value(arr interface {
 	case *array.Decimal256:
 		v := a.Value(idx)
 		dt := a.DataType().(*arrow.Decimal256Type)
-		return v.ToFloat64(dt.Scale)
+		return v.ToString(dt.Scale)
 	case *array.Date32:
 		v := a.Value(idx)
 		return v.ToTime()

--- a/internal/arrowutil/value.go
+++ b/internal/arrowutil/value.go
@@ -43,7 +43,7 @@ func Value(arr interface {
 	case *array.Decimal256:
 		v := a.Value(idx)
 		dt := a.DataType().(*arrow.Decimal256Type)
-		return v.ToString(dt.Scale)
+		return v.ToFloat64(dt.Scale)
 	case *array.Date32:
 		v := a.Value(idx)
 		return v.ToTime()

--- a/pkg/arrowconv/convert.go
+++ b/pkg/arrowconv/convert.go
@@ -15,6 +15,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/decimal256"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/araddon/dateparse"
 	"github.com/bruin-data/ingestr/pkg/schema"
@@ -716,6 +717,72 @@ func AppendValue(builder array.Builder, val interface{}) {
 			b.Append(decimal128.FromBigInt(v))
 		case json.Number:
 			AppendValue(b, string(v))
+		default:
+			b.AppendNull()
+		}
+
+	case *array.Decimal256Builder:
+		dt, ok := builder.Type().(*arrow.Decimal256Type)
+		if !ok {
+			b.AppendNull()
+			return
+		}
+		appendDecimal256 := func(s string) {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				b.AppendNull()
+				return
+			}
+			num, err := decimal256.FromString(s, dt.Precision, dt.Scale)
+			if err != nil {
+				bf := new(big.Float)
+				if _, ok := bf.SetString(s); ok {
+					scale := new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(dt.Scale)), nil))
+					bf.Mul(bf, scale)
+					bi, _ := bf.Int(nil)
+					b.Append(decimal256.FromBigInt(bi))
+				} else {
+					b.AppendNull()
+				}
+				return
+			}
+			b.Append(num)
+		}
+		switch v := val.(type) {
+		case decimal256.Num:
+			b.Append(v)
+		case decimal128.Num:
+			b.Append(decimal256.FromBigInt(v.BigInt()))
+		case decimal.Decimal:
+			appendDecimal256(v.String())
+		case string:
+			appendDecimal256(v)
+		case []byte:
+			appendDecimal256(string(v))
+		case json.Number:
+			appendDecimal256(string(v))
+		case float64:
+			appendDecimal256(strconv.FormatFloat(v, 'f', -1, 64))
+		case int64:
+			appendDecimal256(strconv.FormatInt(v, 10))
+		case int:
+			appendDecimal256(strconv.FormatInt(int64(v), 10))
+		case int8:
+			appendDecimal256(strconv.FormatInt(int64(v), 10))
+		case int16:
+			appendDecimal256(strconv.FormatInt(int64(v), 10))
+		case int32:
+			appendDecimal256(strconv.FormatInt(int64(v), 10))
+		case uint8:
+			appendDecimal256(strconv.FormatUint(uint64(v), 10))
+		case uint16:
+			appendDecimal256(strconv.FormatUint(uint64(v), 10))
+		case uint32:
+			appendDecimal256(strconv.FormatUint(uint64(v), 10))
+		case uint64:
+			appendDecimal256(strconv.FormatUint(v, 10))
+		case *big.Int:
+			b.Append(decimal256.FromBigInt(v))
 		default:
 			b.AppendNull()
 		}

--- a/pkg/arrowconv/convert_test.go
+++ b/pkg/arrowconv/convert_test.go
@@ -2,6 +2,7 @@ package arrowconv
 
 import (
 	"encoding/json"
+	"math/big"
 	"net"
 	"testing"
 	"time"
@@ -422,6 +423,42 @@ func TestAppendValue_Decimal128_JSONNumber(t *testing.T) {
 			assert.False(t, arr.IsNull(0), "got null for input %q", string(tt.val))
 			gotBigI := decimal128.Num(arr.Value(0)).BigInt().String()
 			assert.Equal(t, tt.wantBigI, gotBigI)
+		})
+	}
+}
+
+func TestAppendValue_Decimal256(t *testing.T) {
+	dt := &arrow.Decimal256Type{Precision: 40, Scale: 25}
+
+	bigUnscaled, _ := new(big.Int).SetString("12345678901234567890123456789012345", 10)
+
+	tests := []struct {
+		name     string
+		val      any
+		wantNull bool
+		wantStr  string
+	}{
+		{name: "string", val: "123456789012345.1234567890123456789012345", wantStr: "123456789012345.1234567890123456789012345"},
+		{name: "big.Int unscaled", val: bigUnscaled, wantStr: "1234567890.1234567890123456789012345"},
+		{name: "json.Number", val: json.Number("1.5"), wantStr: "1.5000000000000000000000000"},
+		{name: "empty string", val: "", wantNull: true},
+		{name: "garbage", val: "xyz", wantNull: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := array.NewDecimal256Builder(memory.NewGoAllocator(), dt)
+			AppendValue(b, tt.val)
+			arr := b.NewArray().(*array.Decimal256)
+			defer arr.Release()
+
+			require.Equal(t, 1, arr.Len())
+			if tt.wantNull {
+				assert.True(t, arr.IsNull(0))
+				return
+			}
+			assert.False(t, arr.IsNull(0))
+			assert.Equal(t, tt.wantStr, arr.Value(0).ToString(dt.Scale))
 		})
 	}
 }

--- a/pkg/destination/athena/sql.go
+++ b/pkg/destination/athena/sql.go
@@ -208,6 +208,10 @@ func arrowLiteral(arr arrow.Array, dt arrow.DataType, idx int) (string, error) {
 		v := a.Value(idx)
 		dt := a.DataType().(*arrow.Decimal128Type)
 		return v.ToString(dt.Scale), nil
+	case *array.Decimal256:
+		v := a.Value(idx)
+		dt := a.DataType().(*arrow.Decimal256Type)
+		return v.ToString(dt.Scale), nil
 	case *array.Date32:
 		t := a.Value(idx).ToTime()
 		return "DATE " + quoteString(t.Format("2006-01-02")), nil
@@ -252,6 +256,12 @@ func arrowLiteral(arr arrow.Array, dt arrow.DataType, idx int) (string, error) {
 			if decArr, ok := arr.(*array.Decimal128); ok {
 				v := decArr.Value(idx)
 				dt := decArr.DataType().(*arrow.Decimal128Type)
+				return v.ToString(dt.Scale), nil
+			}
+		case arrow.DECIMAL256:
+			if decArr, ok := arr.(*array.Decimal256); ok {
+				v := decArr.Value(idx)
+				dt := decArr.DataType().(*arrow.Decimal256Type)
 				return v.ToString(dt.Scale), nil
 			}
 		}

--- a/pkg/destination/bigquery/load_job.go
+++ b/pkg/destination/bigquery/load_job.go
@@ -1547,6 +1547,8 @@ func extractJSONLValue(arr arrow.Array, idx int) any {
 		return t.Format(time.RFC3339Nano)
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case *array.List:
 		start, end := a.ValueOffsets(idx)
 		return extractJSONLListValue(a.ListValues(), start, end)

--- a/pkg/destination/cassandra/cassandra.go
+++ b/pkg/destination/cassandra/cassandra.go
@@ -638,6 +638,10 @@ func arrowToCassandra(arr arrow.Array, idx int) interface{} {
 		val := a.Value(idx)
 		dt := a.DataType().(*arrow.Decimal128Type)
 		return inf.NewDecBig(val.BigInt(), inf.Scale(dt.Scale))
+	case *array.Decimal256:
+		val := a.Value(idx)
+		dt := a.DataType().(*arrow.Decimal256Type)
+		return inf.NewDecBig(val.BigInt(), inf.Scale(dt.Scale))
 	case *array.Date32:
 		return a.Value(idx).ToTime()
 	case *array.Date64:

--- a/pkg/destination/clevertap/clevertap.go
+++ b/pkg/destination/clevertap/clevertap.go
@@ -675,6 +675,12 @@ func arrowToValue(arr arrow.Array, idx int) interface{} {
 			return val.ToString(dt.Scale)
 		}
 		return val.ToString(0)
+	case *array.Decimal256:
+		val := a.Value(idx)
+		if dt, ok := a.DataType().(*arrow.Decimal256Type); ok {
+			return val.ToString(dt.Scale)
+		}
+		return val.ToString(0)
 	case *array.Date32:
 		return a.Value(idx).ToTime().Format("2006-01-02")
 	case *array.Date64:

--- a/pkg/destination/clickhouse/clickhouse.go
+++ b/pkg/destination/clickhouse/clickhouse.go
@@ -1036,6 +1036,10 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		v := a.Value(idx)
 		dt := a.DataType().(*arrow.Decimal128Type)
 		return decimal.NewFromBigInt(v.BigInt(), -dt.Scale)
+	case *array.Decimal256:
+		v := a.Value(idx)
+		dt := a.DataType().(*arrow.Decimal256Type)
+		return decimal.NewFromBigInt(v.BigInt(), -dt.Scale)
 	case array.ExtensionArray:
 		storage := a.Storage()
 		return extractValue(storage, idx)

--- a/pkg/destination/cratedb/cratedb.go
+++ b/pkg/destination/cratedb/cratedb.go
@@ -860,6 +860,8 @@ func extractValue(arr arrow.Array, idx int) any {
 		return v.ToTime(a.DataType().(*arrow.TimestampType).Unit)
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case *array.List:
 		return a.ValueStr(idx)
 	case array.ExtensionArray:

--- a/pkg/destination/csv/csv.go
+++ b/pkg/destination/csv/csv.go
@@ -344,6 +344,8 @@ func formatValue(arr arrow.Array, idx int) string {
 		return t.Format("2006-01-02T15:04:05.000000")
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case array.ExtensionArray:
 		return formatValue(a.Storage(), idx)
 	default:

--- a/pkg/destination/dynamodb/dynamodb.go
+++ b/pkg/destination/dynamodb/dynamodb.go
@@ -746,6 +746,12 @@ func arrowToDynamoDB(arr arrow.Array, idx int) types.AttributeValue {
 			return &types.AttributeValueMemberN{Value: val.ToString(dt.Scale)}
 		}
 		return &types.AttributeValueMemberN{Value: val.ToString(0)}
+	case *array.Decimal256:
+		val := a.Value(idx)
+		if dt, ok := a.DataType().(*arrow.Decimal256Type); ok {
+			return &types.AttributeValueMemberN{Value: val.ToString(dt.Scale)}
+		}
+		return &types.AttributeValueMemberN{Value: val.ToString(0)}
 	case *array.Date32:
 		return &types.AttributeValueMemberS{Value: a.Value(idx).ToTime().Format("2006-01-02")}
 	case *array.Date64:

--- a/pkg/destination/elasticsearch/elasticsearch.go
+++ b/pkg/destination/elasticsearch/elasticsearch.go
@@ -528,6 +528,12 @@ func arrowToValue(arr arrow.Array, idx int) interface{} {
 			return val.ToString(dt.Scale)
 		}
 		return val.ToString(0)
+	case *array.Decimal256:
+		val := a.Value(idx)
+		if dt, ok := a.DataType().(*arrow.Decimal256Type); ok {
+			return val.ToString(dt.Scale)
+		}
+		return val.ToString(0)
 	case *array.Date32:
 		return a.Value(idx).ToTime().Format("2006-01-02")
 	case *array.Date64:

--- a/pkg/destination/google_sheets/google_sheets.go
+++ b/pkg/destination/google_sheets/google_sheets.go
@@ -448,6 +448,8 @@ func valueToCell(arr arrow.Array, idx int) interface{} {
 		return a.Value(idx)
 	case *array.Decimal128:
 		return a.Value(idx).ToFloat64(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToFloat64(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case *array.String:
 		return a.Value(idx)
 	case *array.LargeString:

--- a/pkg/destination/iceberg/rows.go
+++ b/pkg/destination/iceberg/rows.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/decimal128"
+	"github.com/apache/arrow-go/v18/arrow/decimal256"
 	"github.com/apache/arrow-go/v18/arrow/extensions"
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	iceberggo "github.com/apache/iceberg-go"
@@ -336,6 +337,17 @@ func appendValue(b array.Builder, v any) error {
 		}
 		dt := bldr.Type().(*arrow.Decimal128Type)
 		num, err := decimal128.FromString(val, dt.Precision, dt.Scale)
+		if err != nil {
+			return fmt.Errorf("cannot convert %q to %s: %w", val, dt, err)
+		}
+		bldr.Append(num)
+	case *array.Decimal256Builder:
+		val, ok := asString(v)
+		if !ok {
+			return typeMismatch(b, v)
+		}
+		dt := bldr.Type().(*arrow.Decimal256Type)
+		num, err := decimal256.FromString(val, dt.Precision, dt.Scale)
 		if err != nil {
 			return fmt.Errorf("cannot convert %q to %s: %w", val, dt, err)
 		}

--- a/pkg/destination/jsonl/jsonl.go
+++ b/pkg/destination/jsonl/jsonl.go
@@ -302,6 +302,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return t.Format(time.RFC3339Nano)
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case array.ExtensionArray:
 		storage := a.Storage()
 		if sb, ok := storage.(*array.String); ok {

--- a/pkg/destination/maxcompute/maxcompute.go
+++ b/pkg/destination/maxcompute/maxcompute.go
@@ -626,6 +626,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.000000")
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case array.ExtensionArray:
 		return extractValue(a.Storage(), idx)
 	default:

--- a/pkg/destination/mongodb/mongodb.go
+++ b/pkg/destination/mongodb/mongodb.go
@@ -526,6 +526,17 @@ func arrowValueToBSON(arr arrow.Array, idx int) (interface{}, error) {
 			return decStr, nil
 		}
 		return val.ToString(0), nil
+	case *array.Decimal256:
+		val := a.Value(idx)
+		if dt, ok := a.DataType().(*arrow.Decimal256Type); ok {
+			decStr := val.ToString(dt.Scale)
+			dec, err := primitive.ParseDecimal128(decStr)
+			if err == nil {
+				return dec, nil
+			}
+			return decStr, nil
+		}
+		return val.ToString(0), nil
 	case *array.Date32:
 		return a.Value(idx).ToTime(), nil
 	case *array.Date64:

--- a/pkg/destination/mysql/mysql.go
+++ b/pkg/destination/mysql/mysql.go
@@ -2316,6 +2316,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.000000")
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case array.ExtensionArray:
 		storage := a.Storage()
 		return extractValue(storage, idx)

--- a/pkg/destination/onelake/onelake.go
+++ b/pkg/destination/onelake/onelake.go
@@ -1044,6 +1044,10 @@ func arrowFieldToColumn(f arrow.Field) schema.Column {
 		col.DataType = schema.TypeDecimal
 		col.Precision = int(dt.Precision)
 		col.Scale = int(dt.Scale)
+	case *arrow.Decimal256Type:
+		col.DataType = schema.TypeDecimal
+		col.Precision = int(dt.Precision)
+		col.Scale = int(dt.Scale)
 	case *arrow.BinaryType, *arrow.LargeBinaryType:
 		col.DataType = schema.TypeBinary
 	case *arrow.Date32Type, *arrow.Date64Type:

--- a/pkg/destination/onelake/transform.go
+++ b/pkg/destination/onelake/transform.go
@@ -436,31 +436,31 @@ func boundCanonical(v interface{}, keyType schema.DataType) (interface{}, bool) 
 	return canonicalValue(v, keyType)
 }
 
-// canonicalCmp compares two canonical values (both float64 or both string).
+// canonicalCmp compares two canonical values. Numeric values (float64 and
+// Decimal256's big.Rat) are compared by value even when the two sides differ;
+// non-numeric values fall back to lexical comparison.
 func canonicalCmp(a, b interface{}) int {
-	switch av := a.(type) {
+	if ar, ok := toRat(a); ok {
+		if br, ok := toRat(b); ok {
+			return ar.Cmp(br)
+		}
+	}
+	return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
+}
+
+// toRat coerces the numeric canonical forms (float64, *big.Rat) to *big.Rat.
+func toRat(v interface{}) (*big.Rat, bool) {
+	switch n := v.(type) {
 	case *big.Rat:
-		if bv, ok := b.(*big.Rat); ok {
-			return av.Cmp(bv)
-		}
-		return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
+		return n, true
 	case float64:
-		bv, ok := b.(float64)
-		if !ok {
-			return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
+		r := new(big.Rat)
+		if r.SetFloat64(n) == nil {
+			return nil, false
 		}
-		switch {
-		case av < bv:
-			return -1
-		case av > bv:
-			return 1
-		default:
-			return 0
-		}
-	case string:
-		return strings.Compare(av, fmt.Sprintf("%v", b))
+		return r, true
 	default:
-		return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
+		return nil, false
 	}
 }
 

--- a/pkg/destination/onelake/transform.go
+++ b/pkg/destination/onelake/transform.go
@@ -3,7 +3,7 @@ package onelake
 import (
 	"context"
 	"fmt"
-	"strconv"
+	"math/big"
 	"strings"
 	"time"
 
@@ -412,12 +412,13 @@ func canonicalValue(v interface{}, keyType schema.DataType) (interface{}, bool) 
 		case float64:
 			return n, true
 		case string:
-			// High-precision decimals (Decimal256) arrive as exact text.
-			f, err := strconv.ParseFloat(n, 64)
-			if err != nil {
+			// High-precision decimals (Decimal256) arrive as exact text; compare
+			// them exactly so close keys do not collapse to the same float64.
+			r, ok := new(big.Rat).SetString(n)
+			if !ok {
 				return nil, false
 			}
-			return f, true
+			return r, true
 		default:
 			return nil, false
 		}
@@ -438,6 +439,11 @@ func boundCanonical(v interface{}, keyType schema.DataType) (interface{}, bool) 
 // canonicalCmp compares two canonical values (both float64 or both string).
 func canonicalCmp(a, b interface{}) int {
 	switch av := a.(type) {
+	case *big.Rat:
+		if bv, ok := b.(*big.Rat); ok {
+			return av.Cmp(bv)
+		}
+		return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
 	case float64:
 		bv, ok := b.(float64)
 		if !ok {

--- a/pkg/destination/onelake/transform.go
+++ b/pkg/destination/onelake/transform.go
@@ -3,6 +3,7 @@ package onelake
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -410,6 +411,13 @@ func canonicalValue(v interface{}, keyType schema.DataType) (interface{}, bool) 
 			return float64(n), true
 		case float64:
 			return n, true
+		case string:
+			// High-precision decimals (Decimal256) arrive as exact text.
+			f, err := strconv.ParseFloat(n, 64)
+			if err != nil {
+				return nil, false
+			}
+			return f, true
 		default:
 			return nil, false
 		}

--- a/pkg/destination/onelake/transform_test.go
+++ b/pkg/destination/onelake/transform_test.go
@@ -627,4 +627,10 @@ func TestCanonicalDecimal256KeysCompareExactly(t *testing.T) {
 	require.Equal(t, -1, canonicalCmp(a, b))
 	require.Equal(t, 1, canonicalCmp(b, a))
 	require.Equal(t, 0, canonicalCmp(a, a))
+
+	// A big.Rat cell and a float64 interval bound must compare numerically.
+	rat, ok := canonicalValue("10.5", schema.TypeDecimal)
+	require.True(t, ok)
+	require.Equal(t, 1, canonicalCmp(rat, float64(2)))
+	require.Equal(t, -1, canonicalCmp(float64(2), rat))
 }

--- a/pkg/destination/onelake/transform_test.go
+++ b/pkg/destination/onelake/transform_test.go
@@ -615,3 +615,16 @@ func TestSCD2IncrementalKeySkipsSoftDelete(t *testing.T) {
 	assert.Equal(t, true, byID[1][destination.SCD2IsCurrentColumn]) // untouched
 	assert.Equal(t, true, byID[2][destination.SCD2IsCurrentColumn]) // net-new
 }
+
+func TestCanonicalDecimal256KeysCompareExactly(t *testing.T) {
+	// Two Decimal256 keys differing only beyond float64's precision must not
+	// collapse; exact comparison keeps them distinct for interval membership.
+	a, ok := canonicalValue("123456789012345678901234567890.00000000000000000001", schema.TypeDecimal)
+	require.True(t, ok)
+	b, ok := canonicalValue("123456789012345678901234567890.00000000000000000002", schema.TypeDecimal)
+	require.True(t, ok)
+
+	require.Equal(t, -1, canonicalCmp(a, b))
+	require.Equal(t, 1, canonicalCmp(b, a))
+	require.Equal(t, 0, canonicalCmp(a, a))
+}

--- a/pkg/destination/oracle/oracle.go
+++ b/pkg/destination/oracle/oracle.go
@@ -1641,6 +1641,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return a.Value(idx).ToTime(a.DataType().(*arrow.TimestampType).Unit)
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case array.ListLike:
 		return a.ValueStr(idx)
 	case *array.Struct:

--- a/pkg/destination/postgres/postgres.go
+++ b/pkg/destination/postgres/postgres.go
@@ -628,6 +628,18 @@ func postgresValueGetterForType(col arrow.Array, dataType schema.DataType) func(
 				Valid: true,
 			}
 		}
+	case *array.Decimal256:
+		dt := a.DataType().(*arrow.Decimal256Type)
+		return func(i int) any {
+			if a.IsNull(i) {
+				return nil
+			}
+			return pgtype.Numeric{
+				Int:   a.Value(i).BigInt(),
+				Exp:   -dt.Scale,
+				Valid: true,
+			}
+		}
 	case *array.Date32:
 		return func(i int) any {
 			if a.IsNull(i) {

--- a/pkg/destination/sqlite/sqlite.go
+++ b/pkg/destination/sqlite/sqlite.go
@@ -1490,6 +1490,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return a.ValueStr(idx)
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case array.ExtensionArray:
 		// Handle extension types by extracting the underlying storage value
 		storage := a.Storage()

--- a/pkg/destination/starrocks/helpers.go
+++ b/pkg/destination/starrocks/helpers.go
@@ -157,6 +157,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.000000")
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case *array.List:
 		start, end := a.ValueOffsets(idx)
 		return listElements(a.ListValues(), int(start), int(end))

--- a/pkg/destination/synapse/synapse.go
+++ b/pkg/destination/synapse/synapse.go
@@ -908,6 +908,8 @@ func extractValue(arr arrow.Array, idx int) interface{} {
 		return ts.ToTime(a.DataType().(*arrow.TimestampType).Unit).Format("2006-01-02 15:04:05.0000000")
 	case *array.Decimal128:
 		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal128Type).Scale))
+	case *array.Decimal256:
+		return a.Value(idx).ToString(int32(a.DataType().(*arrow.Decimal256Type).Scale))
 	case array.ExtensionArray:
 		storage := a.Storage()
 		return extractValue(storage, idx)

--- a/pkg/destination/trino/trino.go
+++ b/pkg/destination/trino/trino.go
@@ -795,6 +795,10 @@ func formatValueForSQL(arr arrow.Array, idx int, jsonType jsonTypeMode) string {
 		v := a.Value(idx)
 		dt := a.DataType().(*arrow.Decimal128Type)
 		return fmt.Sprintf("DECIMAL '%s'", v.ToString(dt.Scale))
+	case *array.Decimal256:
+		v := a.Value(idx)
+		dt := a.DataType().(*arrow.Decimal256Type)
+		return fmt.Sprintf("DECIMAL '%s'", v.ToString(dt.Scale))
 	case array.ExtensionArray:
 		extType := a.ExtensionType()
 		if extType.ExtensionName() == "json" {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -163,6 +163,12 @@ func DataTypeToArrowType(col Column) arrow.DataType {
 		if precision == 0 {
 			precision = 38
 		}
+		if precision > 38 {
+			if precision > 76 {
+				precision = 76
+			}
+			return &arrow.Decimal256Type{Precision: precision, Scale: scale}
+		}
 		return &arrow.Decimal128Type{Precision: precision, Scale: scale}
 	case TypeString, TypeUUID:
 		return arrow.BinaryTypes.String

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -26,6 +26,26 @@ func TestDataTypeToArrowType_ArrayDecimalPreservesPrecisionScale(t *testing.T) {
 	require.Equal(t, int32(5), decimalType.Scale)
 }
 
+func TestDataTypeToArrowType_HighPrecisionDecimalUsesDecimal256(t *testing.T) {
+	t.Parallel()
+
+	got := DataTypeToArrowType(Column{DataType: TypeDecimal, Precision: 40, Scale: 25})
+
+	decimalType, ok := got.(*arrow.Decimal256Type)
+	require.True(t, ok, "precision > 38 must map to Decimal256")
+	require.Equal(t, int32(40), decimalType.Precision)
+	require.Equal(t, int32(25), decimalType.Scale)
+}
+
+func TestDataTypeToArrowType_DecimalWithinDecimal128Range(t *testing.T) {
+	t.Parallel()
+
+	got := DataTypeToArrowType(Column{DataType: TypeDecimal, Precision: 38, Scale: 9})
+
+	_, ok := got.(*arrow.Decimal128Type)
+	require.True(t, ok, "precision <= 38 must stay Decimal128")
+}
+
 func TestTableSchemaSameColumnShapeIncludesMaxLength(t *testing.T) {
 	left := &TableSchema{Columns: []Column{{Name: "name", DataType: TypeString, MaxLength: 20}}}
 	right := &TableSchema{Columns: []Column{{Name: "name", DataType: TypeString, MaxLength: 40}}}

--- a/pkg/schemaevolution/array_compare_test.go
+++ b/pkg/schemaevolution/array_compare_test.go
@@ -54,12 +54,12 @@ func TestCompareMergesDecimalArrayElementPrecision(t *testing.T) {
 	require.Equal(t, 24, comparison.Changes[0].NewColumn.Precision)
 	require.Equal(t, 8, comparison.Changes[0].NewColumn.Scale)
 
-	source.Columns[0].Precision = 38
+	source.Columns[0].Precision = 76
 	source.Columns[0].Scale = 38
-	dest.Columns[0].Precision = 38
+	dest.Columns[0].Precision = 76
 	dest.Columns[0].Scale = 0
 	_, err = Compare(source, dest, nil)
-	require.ErrorContains(t, err, "maximum supported precision is 38")
+	require.ErrorContains(t, err, "maximum supported precision is 76")
 }
 
 func TestCompareWidensStringArrayElementLength(t *testing.T) {
@@ -78,14 +78,14 @@ func TestCompareWidensStringArrayElementLength(t *testing.T) {
 
 func TestCompareRejectsUnrepresentableScalarDecimalWidening(t *testing.T) {
 	source := &schema.TableSchema{Columns: []schema.Column{{
-		Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 38,
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 76, Scale: 38,
 	}}}
 	dest := &schema.TableSchema{Columns: []schema.Column{{
-		Name: "amount", DataType: schema.TypeDecimal, Precision: 38, Scale: 0,
+		Name: "amount", DataType: schema.TypeDecimal, Precision: 76, Scale: 0,
 	}}}
 
 	_, err := Compare(source, dest, nil)
-	require.ErrorContains(t, err, "maximum supported precision is 38")
+	require.ErrorContains(t, err, "maximum supported precision is 76")
 }
 
 func TestComparePreservesDecimalIntegerDigits(t *testing.T) {
@@ -128,8 +128,12 @@ func TestCompareTreatsUnspecifiedDecimalPrecisionAsDecimal38(t *testing.T) {
 	}}}
 
 	comparison, err := Compare(source, dest, nil)
-	require.ErrorContains(t, err, "maximum supported precision is 38")
-	require.Nil(t, comparison)
+	require.NoError(t, err)
+	require.Len(t, comparison.Changes, 1)
+	// Unspecified precision is treated as 38 integer digits, so widening with a
+	// scale-2 column yields precision 40.
+	require.Equal(t, 40, comparison.Changes[0].NewColumn.Precision)
+	require.Equal(t, 2, comparison.Changes[0].NewColumn.Scale)
 }
 
 func TestCompareUsesUnboundedStringForCrossTypeWidening(t *testing.T) {

--- a/pkg/schemaevolution/override.go
+++ b/pkg/schemaevolution/override.go
@@ -225,8 +225,8 @@ func parseColumnOverride(pair string) (ColumnOverride, error) {
 			if err != nil {
 				return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': %w", typeSpec, err)
 			}
-			if p < 1 || p > 38 {
-				return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': must be between 1 and 38", typeSpec)
+			if p < 1 || p > 76 {
+				return ColumnOverride{}, fmt.Errorf("invalid precision in '%s': must be between 1 and 76", typeSpec)
 			}
 			override.Precision = p
 			if len(params) == 2 {

--- a/pkg/schemaevolution/override_test.go
+++ b/pkg/schemaevolution/override_test.go
@@ -98,7 +98,7 @@ func TestParseColumnOverrides_DecimalValidationAndExplicitZeroScale(t *testing.T
 
 	for _, spec := range []string{
 		"amount:decimal(0,0)",
-		"amount:decimal(39,2)",
+		"amount:decimal(77,2)",
 		"amount:decimal(10,-1)",
 		"amount:decimal(10,11)",
 		"amount:decimal(10,2,1)",

--- a/pkg/schemaevolution/widen.go
+++ b/pkg/schemaevolution/widen.go
@@ -144,9 +144,9 @@ func MergeDecimalPrecision(src, dest schema.Column) (precision, scale int) {
 
 func MergeDecimalPrecisionChecked(src, dest schema.Column) (precision, scale int, err error) {
 	precision, scale = MergeDecimalPrecision(src, dest)
-	if precision > 38 {
+	if precision > 76 {
 		return 0, 0, fmt.Errorf(
-			"decimal widening requires precision %d (integer digits %d + scale %d), maximum supported precision is 38",
+			"decimal widening requires precision %d (integer digits %d + scale %d), maximum supported precision is 76",
 			precision, precision-scale, scale,
 		)
 	}

--- a/pkg/schemainfer/merge.go
+++ b/pkg/schemainfer/merge.go
@@ -155,10 +155,14 @@ func promoteNumericTypes(a, b arrow.DataType) (arrow.DataType, error) {
 		return arrow.PrimitiveTypes.Float32, nil
 	}
 
-	// If either is decimal, result is decimal
+	// If either is decimal, result is decimal. A Decimal256 input must not be
+	// narrowed back to Decimal128, or replay fails its precision check on
+	// high-precision values.
 	if a.ID() == arrow.DECIMAL128 || b.ID() == arrow.DECIMAL128 ||
 		a.ID() == arrow.DECIMAL256 || b.ID() == arrow.DECIMAL256 {
-		// Use default precision/scale for merged decimals
+		if a.ID() == arrow.DECIMAL256 || b.ID() == arrow.DECIMAL256 {
+			return &arrow.Decimal256Type{Precision: 76, Scale: 38}, nil
+		}
 		return &arrow.Decimal128Type{Precision: 38, Scale: 9}, nil
 	}
 
@@ -270,7 +274,11 @@ func ArrowFieldToColumn(name string, dt arrow.DataType, nullable bool) schema.Co
 		col.DataType = schema.TypeFloat64
 	case arrow.DECIMAL128, arrow.DECIMAL256:
 		col.DataType = schema.TypeDecimal
-		if decType, ok := dt.(*arrow.Decimal128Type); ok {
+		switch decType := dt.(type) {
+		case *arrow.Decimal128Type:
+			col.Precision = int(decType.Precision)
+			col.Scale = int(decType.Scale)
+		case *arrow.Decimal256Type:
 			col.Precision = int(decType.Precision)
 			col.Scale = int(decType.Scale)
 		}

--- a/pkg/schemainfer/merge.go
+++ b/pkg/schemainfer/merge.go
@@ -155,14 +155,19 @@ func promoteNumericTypes(a, b arrow.DataType) (arrow.DataType, error) {
 		return arrow.PrimitiveTypes.Float32, nil
 	}
 
-	// If either is decimal, result is decimal. A Decimal256 input must not be
-	// narrowed back to Decimal128, or replay fails its precision check on
-	// high-precision values.
+	// If either is decimal, result is decimal (Decimal256 must not narrow to Decimal128).
 	if a.ID() == arrow.DECIMAL128 || b.ID() == arrow.DECIMAL128 ||
 		a.ID() == arrow.DECIMAL256 || b.ID() == arrow.DECIMAL256 {
 		if a.ID() == arrow.DECIMAL256 || b.ID() == arrow.DECIMAL256 {
-			precision, scale := mergedDecimalBounds(a, b)
-			return &arrow.Decimal256Type{Precision: precision, Scale: scale}, nil
+			intA, scaleA := decimalIntDigitsAndScale(a)
+			intB, scaleB := decimalIntDigitsAndScale(b)
+			intDigits := max(intA, intB)
+			scale := max(scaleA, scaleB)
+			// Both integer digits and scale must fit Decimal256's 76; else carry as string.
+			if intDigits+scale > 76 {
+				return arrow.BinaryTypes.String, nil
+			}
+			return &arrow.Decimal256Type{Precision: intDigits + scale, Scale: scale}, nil
 		}
 		return &arrow.Decimal128Type{Precision: 38, Scale: 9}, nil
 	}
@@ -185,24 +190,6 @@ func promoteNumericTypes(a, b arrow.DataType) (arrow.DataType, error) {
 	default:
 		return arrow.PrimitiveTypes.Int64, nil
 	}
-}
-
-// mergedDecimalBounds picks a Decimal256 precision/scale wide enough to hold
-// both inputs: it keeps the larger integer-digit capacity and the larger scale,
-// clamped to Decimal256's 76-digit ceiling (trimming scale first so integer
-// digits — where overflow would occur — are preserved).
-func mergedDecimalBounds(a, b arrow.DataType) (int32, int32) {
-	intA, scaleA := decimalIntDigitsAndScale(a)
-	intB, scaleB := decimalIntDigitsAndScale(b)
-	intDigits := max(intA, intB)
-	scale := max(scaleA, scaleB)
-	if intDigits > 76 {
-		intDigits = 76
-	}
-	if intDigits+scale > 76 {
-		scale = 76 - intDigits
-	}
-	return intDigits + scale, scale
 }
 
 // decimalIntDigitsAndScale returns a type's integer-digit capacity and scale.

--- a/pkg/schemainfer/merge.go
+++ b/pkg/schemainfer/merge.go
@@ -161,7 +161,8 @@ func promoteNumericTypes(a, b arrow.DataType) (arrow.DataType, error) {
 	if a.ID() == arrow.DECIMAL128 || b.ID() == arrow.DECIMAL128 ||
 		a.ID() == arrow.DECIMAL256 || b.ID() == arrow.DECIMAL256 {
 		if a.ID() == arrow.DECIMAL256 || b.ID() == arrow.DECIMAL256 {
-			return &arrow.Decimal256Type{Precision: 76, Scale: 38}, nil
+			precision, scale := mergedDecimalBounds(a, b)
+			return &arrow.Decimal256Type{Precision: precision, Scale: scale}, nil
 		}
 		return &arrow.Decimal128Type{Precision: 38, Scale: 9}, nil
 	}
@@ -183,6 +184,37 @@ func promoteNumericTypes(a, b arrow.DataType) (arrow.DataType, error) {
 		return arrow.PrimitiveTypes.Int64, nil
 	default:
 		return arrow.PrimitiveTypes.Int64, nil
+	}
+}
+
+// mergedDecimalBounds picks a Decimal256 precision/scale wide enough to hold
+// both inputs: it keeps the larger integer-digit capacity and the larger scale,
+// clamped to Decimal256's 76-digit ceiling (trimming scale first so integer
+// digits — where overflow would occur — are preserved).
+func mergedDecimalBounds(a, b arrow.DataType) (int32, int32) {
+	intA, scaleA := decimalIntDigitsAndScale(a)
+	intB, scaleB := decimalIntDigitsAndScale(b)
+	intDigits := max(intA, intB)
+	scale := max(scaleA, scaleB)
+	if intDigits > 76 {
+		intDigits = 76
+	}
+	if intDigits+scale > 76 {
+		scale = 76 - intDigits
+	}
+	return intDigits + scale, scale
+}
+
+// decimalIntDigitsAndScale returns a type's integer-digit capacity and scale.
+// Non-decimal numerics are treated as 64-bit integers (up to 19 digits).
+func decimalIntDigitsAndScale(dt arrow.DataType) (int32, int32) {
+	switch t := dt.(type) {
+	case *arrow.Decimal128Type:
+		return t.Precision - t.Scale, t.Scale
+	case *arrow.Decimal256Type:
+		return t.Precision - t.Scale, t.Scale
+	default:
+		return 19, 0
 	}
 }
 

--- a/pkg/schemainfer/merge_test.go
+++ b/pkg/schemainfer/merge_test.go
@@ -220,8 +220,7 @@ func TestMergeArrowTypes_Decimal256NotNarrowed(t *testing.T) {
 }
 
 func TestMergeArrowTypes_Decimal256PreservesIntegerDigits(t *testing.T) {
-	// numeric(76,0) has 76 integer digits; the merged type must keep room for
-	// all of them or a low-scale value overflows during replay.
+	// The merged type must keep room for all 76 integer digits.
 	result, err := MergeArrowTypes(&arrow.Decimal256Type{Precision: 76, Scale: 0}, arrow.PrimitiveTypes.Int64)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -232,6 +231,17 @@ func TestMergeArrowTypes_Decimal256PreservesIntegerDigits(t *testing.T) {
 	}
 	if dt.Precision-dt.Scale < 76 {
 		t.Errorf("merged type must keep 76 integer digits, got precision=%d scale=%d", dt.Precision, dt.Scale)
+	}
+}
+
+func TestMergeArrowTypes_Decimal256OverflowFallsBackToString(t *testing.T) {
+	// 76 integer digits + 25 fractional exceed Decimal256's 76-digit limit.
+	result, err := MergeArrowTypes(&arrow.Decimal256Type{Precision: 76, Scale: 0}, &arrow.Decimal256Type{Precision: 40, Scale: 25})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID() != arrow.STRING {
+		t.Errorf("expected string fallback when digits do not fit, got %v", result)
 	}
 }
 

--- a/pkg/schemainfer/merge_test.go
+++ b/pkg/schemainfer/merge_test.go
@@ -205,6 +205,20 @@ func TestMergeArrowTypes_DecimalPromotion(t *testing.T) {
 	}
 }
 
+func TestMergeArrowTypes_Decimal256NotNarrowed(t *testing.T) {
+	dec256 := &arrow.Decimal256Type{Precision: 40, Scale: 25}
+
+	for _, other := range []arrow.DataType{arrow.PrimitiveTypes.Int64, &arrow.Decimal128Type{Precision: 18, Scale: 2}} {
+		result, err := MergeArrowTypes(dec256, other)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.ID() != arrow.DECIMAL256 {
+			t.Errorf("merging Decimal256 with %v must stay Decimal256, got %v", other, result)
+		}
+	}
+}
+
 func TestIsNumericType(t *testing.T) {
 	numericTypes := []arrow.DataType{
 		arrow.PrimitiveTypes.Int8,

--- a/pkg/schemainfer/merge_test.go
+++ b/pkg/schemainfer/merge_test.go
@@ -219,6 +219,22 @@ func TestMergeArrowTypes_Decimal256NotNarrowed(t *testing.T) {
 	}
 }
 
+func TestMergeArrowTypes_Decimal256PreservesIntegerDigits(t *testing.T) {
+	// numeric(76,0) has 76 integer digits; the merged type must keep room for
+	// all of them or a low-scale value overflows during replay.
+	result, err := MergeArrowTypes(&arrow.Decimal256Type{Precision: 76, Scale: 0}, arrow.PrimitiveTypes.Int64)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dt, ok := result.(*arrow.Decimal256Type)
+	if !ok {
+		t.Fatalf("expected Decimal256, got %v", result)
+	}
+	if dt.Precision-dt.Scale < 76 {
+		t.Errorf("merged type must keep 76 integer digits, got precision=%d scale=%d", dt.Precision, dt.Scale)
+	}
+}
+
 func TestIsNumericType(t *testing.T) {
 	numericTypes := []arrow.DataType{
 		arrow.PrimitiveTypes.Int8,

--- a/pkg/source/postgres/mapper.go
+++ b/pkg/source/postgres/mapper.go
@@ -8,6 +8,10 @@ import (
 	"github.com/bruin-data/ingestr/pkg/schema"
 )
 
+// maxDecimal256Precision is the largest precision Arrow's Decimal256 can hold.
+// PostgreSQL numeric allows up to 1000, so anything wider is carried as text.
+const maxDecimal256Precision = 76
+
 var (
 	numericPrecisionRegex = regexp.MustCompile(`numeric\((\d+),\s*(\d+)\)`)
 	arrayTypeRegex        = regexp.MustCompile(`^(.+)\[\]$`)

--- a/pkg/source/postgres/postgres.go
+++ b/pkg/source/postgres/postgres.go
@@ -205,6 +205,14 @@ func (s *PostgresSource) getSchema(ctx context.Context, table string) (*schema.T
 			col.Scale = scale
 		}
 
+		// Decimals wider than Decimal256 can hold (76 digits) would overflow the
+		// Arrow builder and panic; carry them as exact text instead.
+		if col.DataType == schema.TypeDecimal && col.Precision > maxDecimal256Precision {
+			col.DataType = schema.TypeString
+			col.Precision = 0
+			col.Scale = 0
+		}
+
 		if charMaxLen != nil {
 			col.MaxLength = *charMaxLen
 		}
@@ -620,6 +628,13 @@ func convertValue(val interface{}, col schema.Column) interface{} {
 	case pgtype.Numeric:
 		if !v.Valid || v.NaN {
 			return nil
+		}
+		if col.DataType == schema.TypeString {
+			if s, err := v.Value(); err == nil {
+				if str, ok := s.(string); ok {
+					return str
+				}
+			}
 		}
 		return numericToBigInt(v, col.Scale)
 	default:


### PR DESCRIPTION
## Problem

Ingesting a PostgreSQL `numeric(40,25)` column (or any decimal with precision > 38) crashes at the source:

```
panic: arrow/decimal128: cannot represent value larger than 128bits
    arrow/decimal128.FromBigInt(...)
```

Arrow's `Decimal128` holds 128 bits (~38 digits), but `schema.DataTypeToArrowType` always mapped `TypeDecimal` to `Decimal128Type` regardless of precision. A 40-digit value overflows and panics before any destination code runs.