### PR TITLE
Resume keyed CDC from the last complete generation after a killed run

### DIFF
--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -350,21 +350,6 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 			p.config.CDCResumeIncarnation = sourceIncarnation
 			p.config.CDCResumeSchemaFingerprint = sourceSchemaFingerprint
 			config.Debug("[PIPELINE] Found destination-managed CDC state, resuming from: %s", resumeLSN)
-		} else {
-			// Once any state exists, replacement snapshots are authorized: this
-			// connector already owns the target. With no state at all, a target
-			// that contains CDC data belongs to an unmanaged (pre-state) run or
-			// to a lost state table, so fail closed.
-			stateEmpty, err := cdcStateManager.StateEmpty(ctx)
-			if err != nil {
-				return err
-			}
-			if stateEmpty {
-				if err := rejectUnprovenLegacyCDCTarget(ctx, dest, p.config.SourceTable, p.config.DestTable); err != nil {
-					return err
-				}
-			}
-			config.Debug("[PIPELINE] No completed CDC snapshot state found, will perform full snapshot")
 		}
 	} else if isManagedChangeSource(p.config.SourceURI) && !p.config.FullRefresh {
 		resumeProvider, ok := dest.(destination.CDCResumeProvider)
@@ -432,6 +417,26 @@ func (p *Pipeline) Run(ctx context.Context) (retErr error) {
 
 	if shouldWarnCDCStrategy(p.config, preFetchStrategy) {
 		output.Warnf("Warning: change data source is using %q strategy instead of %q; delete and update operations may not be properly reflected in the destination\n", preFetchStrategy, config.StrategyMerge)
+	}
+	if cdcStateManager != nil && !p.config.FullRefresh && p.config.CDCResumeLSN == "" {
+		if preFetchStrategy == config.StrategyMerge && len(preFetchConfig.PrimaryKeys) > 0 {
+			resumeLSN, err := cdcStateManager.ResumePositionForKeyedMerge(ctx, p.config.SourceTable)
+			if err != nil {
+				return err
+			}
+			if resumeLSN != "" {
+				p.config.CDCResumeLSN = resumeLSN
+				p.config.CDCResumeIncarnation = sourceIncarnation
+				p.config.CDCResumeSchemaFingerprint = sourceSchemaFingerprint
+				config.Debug("[PIPELINE] Found previous completed CDC state, resuming keyed merge from: %s", resumeLSN)
+			}
+		}
+		if p.config.CDCResumeLSN == "" {
+			if err := rejectUnprovenLegacyCDCTarget(ctx, dest, p.config.SourceTable, p.config.DestTable); err != nil {
+				return err
+			}
+			config.Debug("[PIPELINE] No completed CDC snapshot state found, will perform full snapshot")
+		}
 	}
 
 	tracker, err := p.createTracker(ctx)
@@ -1556,12 +1561,14 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 	var cdcResumeLSNs map[string]string
 	if cdcStateManager != nil && !p.config.FullRefresh {
 		cdcResumeLSNs = make(map[string]string)
-		stateEmpty, err := cdcStateManager.StateEmpty(ctx)
-		if err != nil {
-			return err
-		}
 		for _, table := range tables {
-			resumeLSN, err := cdcStateManager.ResumePosition(ctx, table.Name)
+			var resumeLSN string
+			var err error
+			if resolvedStrategy == config.StrategyMerge && len(table.PrimaryKeys) > 0 {
+				resumeLSN, err = cdcStateManager.ResumePositionForKeyedMerge(ctx, table.Name)
+			} else {
+				resumeLSN, err = cdcStateManager.ResumePosition(ctx, table.Name)
+			}
 			if err != nil {
 				return err
 			}
@@ -1569,10 +1576,8 @@ func (p *Pipeline) runMultiTable(ctx context.Context, src source.MultiTableSourc
 				cdcResumeLSNs[table.Name] = resumeLSN
 				config.Debug("[PIPELINE] Found destination-managed CDC state for %s: %s", table.Name, resumeLSN)
 			} else {
-				if stateEmpty {
-					if err := rejectUnprovenLegacyCDCTarget(ctx, p.dest, table.Name, tableDestNames[table.Name]); err != nil {
-						return err
-					}
+				if err := rejectUnprovenLegacyCDCTarget(ctx, p.dest, table.Name, tableDestNames[table.Name]); err != nil {
+					return err
 				}
 				config.Debug("[PIPELINE] No completed CDC snapshot state for %s, will snapshot", table.Name)
 			}

--- a/pkg/strategy/cdc_state.go
+++ b/pkg/strategy/cdc_state.go
@@ -758,6 +758,16 @@ func (m *CDCStateManager) RegisterTableForReadState(sourceTable, destTable, inca
 // ResumePosition requires a complete marker for the latest generation of the
 // source table. The later complete connector checkpoint is then safe to use.
 func (m *CDCStateManager) ResumePosition(ctx context.Context, sourceTable string) (string, error) {
+	return m.resumePosition(ctx, sourceTable, false)
+}
+
+// ResumePositionForKeyedMerge may resume the last completed generation when
+// the latest run was interrupted before it persisted a checkpoint.
+func (m *CDCStateManager) ResumePositionForKeyedMerge(ctx context.Context, sourceTable string) (string, error) {
+	return m.resumePosition(ctx, sourceTable, true)
+}
+
+func (m *CDCStateManager) resumePosition(ctx context.Context, sourceTable string, allowPreviousComplete bool) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -768,55 +778,100 @@ func (m *CDCStateManager) ResumePosition(ctx context.Context, sourceTable string
 		return "", err
 	}
 
-	if len(m.runs) != 1 {
+	if len(m.runs) == 1 {
+		if position, complete, err := m.resumePositionFromGeneration(ctx, sourceTable, m.runs, m.states); err != nil || complete {
+			return position, err
+		}
+	}
+
+	if !allowPreviousComplete || len(m.runs) != 1 {
 		return "", nil
 	}
 	runID := onlyCDCStateRun(m.runs)
-	snapshot := m.states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindSnapshot}]
-	if !snapshot.complete {
+	latestSnapshot, exists := m.states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindSnapshot}]
+	if !exists || latestSnapshot.complete || latestSnapshot.snapshotEpoch > 0 {
 		return "", nil
+	}
+
+	for _, generation := range m.generationsDescending() {
+		if generation >= m.generation {
+			continue
+		}
+		runs, states := m.reduceGeneration(generation)
+		if len(runs) != 1 {
+			return "", nil
+		}
+		runID := onlyCDCStateRun(runs)
+		snapshot, exists := states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindSnapshot}]
+		if !exists {
+			return "", nil
+		}
+		position, complete, err := m.resumePositionFromGeneration(ctx, sourceTable, runs, states)
+		if err != nil {
+			return "", err
+		}
+		if complete {
+			return position, nil
+		}
+		if snapshot.complete || snapshot.snapshotEpoch > 0 {
+			return "", nil
+		}
+	}
+	return "", nil
+}
+
+func (m *CDCStateManager) resumePositionFromGeneration(
+	ctx context.Context,
+	sourceTable string,
+	runs map[string]struct{},
+	states map[cdcStateKey]reducedCDCState,
+) (string, bool, error) {
+	runID := onlyCDCStateRun(runs)
+	snapshot := states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindSnapshot}]
+	if !snapshot.complete {
+		return "", false, nil
 	}
 	if snapshot.destTable != m.destTables[sourceTable] {
-		return "", fmt.Errorf("CDC state ID %q maps source table %q to destination %q, not %q", m.connectorID, sourceTable, snapshot.destTable, m.destTables[sourceTable])
+		return "", false, fmt.Errorf("CDC state ID %q maps source table %q to destination %q, not %q", m.connectorID, sourceTable, snapshot.destTable, m.destTables[sourceTable])
 	}
 	if current := m.currentIncarnations[sourceTable]; current != "" && snapshot.incarnation != current {
-		return "", nil
+		return "", false, nil
 	}
 	if current := compactSchemaFingerprint(m.currentSchemas[sourceTable]); current != "" && snapshot.schemaFingerprint != current {
-		return "", nil
+		return "", false, nil
 	}
 	if m.incarnation == nil {
-		return "", nil
+		return "", false, nil
 	}
