### PR TITLE
Fix PostgreSQL CDC row loss during schema rebuilds

### DIFF
--- a/pkg/source/postgres_cdc/batch_accumulator.go
+++ b/pkg/source/postgres_cdc/batch_accumulator.go
@@ -217,9 +217,7 @@ func (a *batchAccumulator) flushAllContext(ctx context.Context, results chan<- s
 	return nil
 }
 
-// Flush unaffected tables before discarding the accumulator for a rebuild.
-// Failed tables retain their low-water marks during this flush, so these batches
-// cannot acknowledge WAL that still needs a replacement snapshot.
+// Flush unaffected tables without acknowledging WAL still needed by replacement snapshots.
 func (a *batchAccumulator) flushForSchemaRebuild(ctx context.Context, results chan<- source.RecordBatchResult, token tokenFunc, first *SchemaChangedError) ([]*SchemaChangedError, error) {
 	var schemaErrors []*SchemaChangedError
 	if first != nil {

--- a/pkg/source/postgres_cdc/batch_accumulator.go
+++ b/pkg/source/postgres_cdc/batch_accumulator.go
@@ -2,6 +2,7 @@ package postgres_cdc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"unsafe"
@@ -216,6 +217,29 @@ func (a *batchAccumulator) flushAllContext(ctx context.Context, results chan<- s
 	return nil
 }
 
+// Flush unaffected tables before discarding the accumulator for a rebuild.
+// Failed tables retain their low-water marks during this flush, so these batches
+// cannot acknowledge WAL that still needs a replacement snapshot.
+func (a *batchAccumulator) flushForSchemaRebuild(ctx context.Context, results chan<- source.RecordBatchResult, token tokenFunc, first *SchemaChangedError) ([]*SchemaChangedError, error) {
+	var schemaErrors []*SchemaChangedError
+	if first != nil {
+		schemaErrors = append(schemaErrors, first)
+	}
+	for tableName := range a.changes {
+		if first != nil && tableName == first.Table {
+			continue
+		}
+		if err := a.flushTableContext(ctx, tableName, results, token); err != nil {
+			var schemaErr *SchemaChangedError
+			if !errors.As(err, &schemaErr) {
+				return nil, err
+			}
+			schemaErrors = append(schemaErrors, schemaErr)
+		}
+	}
+	return schemaErrors, nil
+}
+
 func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName string, results chan<- source.RecordBatchResult, token tokenFunc) error {
 	if err := source.ConnectorLeaseLoss(ctx); err != nil {
 		a.discard()
@@ -225,14 +249,6 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 	if len(changes) == 0 {
 		return nil
 	}
-
-	delete(a.changes, tableName)
-	delete(a.minLSN, tableName)
-	a.totalBytes -= a.bytes[tableName]
-	if a.totalBytes < 0 {
-		a.totalBytes = 0
-	}
-	delete(a.bytes, tableName)
 
 	if a.durable != nil {
 		if err := a.toast.prune(ctx, a.durable()); err != nil {
@@ -273,6 +289,14 @@ func (a *batchAccumulator) flushTableContext(ctx context.Context, tableName stri
 	if len(changes) > 0 {
 		changes = compactChanges(changes, tableSchema)
 	}
+
+	delete(a.changes, tableName)
+	delete(a.minLSN, tableName)
+	a.totalBytes -= a.bytes[tableName]
+	if a.totalBytes < 0 {
+		a.totalBytes = 0
+	}
+	delete(a.bytes, tableName)
 
 	var commitToken any
 	if token != nil {

--- a/pkg/source/postgres_cdc/multitable_reader.go
+++ b/pkg/source/postgres_cdc/multitable_reader.go
@@ -843,6 +843,32 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 	if opts.Streaming {
 		token = func() any { return checkpointCommitToken(safeCommitLSN(repl, accum)) }
 	}
+	defer func() {
+		if !opts.Streaming {
+			return
+		}
+		var schemaErr *SchemaChangedError
+		if retErr != nil && !errors.As(retErr, &schemaErr) {
+			return
+		}
+		if retSignal == nil && schemaErr == nil {
+			return
+		}
+		schemaErrors, err := accum.flushForSchemaRebuild(ctx, results, token, schemaErr)
+		if err != nil {
+			retSignal, retErr = nil, err
+			return
+		}
+		if retSignal == nil {
+			retSignal = &streamSignal{}
+		}
+		for _, schemaErr := range schemaErrors {
+			output.Statusf("Schema change detected on table %s (column %q %s); rebuilding stream around the new schema\n", schemaErr.Table, schemaErr.Column, schemaErr.Reason)
+			retSignal.changedTables = append(retSignal.changedTables, schemaErr.Table)
+			retSignal.schemaErrors = append(retSignal.schemaErrors, schemaErr)
+		}
+		retErr = nil
+	}()
 
 	// lastIdleToken is the highest LSN already handed to the pipeline via a bare
 	// idle commit token, so we only emit one when the caught-up position has
@@ -884,9 +910,6 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 				// transaction still inside the decoder is dropped with the
 				// replicator; the slot cannot have confirmed past it, so the
 				// rebuilt stream re-decodes it.
-				if err := accum.flushAllContext(ctx, results, token); err != nil {
-					return nil, err
-				}
 				return &streamSignal{newTables: newNames, changedTables: changed, reincarnatedTables: reincarnated}, nil
 			}
 		}
@@ -907,16 +930,10 @@ func (r *MultiTableCDCReader) streamChanges(ctx context.Context, startLSN pglogr
 				// rebuilt stream re-decodes it in full. Batch runs skip this and
 				// surface the error instead — a restart heals them the same way.
 				output.Statusf("Schema change detected on table %s (column %q %s); rebuilding stream around the new schema\n", schemaErr.Table, schemaErr.Column, schemaErr.Reason)
-				if err := accum.flushAllContext(ctx, results, token); err != nil {
-					return nil, err
-				}
 				return &streamSignal{changedTables: []string{schemaErr.Table}, schemaErrors: []*SchemaChangedError{schemaErr}}, nil
 			}
 			var reincarnationErr *TableReincarnatedError
 			if opts.Streaming && errors.As(err, &reincarnationErr) {
-				if err := accum.flushAllContext(ctx, results, token); err != nil {
-					return nil, err
-				}
 				relationID, parseErr := strconv.ParseUint(reincarnationErr.Current, 10, 32)
 				if parseErr != nil {
 					return nil, fmt.Errorf("invalid PostgreSQL relation incarnation %q: %w", reincarnationErr.Current, parseErr)

--- a/pkg/source/postgres_cdc/toast_state_test.go
+++ b/pkg/source/postgres_cdc/toast_state_test.go
@@ -160,4 +160,54 @@ func TestToastKeyMoveAfterRelationChangeRequestsSchemaRebuild(t *testing.T) {
 	require.ErrorAs(t, err, &schemaErr)
 	require.Equal(t, "public.t", schemaErr.Table)
 	require.Equal(t, "config_data", schemaErr.Column)
+	low, pending := a.minPendingLSN()
+	require.True(t, pending, "failed materialization must still block WAL acknowledgement")
+	require.Equal(t, pglogrepl.LSN(2), low)
+	require.Len(t, a.changes["public.t"], 1)
+}
+
+func TestSchemaRebuildFlushesUnaffectedTables(t *testing.T) {
+	for _, failedFirst := range []bool{false, true} {
+		t.Run(fmt.Sprintf("failed_first=%t", failedFirst), func(t *testing.T) {
+			a := newBatchAccumulator(1, map[string]*schema.TableSchema{
+				"changed_a": fillTestSchema(), "changed_b": fillTestSchema(), "unaffected": fillTestSchema(),
+			})
+			t.Cleanup(func() { require.NoError(t, a.toast.close()) })
+			for _, table := range []string{"changed_a", "changed_b"} {
+				a.add(table, []Change{{
+					Operation: "UPDATE", LSN: 20, Sequence: 2,
+					Values:    []interface{}{int64(2), tupleRelationMissingMarker, "moved"},
+					OldValues: []interface{}{int64(1), nil, nil},
+				}}, 20)
+			}
+			a.add("unaffected", []Change{{
+				Operation: "INSERT", LSN: 30,
+				Values: []interface{}{int64(3), "payload", "kept"},
+			}}, 30)
+			out := make(chan source.RecordBatchResult, 3)
+			t.Cleanup(func() { close(out); drainRecordBatchResults(out) })
+			token := func() any { return safeCommitLSN(&fakeReplicator{lsn: 100}, a) }
+			var first *SchemaChangedError
+			if failedFirst {
+				err := a.flushTableContext(t.Context(), "changed_a", out, token)
+				require.ErrorAs(t, err, &first)
+			}
+			schemaErrors, err := a.flushForSchemaRebuild(t.Context(), out, token, first)
+			require.NoError(t, err)
+			var changed []string
+			for _, schemaErr := range schemaErrors {
+				changed = append(changed, schemaErr.Table)
+			}
+			require.ElementsMatch(t, []string{"changed_a", "changed_b"}, changed)
+			require.Len(t, out, 1, "unaffected rows must not be discarded at the schema boundary")
+			res := <-out
+			defer res.Batch.Release()
+			require.Equal(t, "unaffected", res.TableName)
+			require.EqualValues(t, 1, res.Batch.NumRows())
+			require.Equal(t, int64(3), res.Batch.Column(0).(*array.Int64).Value(0))
+			require.Equal(t, pglogrepl.LSN(19), res.CommitToken, "unflushed schema changes still block acknowledgement")
+			require.NotContains(t, a.changes, "unaffected")
+			require.Len(t, a.changes, 2)
+		})
+	}
 }

--- a/tests/integration/postgres_cdc_stress_test.go
+++ b/tests/integration/postgres_cdc_stress_test.go
@@ -523,15 +523,62 @@ func TestPostgresCDC_StressComplexWorkload(t *testing.T) {
 		truths[tbl.name] = tr
 		t.Logf("source truth %s: count=%d sum=%s", tbl.name, tr.count, tr.sum)
 	}
-	// While the streams are writing, monitoring must open the file read-only;
-	// after shutdown the held read-write connection takes over.
-	var duckDB *sql.DB
-	withDuckDB := func(fn func(*sql.DB) error) error {
-		if duckDB != nil {
-			return fn(duckDB)
+	// Independent DuckDB instances do not share the writer's buffer pool, even
+	// when opened read-only. Wait for durable WAL acknowledgements and close
+	// both writers before opening the file for verification.
+	// Use the insert position to include commits with synchronous_commit=off.
+	var finalLSN string
+	require.NoError(t, srcPool.QueryRow(ctx, `SELECT pg_current_wal_insert_lsn()::text`).Scan(&finalLSN))
+	deadline := time.Now().Add(stressConvergeTimeout)
+	lastProgressLog := time.Now()
+	for {
+		select {
+		case exit := <-streamExits:
+			if restartStreamIfRequired(exit) {
+				continue
+			}
+			stressDumpReplicationState(t, ctx, srcPool)
+			t.Fatalf("%s stream exited during convergence: %v", exit.sink.name, exit.err)
+		default:
 		}
-		return withCDCStressDuckDBReadOnly(duckDBPath, fn)
+		var caughtUp int
+		require.NoError(t, srcPool.QueryRow(ctx, `
+			SELECT count(*) FROM pg_replication_slots
+			WHERE NOT temporary AND active AND confirmed_flush_lsn >= $1::pg_lsn
+		`, finalLSN).Scan(&caughtUp))
+		if caughtUp == len(streamSinks) {
+			break
+		}
+		if time.Since(lastProgressLog) > 20*time.Second {
+			lastProgressLog = time.Now()
+			t.Logf("waiting for durable CDC acknowledgement through %s: %d/%d streams", finalLSN, caughtUp, len(streamSinks))
+		}
+		if time.Now().After(deadline) {
+			stressDumpReplicationState(t, ctx, srcPool)
+			stressDumpContainerLogs(t, ctx, sourceContainer, 120)
+			t.Fatalf("streams did not acknowledge %s within %v", finalLSN, stressConvergeTimeout)
+		}
+		time.Sleep(2 * time.Second)
 	}
+	for _, sink := range streamSinks {
+		require.Positive(t, sink.restarts, "%s workload should exercise the safe restart boundary", sink.name)
+	}
+
+	cancelStream()
+	stopped := make(map[string]struct{}, len(streamSinks))
+	deadline = time.Now().Add(60 * time.Second)
+	for len(stopped) < len(streamSinks) {
+		select {
+		case exit := <-streamExits:
+			if exit.err != nil {
+				require.ErrorIs(t, exit.err, context.Canceled, "%s stream shutdown", exit.sink.name)
+			}
+			stopped[exit.sink.name] = struct{}{}
+		case <-time.After(time.Until(deadline)):
+			t.Fatal("streaming pipelines did not exit within 60s of cancellation")
+		}
+	}
+	duckDB := openCDCStressDuckDB(t, duckDBPath)
 
 	type stressDestination struct {
 		name          string
@@ -563,35 +610,21 @@ func TestPostgresCDC_StressComplexWorkload(t *testing.T) {
 		{
 			name: "duckdb",
 			aggregate: func(table string) (stressTruth, error) {
-				var truth stressTruth
-				err := withDuckDB(func(db *sql.DB) error {
-					var err error
-					truth, err = stressDuckDBTruth(ctx, db, table)
-					return err
-				})
-				return truth, err
+				return stressDuckDBTruth(ctx, duckDB, table)
 			},
 			compareAll: func() error {
-				return withDuckDB(func(db *sql.DB) error {
-					return stressCompareAllDuckDB(ctx, srcPool, db, finalTables)
-				})
+				return stressCompareAllDuckDB(ctx, srcPool, duckDB, finalTables)
 			},
 			validate: func() error {
-				return withDuckDB(func(db *sql.DB) error {
-					return stressValidateDuckDBSchemas(ctx, srcPool, db, finalTables)
-				})
+				return stressValidateDuckDBSchemas(ctx, srcPool, duckDB, finalTables)
 			},
 			validateState: func() error {
-				return withDuckDB(func(db *sql.DB) error {
-					return stressValidateDuckDBState(ctx, db, len(finalTables))
-				})
+				return stressValidateDuckDBState(ctx, duckDB, len(finalTables))
 			},
 			softDeleted: func(table string) (int64, error) {
 				var deleted int64
-				err := withDuckDB(func(db *sql.DB) error {
-					return db.QueryRowContext(ctx,
-						fmt.Sprintf(`SELECT count(*) FROM %s WHERE _cdc_deleted = true`, quoteStressIdentifier(table))).Scan(&deleted)
-				})
+				err := duckDB.QueryRowContext(ctx,
+					fmt.Sprintf(`SELECT count(*) FROM %s WHERE _cdc_deleted = true`, quoteStressIdentifier(table))).Scan(&deleted)
 				return deleted, err
 			},
 		},
@@ -611,77 +644,15 @@ func TestPostgresCDC_StressComplexWorkload(t *testing.T) {
 		stressDumpContainerLogs(t, ctx, sourceContainer, 120)
 	}
 
-	deadline := time.Now().Add(stressConvergeTimeout)
-	lastProgressLog := time.Now()
-	for {
-		select {
-		case exit := <-streamExits:
-			if restartStreamIfRequired(exit) {
-				continue
-			}
-			dumpDiagnostics()
-			t.Fatalf("%s stream exited during convergence: %v", exit.sink.name, exit.err)
-		default:
-		}
-		pending := ""
-		for _, destination := range destinations {
-			for _, tbl := range finalTables {
-				got, err := destination.aggregate(tbl.name)
-				if err != nil || got != truths[tbl.name] {
-					pending = fmt.Sprintf("%s/%s: want %+v, got %+v (err=%v)", destination.name, tbl.name, truths[tbl.name], got, err)
-					break
-				}
-			}
-			if pending != "" {
-				break
-			}
-		}
-		if pending == "" {
-			break
-		}
-		if time.Since(lastProgressLog) > 20*time.Second {
-			lastProgressLog = time.Now()
-			t.Logf("convergence pending: %s", pending)
-		}
-		if time.Now().After(deadline) {
-			dumpDiagnostics()
-			t.Fatalf("destination did not converge within %v; still pending: %s", stressConvergeTimeout, pending)
-		}
-		time.Sleep(2 * time.Second)
-	}
-	t.Log("PostgreSQL and DuckDB destinations converged on count/sum aggregates for all tables")
-	for _, sink := range streamSinks {
-		require.Positive(t, sink.restarts, "%s workload should exercise the safe restart boundary", sink.name)
-	}
-
-	cancelStream()
-	stopped := make(map[string]struct{}, len(streamSinks))
-	deadline = time.Now().Add(60 * time.Second)
-	for len(stopped) < len(streamSinks) {
-		select {
-		case exit := <-streamExits:
-			if exit.err != nil {
-				require.ErrorIs(t, exit.err, context.Canceled, "%s stream shutdown", exit.sink.name)
-			}
-			stopped[exit.sink.name] = struct{}{}
-		case <-time.After(time.Until(deadline)):
-			t.Fatal("streaming pipelines did not exit within 60s of cancellation")
-		}
-	}
-	duckDB = openCDCStressDuckDB(t, duckDBPath)
-
-	// Aggregates can match while a final merge is still landing payload
-	// updates, so retry the deep comparison briefly before declaring failure.
 	for _, destination := range destinations {
-		var compareErr error
-		for attempt := 1; attempt <= 6; attempt++ {
-			if compareErr = destination.compareAll(); compareErr == nil {
-				break
+		for _, tbl := range finalTables {
+			got, err := destination.aggregate(tbl.name)
+			if err != nil || got != truths[tbl.name] {
+				dumpDiagnostics()
+				t.Fatalf("%s/%s: want %+v, got %+v (err=%v)", destination.name, tbl.name, truths[tbl.name], got, err)
 			}
-			t.Logf("%s deep comparison attempt %d: %v", destination.name, attempt, compareErr)
-			time.Sleep(5 * time.Second)
 		}
-		require.NoError(t, compareErr, "%s row-by-row content comparison failed", destination.name)
+		require.NoError(t, destination.compareAll(), "%s row-by-row content comparison failed", destination.name)
 		t.Logf("%s row-by-row content comparison passed for all tables", destination.name)
 		require.NoError(t, destination.validate(), "%s destination schema validation failed", destination.name)
 		require.NoError(t, destination.validateState(), "%s destination CDC state validation failed", destination.name)

--- a/tests/integration/postgres_cdc_stress_test.go
+++ b/tests/integration/postgres_cdc_stress_test.go
@@ -523,11 +523,9 @@ func TestPostgresCDC_StressComplexWorkload(t *testing.T) {
 		truths[tbl.name] = tr
 		t.Logf("source truth %s: count=%d sum=%s", tbl.name, tr.count, tr.sum)
 	}
-	// Independent DuckDB instances do not share the writer's buffer pool, even
-	// when opened read-only. Wait for durable WAL acknowledgements and close
-	// both writers before opening the file for verification.
-	// Use the insert position to include commits with synchronous_commit=off.
+	// Wait for durable WAL acknowledgement before opening an independent DuckDB reader.
 	var finalLSN string
+	// Include commits made with synchronous_commit=off that are not yet written to WAL.
 	require.NoError(t, srcPool.QueryRow(ctx, `SELECT pg_current_wal_insert_lsn()::text`).Scan(&finalLSN))
 	deadline := time.Now().Add(stressConvergeTimeout)
 	lastProgressLog := time.Now()


### PR DESCRIPTION
## What

Fix real PostgreSQL CDC row loss exposed by the intermittently failing complex stress test in #1173.

A primary-key update after a column drop can raise `SchemaChangedError` while materializing accumulated changes. The old flush stopped at that table, and rebuilding discarded other tables' remaining batches even though their LSNs were already marked processed. Replay then filtered out those rows. Go map iteration order made the affected table and occurrence random.

## Changes

- Flush unaffected tables before a multi-table schema rebuild and collect all schema failures for replacement snapshots.
- Retain failed tables' buffered changes and low-water marks during the flush so unaffected batches cannot acknowledge their WAL prematurely.
- Add deterministic coverage for retained low-water marks, multiple schema failures, and preservation of unaffected rows.
- Replace independent live DuckDB file reads in the PostgreSQL stress test with a durable WAL acknowledgement wait, writer shutdown, and exact post-shutdown validation. Use the WAL insert position because the test disables synchronous commit.

The monitoring-only hypothesis was ruled out: the test still reproduced missing rows after both writers closed, before the production fix.

## How to test

1. `make format && make lint && make test` — passed.
2. `go test -race ./pkg/source/postgres_cdc` — passed.
3. PostgreSQL TOAST integration tests (`TestPostgresCDCToastAcrossBatches`, `TestPostgresCDCToastKeyMove`) — all six subcases passed.
4. `TESTCONTAINERS_RYUK_DISABLED=true INGESTR_DISABLE_TELEMETRY=true DISABLE_TELEMETRY=true go test -tags stress -count=2 -v -timeout 15m -run '^TestPostgresCDC_StressComplexWorkload$' ./tests/integration/` — PASS, 389.180s. Four full-size stress runs passed in total, each with 180,000 attempted operations, zero dropped operations/errors, and exact PostgreSQL/DuckDB contents, schemas, state, and tombstone checks.
5. Stress-tagged fast linters — zero issues.

An intervening local stress run was invalidated by disk exhaustion while the integration harness downloaded shared database images. Temporary fixtures were removed, and the isolated two-run command above passed. The full integration suite was not run locally.

## Risk & rollback
- **Risk:** Medium: changes multi-table PostgreSQL CDC rebuild handling. Failed-table WAL remains unacknowledged until replacement data is delivered; unrelated buffered tables are flushed rather than discarded. No destination implementation or dependencies changed.
- **Rollback:** Revert the merge commit. Reverting does not repair data already lost by the previous behavior; affected destinations may need a full refresh.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Full integration suite passes (awaiting CI; targeted integration tests passed locally)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered

## Related issues

Original failing job: https://github.com/bruin-data/ingestr/actions/runs/34244808373/job/102123951059?pr=1173