-	destinationState := m.states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindDestination}]
+	destinationState := states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindDestination}]
 	if !destinationState.complete || destinationState.destTable != m.destTables[sourceTable] ||
 		destinationState.snapshotEpoch != snapshot.snapshotEpoch || compareCDCPositions(destinationState.position, snapshot.position) != 0 {
-		return "", nil
+		return "", false, nil
 	}
 	currentDestination, exists, err := m.currentDestinationIncarnation(ctx, sourceTable)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	if !exists || currentDestination != destinationState.incarnation {
-		return "", nil
+		return "", false, nil
 	}
 	destSchema, err := m.dest.GetTableSchema(ctx, m.destTables[sourceTable])
 	if err != nil {
-		return "", fmt.Errorf("failed to verify CDC destination table %q: %w", m.destTables[sourceTable], err)
+		return "", false, fmt.Errorf("failed to verify CDC destination table %q: %w", m.destTables[sourceTable], err)
 	}
 	if destSchema == nil {
-		return "", nil
+		return "", false, nil
 	}
 	m.knownComplete[sourceTable] = snapshot.position
 	m.knownIncarnations[sourceTable] = snapshot.incarnation
 	m.knownSchemas[sourceTable] = snapshot.schemaFingerprint
 	m.knownDestinations[sourceTable] = destinationState.incarnation
 
-	checkpoint := m.states[cdcStateKey{runID: runID, kind: cdcStateKindCheckpoint}]
+	checkpoint := states[cdcStateKey{runID: runID, kind: cdcStateKindCheckpoint}]
 	if checkpoint.complete && compareCDCPositions(checkpoint.position, snapshot.position) > 0 {
-		return checkpoint.position, nil
+		return checkpoint.position, true, nil
 	}
-	return snapshot.position, nil
+	return snapshot.position, true, nil
 }
 
 func (m *CDCStateManager) currentDestinationIncarnation(ctx context.Context, sourceTable string) (string, bool, error) {
@@ -848,8 +903,8 @@ func (m *CDCStateManager) StateEmpty(ctx context.Context) (bool, error) {
 }
 
 // BeginRun appends an in-progress marker for every registered source table at
-// a new connector generation. A crash leaves that generation incomplete, so
-// older completed rows cannot make a partial target resumable.
+// a new connector generation. The previous completed generation is retained
+// so keyed merges can replay safely after a crash.
 func (m *CDCStateManager) BeginRun(ctx context.Context, fullRefresh bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1155,6 +1210,47 @@ func (m *CDCStateManager) load(ctx context.Context) error {
 	return nil
 }
 
+func (m *CDCStateManager) generationsDescending() []int64 {
+	seen := make(map[int64]struct{})
+	for _, entry := range m.entries {
+		seen[entry.Generation] = struct{}{}
+	}
+	generations := make([]int64, 0, len(seen))
+	for generation := range seen {
+		generations = append(generations, generation)
+	}
+	sort.Slice(generations, func(i, j int) bool {
+		return generations[i] > generations[j]
+	})
+	return generations
+}
+
+func (m *CDCStateManager) reduceGeneration(generation int64) (map[string]struct{}, map[cdcStateKey]reducedCDCState) {
+	runs := make(map[string]struct{})
+	states := make(map[cdcStateKey]reducedCDCState)
+	for _, entry := range m.entries {
+		if entry.Generation != generation {
+			continue
+		}
+		runID, ok := cdcStateRunID(entry.EventID, m.connectorID)
+		if !ok {
+			continue
+		}
+		runs[runID] = struct{}{}
+		key := cdcStateKey{runID: runID, sourceTable: entry.SourceTable, kind: entry.StateKind}
+		state := states[key]
+		if entry.Generation > state.generation {
+			state = reducedCDCState{generation: entry.Generation}
+		}
+		position, incarnation, epoch, valid := decodeCDCStateEntry(entry)
+		if valid {
+			state = reduceCDCStateEntry(state, entry, position, incarnation, epoch)
+		}
+		states[key] = state
+	}
+	return runs, states
+}
+
 func newCDCStateRunID() (string, error) {
 	raw := make([]byte, 16)
 	if _, err := rand.Read(raw); err != nil {
@@ -1445,9 +1541,13 @@ func (m *CDCStateManager) supersededEventIDs() []string {
 		return nil
 	}
 
+	retainedGenerations := m.previousCompleteGenerations()
 	keep := make(map[cdcStateKey]destination.CDCStateEntry)
 	for _, entry := range m.entries {
 		if !cdcStateEntryPositionValid(entry) {
+			continue
+		}
+		if _, retained := retainedGenerations[entry.Generation]; retained {
 			continue
 		}
 		runID, ok := cdcStateRunID(entry.EventID, m.connectorID)
@@ -1467,11 +1567,71 @@ func (m *CDCStateManager) supersededEventIDs() []string {
 	}
 	stale := make([]string, 0, len(m.entries)-len(keepIDs))
 	for _, entry := range m.entries {
+		if _, retained := retainedGenerations[entry.Generation]; retained {
+			continue
+		}
 		if _, ok := keepIDs[entry.EventID]; !ok && entry.EventID != "" && cdcStateEntryPositionValid(entry) {
 			stale = append(stale, entry.EventID)
 		}
 	}
 	return stale
+}
+
+func (m *CDCStateManager) previousCompleteGenerations() map[int64]struct{} {
+	retained := make(map[int64]struct{})
+	if m.generationComplete(m.runs, m.states) {
+		return retained
+	}
+	remaining := make(map[string]string, len(m.destTables))
+	for sourceTable, destTable := range m.destTables {
+		remaining[sourceTable] = destTable
+	}
+	for _, generation := range m.generationsDescending() {
+		if generation >= m.generation {
+			continue
+		}
+		runs, states := m.reduceGeneration(generation)
+		if len(runs) != 1 {
+			continue
+		}
+		runID := onlyCDCStateRun(runs)
+		for sourceTable, destTable := range remaining {
+			snapshot := states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindSnapshot}]
+			destinationState := states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindDestination}]
+			if snapshot.complete && destinationState.complete &&
+				snapshot.destTable == destTable && destinationState.destTable == destTable &&
+				snapshot.snapshotEpoch == destinationState.snapshotEpoch &&
+				compareCDCPositions(snapshot.position, destinationState.position) == 0 {
+				retained[generation] = struct{}{}
+				delete(remaining, sourceTable)
+			}
+		}
+		if len(remaining) == 0 {
+			break
+		}
+	}
+	return retained
+}
+
+func (m *CDCStateManager) generationComplete(
+	runs map[string]struct{},
+	states map[cdcStateKey]reducedCDCState,
+) bool {
+	if len(runs) != 1 || len(m.destTables) == 0 {
+		return false
+	}
+	runID := onlyCDCStateRun(runs)
+	for sourceTable, destTable := range m.destTables {
+		snapshot := states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindSnapshot}]
+		destinationState := states[cdcStateKey{runID: runID, sourceTable: sourceTable, kind: cdcStateKindDestination}]
+		if !snapshot.complete || !destinationState.complete ||
+			snapshot.destTable != destTable || destinationState.destTable != destTable ||
+			snapshot.snapshotEpoch != destinationState.snapshotEpoch ||
+			compareCDCPositions(snapshot.position, destinationState.position) != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func preferCDCStateEntry(candidate, current destination.CDCStateEntry) bool {

--- a/pkg/strategy/cdc_state_test.go
+++ b/pkg/strategy/cdc_state_test.go
@@ -930,6 +930,13 @@ func TestCDCStateDroppedTableCannotReuseOlderGeneration(t *testing.T) {
 	if position != "" {
 		t.Fatalf("recreated table resumed from stale state at %s", position)
 	}
+	position, err = recreated.ResumePositionForKeyedMerge(ctx, "public.orders")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if position != "" {
+		t.Fatalf("recreated keyed table resumed from stale state at %s", position)
+	}
 }
 
 func TestCDCStateLeaseLossDuringPersistSkipsPruneAndReturnsFenceError(t *testing.T) {
@@ -1155,6 +1162,169 @@ func TestCDCStateIncompleteRunMarksStateNonEmpty(t *testing.T) {
 	if stateEmpty {
 		t.Fatal("incomplete run classified the connector state as empty")
 	}
+}
+
+func TestCDCStateKeyedMergeResumesPreviousCompleteGeneration(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	const connectorID = "keyed-crash-resume"
+
+	first, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTable(ctx, "public.orders", "raw.orders"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	require.NoError(t, first.Persist(ctx, source.CDCStateCommitToken{
+		Position:          "00000000/00000020",
+		SnapshotPositions: map[string]string{"public.orders": "00000000/00000010"},
+	}))
+
+	killed, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, killed.RegisterTable(ctx, "public.orders", "raw.orders"))
+	require.Equal(t, "00000000/00000020", mustResumePosition(t, killed, "public.orders"))
+	require.NoError(t, killed.BeginRun(ctx, false))
+
+	restarted, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTable(ctx, "public.orders", "raw.orders"))
+	require.Empty(t, mustResumePosition(t, restarted, "public.orders"))
+	position, err := restarted.ResumePositionForKeyedMerge(ctx, "public.orders")
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000020", position)
+}
+
+func TestCDCStateKeylessMergeDoesNotResumePreviousCompleteGeneration(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	const connectorID = "keyless-crash-resume"
+
+	first, err := NewCDCStateManager(dest, connectorID, "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTable(ctx, "public.events", "raw.events"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	require.NoError(t, first.Persist(ctx, source.CDCStateCommitToken{
+		Position:          "00000000/00000020",
+		SnapshotPositions: map[string]string{"public.events": "00000000/00000010"},
+	}))
+
+	killed, err := NewCDCStateManager(dest, connectorID, "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, killed.RegisterTable(ctx, "public.events", "raw.events"))
+	require.Equal(t, "00000000/00000020", mustResumePosition(t, killed, "public.events"))
+	require.NoError(t, killed.BeginRun(ctx, false))
+
+	restarted, err := NewCDCStateManager(dest, connectorID, "raw.events", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTable(ctx, "public.events", "raw.events"))
+	require.Empty(t, mustResumePosition(t, restarted, "public.events"))
+}
+
+func TestCDCStateSnapshotInvalidationBlocksPreviousCompleteGeneration(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	const connectorID = "invalidated-crash-resume"
+
+	first, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTable(ctx, "public.orders", "raw.orders"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	require.NoError(t, first.Persist(ctx, source.CDCStateCommitToken{
+		Position:          "00000000/00000020",
+		SnapshotPositions: map[string]string{"public.orders": "00000000/00000010"},
+	}))
+
+	killed, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, killed.RegisterTable(ctx, "public.orders", "raw.orders"))
+	require.Equal(t, "00000000/00000020", mustResumePosition(t, killed, "public.orders"))
+	require.NoError(t, killed.BeginRun(ctx, false))
+	require.NoError(t, killed.InvalidateSnapshot(ctx, "public.orders", "raw.orders", ""))
+
+	restarted, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTable(ctx, "public.orders", "raw.orders"))
+	position, err := restarted.ResumePositionForKeyedMerge(ctx, "public.orders")
+	require.NoError(t, err)
+	require.Empty(t, position)
+}
+
+func TestCDCStateDestinationReplacementBlocksPreviousCompleteGeneration(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	const connectorID = "replaced-destination-crash-resume"
+
+	first, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, first.RegisterTable(ctx, "public.orders", "raw.orders"))
+	require.NoError(t, first.BeginRun(ctx, false))
+	require.NoError(t, first.Persist(ctx, source.CDCStateCommitToken{
+		Position:          "00000000/00000020",
+		SnapshotPositions: map[string]string{"public.orders": "00000000/00000010"},
+	}))
+
+	killed, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, killed.RegisterTable(ctx, "public.orders", "raw.orders"))
+	require.Equal(t, "00000000/00000020", mustResumePosition(t, killed, "public.orders"))
+	require.NoError(t, killed.BeginRun(ctx, false))
+	dest.incarnations["raw.orders"] = "replacement"
+
+	restarted, err := NewCDCStateManager(dest, connectorID, "raw.orders", "")
+	require.NoError(t, err)
+	require.NoError(t, restarted.RegisterTable(ctx, "public.orders", "raw.orders"))
+	position, err := restarted.ResumePositionForKeyedMerge(ctx, "public.orders")
+	require.NoError(t, err)
+	require.Empty(t, position)
+}
+
+func TestCDCStateBeginRunRetainsPreviousCompleteGenerationUntilPersist(t *testing.T) {
+	ctx := t.Context()
+	dest := newCDCStateDestination()
+	const connectorID = "prune-crash-resume"
+	const tableCount = cdcStatePruneThreshold
+
+	first, err := NewCDCStateManager(dest, connectorID, "", "")
+	require.NoError(t, err)
+	snapshots := make(map[string]string, tableCount)
+	for i := range tableCount {
+		sourceTable := fmt.Sprintf("public.table_%03d", i)
+		destTable := fmt.Sprintf("raw.table_%03d", i)
+		require.NoError(t, first.RegisterTable(ctx, sourceTable, destTable))
+		snapshots[sourceTable] = "00000000/00000010"
+	}
+	require.NoError(t, first.BeginRun(ctx, false))
+	require.NoError(t, first.Persist(ctx, source.CDCStateCommitToken{
+		Position:          "00000000/00000020",
+		SnapshotPositions: snapshots,
+	}))
+
+	killed, err := NewCDCStateManager(dest, connectorID, "", "")
+	require.NoError(t, err)
+	for i := range tableCount {
+		sourceTable := fmt.Sprintf("public.table_%03d", i)
+		destTable := fmt.Sprintf("raw.table_%03d", i)
+		require.NoError(t, killed.RegisterTable(ctx, sourceTable, destTable))
+		require.Equal(t, "00000000/00000020", mustResumePosition(t, killed, sourceTable))
+	}
+	require.NoError(t, killed.BeginRun(ctx, false))
+
+	restarted, err := NewCDCStateManager(dest, connectorID, "", "")
+	require.NoError(t, err)
+	for i := range tableCount {
+		sourceTable := fmt.Sprintf("public.table_%03d", i)
+		destTable := fmt.Sprintf("raw.table_%03d", i)
+		require.NoError(t, restarted.RegisterTable(ctx, sourceTable, destTable))
+	}
+	position, err := restarted.ResumePositionForKeyedMerge(ctx, "public.table_000")
+	require.NoError(t, err)
+	require.Equal(t, "00000000/00000020", position)
+}
+
+func mustResumePosition(t *testing.T, manager *CDCStateManager, sourceTable string) string {
+	t.Helper()
+	position, err := manager.ResumePosition(t.Context(), sourceTable)
+	require.NoError(t, err)
+	return position
 }
 
 func TestCDCStateConcurrentRunsCannotCertifySibling(t *testing.T) {


### PR DESCRIPTION
## What
Destination-managed CDC no longer snapshots the whole publication after a process is killed between `BeginRun` and `Persist`. Keyed merge resumes from the last completed generation (WAL replay is idempotent). If there is no safe resume and the destination already has CDC data, the job fails closed and asks for `--full-refresh` instead of dropping the replication slot.

## Changes
- `pkg/strategy/cdc_state.go`: `ResumePositionForKeyedMerge` falls back to the newest complete generation when the latest is incomplete; prune keeps that generation until `Persist` succeeds.
- `pkg/pipeline/pipeline.go`: keyed merge uses the fallback; empty resume + dest CDC data always fail closed (not only when the state table is empty).
- `pkg/strategy/cdc_state_test.go`: crash, keyless, snapshot invalidation, dest replacement, dropped table, and prune-retention cases.

## How to test
1. `make format && make lint && make test`
2. Review the new tests in `pkg/strategy/cdc_state_test.go`.

## Risk & rollback
- **Risk:** medium — resume/fail-closed behaviour changes for destination-managed CDC after incomplete runs; keyless and epoch/incarnation mismatches still do not resume.
- **Rollback:** Revert the merge commit.

## Checklist
- [x] Unit tests added or updated (`make test`)
- [x] Format and lint pass (`make format`, `make lint`)
- [ ] Integration tests pass if affected (`make test-integration`)
- [x] No unrelated changes included
- [x] Tested locally

## Security
- [x] No secrets, credentials, or PII in this change
- [x] No new dependencies with known vulnerabilities
- [x] Security implications considered (if applicable)

## Related issues