### PR TITLE
feat: optionally verify installer release archive SHA-256

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,9 +8,11 @@ usage() {
   cat <<EOF
 $this: download go binaries for bruin-data/ingestr
 
-Usage: $this [-b] bindir [-d] [tag]
+Usage: $this [-b bindir] [-d] [-s sha256] [tag]
   -b sets bindir or installation directory, Defaults to ./bin
   -d turns on debug logging
+  -s verifies the downloaded release archive against a trusted SHA-256
+     (64 hexadecimal characters); requires an exact vMAJOR.MINOR.PATCH tag
    [tag] is a tag from
    https://github.com/bruin-data/ingestr/releases
    If tag is missing, then the latest will be used.
@@ -27,16 +29,44 @@ parse_args() {
   # over-ridden by flag below
 
   BINDIR=${BINDIR:-~/.local/bin}
-  while getopts "b:dh?x" arg; do
+  EXPECTED_SHA256=""
+  while getopts "b:ds:h?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
       d) log_set_priority 10 ;;
+      s)
+        if ! valid_sha256 "$OPTARG"; then
+          log_crit "-s requires exactly 64 hexadecimal characters"
+          exit 1
+        fi
+        EXPECTED_SHA256=$(printf '%s' "$OPTARG" | tr 'A-F' 'a-f')
+        ;;
       h | \?) usage "$0" ;;
       x) set -x ;;
     esac
   done
   shift $((OPTIND - 1))
   TAG=$1
+  if [ -n "$EXPECTED_SHA256" ]; then
+    case "$TAG" in
+      *[!v0123456789.]*)
+        log_crit "-s requires an exact vMAJOR.MINOR.PATCH tag"
+        exit 1
+        ;;
+    esac
+    if [ "$#" -ne 1 ] || ! printf '%s\n' "$TAG" | LC_ALL=C grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+      log_crit "-s requires one exact version tag (vMAJOR.MINOR.PATCH); latest is not allowed"
+      exit 1
+    fi
+  fi
+}
+
+cleanup_verified_install() {
+  if [ -n "$_install_pid" ]; then
+    kill "$_install_pid" 2>/dev/null || :
+    wait "$_install_pid" 2>/dev/null || :
+  fi
+  rm -rf "${tmpdir}"
 }
 
 # this function wraps all the destructive operations
@@ -45,6 +75,11 @@ parse_args() {
 # out preventing half-done work
 execute() {
   tmpdir=$(mktemp -d)
+  if [ -n "$EXPECTED_SHA256" ]; then
+    _install_pid=""
+    trap cleanup_verified_install 0
+    trap 'exit 1' HUP INT TERM
+  fi
   log_debug "downloading files into ${tmpdir}"
 
   _use_fancy=false
@@ -71,6 +106,7 @@ execute() {
 
     (
       http_download "${_download_file}" "${TARBALL_URL}" > /dev/null 2>&1 || exit 1
+      verify_expected_sha256 "${_download_file}" || exit 1
       echo "extract" > "$_progress_file"
       (cd "${tmpdir}" && untar "${TARBALL}") > /dev/null 2>&1 || exit 1
       echo "install" > "$_progress_file"
@@ -84,8 +120,9 @@ execute() {
     ) &
     _install_pid=$!
     _download_progress "$_install_pid" "$_download_file" "$_total_size" "$_progress_file"
-    wait "$_install_pid"
-    _install_exit=$?
+    _install_exit=0
+    wait "$_install_pid" || _install_exit=$?
+    _install_pid=""
 
     rm -rf "${tmpdir}"
 
@@ -103,6 +140,7 @@ execute() {
     # Non-interactive or Windows: run synchronously with plain output
     log_info "downloading ingestr ${VERSION}..."
     http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+    verify_expected_sha256 "${tmpdir}/${TARBALL}"
     srcdir="${tmpdir}"
     (cd "${tmpdir}" && untar "${TARBALL}")
     if [ ! -d "${BINDIR}" ]; then install -d "${BINDIR}"; fi
@@ -123,6 +161,10 @@ execute() {
       return 1
     fi
     log_info "ingestr ${VERSION} installed to ${BINDIR}"
+  fi
+
+  if [ -n "$EXPECTED_SHA256" ]; then
+    trap - 0 HUP INT TERM
   fi
 
   # Configure PATH
@@ -199,6 +241,10 @@ get_binaries() {
   esac
 }
 tag_to_version() {
+  if [ -n "$EXPECTED_SHA256" ]; then
+    VERSION=${TAG#v}
+    return 0
+  fi
   if [ -z "${TAG}" ]; then
     log_info "checking GitHub for latest tag"
   else
@@ -495,6 +541,14 @@ http_download_curl() {
   local_file=$1
   source_url=$2
   header=$3
+  if [ -n "$EXPECTED_SHA256" ]; then
+    if [ -z "$header" ]; then
+      curl -fsSL -o "$local_file" "$source_url" || return 1
+    else
+      curl -fsSL -H "$header" -o "$local_file" "$source_url" || return 1
+    fi
+    return 0
+  fi
   if [ -z "$header" ]; then
     log_debug "Executing: curl  -sL -o \"$local_file\" \"$source_url\""
     code=$(curl  -sL -o "$local_file" "$source_url")
@@ -564,10 +618,32 @@ hash_sha256() {
     hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
     echo "$hash" | cut -d ' ' -f 1
   elif is_command openssl; then
-    hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
-    echo "$hash" | cut -d ' ' -f a
+    hash=$(openssl dgst -sha256 "$TARGET") || return 1
+    printf '%s\n' "$hash" | sed 's/^.*= //'
   else
     log_crit "hash_sha256 unable to find command to compute sha-256 hash"
+    return 1
+  fi
+}
+valid_sha256() {
+  [ "${#1}" -eq 64 ] || return 1
+  case "$1" in
+    *[!0123456789abcdefABCDEF]*) return 1 ;;
+  esac
+}
+verify_expected_sha256() {
+  [ -n "$EXPECTED_SHA256" ] || return 0
+  if ! actual_sha256=$(hash_sha256 "$1"); then
+    log_crit "unable to compute release archive SHA-256"
+    return 1
+  fi
+  if ! valid_sha256 "$actual_sha256"; then
+    log_crit "invalid output from SHA-256 tool"
+    return 1
+  fi
+  actual_sha256=$(printf '%s' "$actual_sha256" | tr 'A-F' 'a-f') || return 1
+  if [ "$actual_sha256" != "$EXPECTED_SHA256" ]; then
+    log_crit "release archive SHA-256 mismatch"
     return 1
   fi
 }
@@ -640,8 +716,5 @@ TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
 log_debug "Starting the download of ${TARBALL_URL}"
 
 execute
-
-
-
 
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,8 @@ Usage: $this [-b bindir] [-d] [-s sha256] [tag]
   -d turns on debug logging
   -s verifies the downloaded release archive against a trusted SHA-256
      (64 hexadecimal characters); requires an exact vMAJOR.MINOR.PATCH tag
+     Cancellation waits for the current command, without a fixed timeout.
+     A verified install already underway may finish; forced termination can skip cleanup.
    [tag] is a tag from
    https://github.com/bruin-data/ingestr/releases
    If tag is missing, then the latest will be used.
@@ -62,6 +64,7 @@ parse_args() {
 }
 
 cleanup_verified_install() {
+  trap '' HUP INT TERM
   if [ -n "$_install_pid" ]; then
     kill "$_install_pid" 2>/dev/null || :
     wait "$_install_pid" 2>/dev/null || :
@@ -721,4 +724,3 @@ TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
 log_debug "Starting the download of ${TARBALL_URL}"
 
 execute
-

--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,11 @@ execute() {
     log_debug "expected download size: ${_total_size} bytes"
 
     (
+      if [ -n "$EXPECTED_SHA256" ]; then
+        # Defer cancellation until the foreground command exits, so cleanup
+        # cannot orphan a download, extraction, or destination write.
+        trap 'exit 1' HUP INT TERM
+      fi
       http_download "${_download_file}" "${TARBALL_URL}" > /dev/null 2>&1 || exit 1
       verify_expected_sha256 "${_download_file}" || exit 1
       echo "extract" > "$_progress_file"
@@ -716,5 +721,4 @@ TARBALL_URL=${GITHUB_DOWNLOAD}/${TAG}/${TARBALL}
 log_debug "Starting the download of ${TARBALL_URL}"
 
 execute
-
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
+import time
 import unittest
 import zipfile
 
@@ -20,7 +21,7 @@ BINARY = b"#!/bin/sh\necho executed > \"$ROOT/executed\"\n"
 class InstallerTest(unittest.TestCase):
     def run_install(self, *, platform="Linux", tty=False, digest="correct",
                     tags=("v1.2.3",), tool="sha256sum", failure="", downloader="curl",
-                    machine="x86_64"):
+                    machine="x86_64", cancel_install=False):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             tools = root / "tools"
@@ -74,6 +75,14 @@ if [ "$FAILURE" = download ]; then exit 22; fi
             real_extractor = shutil.which(extractor)
             self.assertIsNotNone(real_extractor)
             stub(extractor, f'echo extracted > "$ROOT/extracted"\nexec "{real_extractor}" "$@"')
+            if cancel_install:
+                (tools / "install").unlink()
+                stub("install", f'''
+echo started > "$ROOT/install-started"
+sleep 1
+"{shutil.which('install')}" "$@"
+echo finished > "$ROOT/install-finished"
+''')
             if tool != "missing":
                 if failure == "tool":
                     stub(tool, f'echo "{expected}  archive"; exit 1')
@@ -97,11 +106,26 @@ if [ "$FAILURE" = download ]; then exit 22; fi
                 if tty:
                     master, slave = pty.openpty()
                 with tempfile.TemporaryFile() as output:
-                    result = subprocess.run(
-                        ["/bin/sh", "-s", "--", *args], input=INSTALLER.read_bytes(),
-                        stdout=slave if tty else output, stderr=output,
-                        env=env, timeout=15,
-                    )
+                    with subprocess.Popen(
+                        ["/bin/sh", "-s", "--", *args], stdin=subprocess.PIPE,
+                        stdout=slave if tty else output, stderr=output, env=env,
+                    ) as process:
+                        if cancel_install:
+                            process.stdin.write(INSTALLER.read_bytes())
+                            process.stdin.close()
+                            process.stdin = None
+                            deadline = time.monotonic() + 10
+                            while not (root / "install-started").exists():
+                                if process.poll() is not None or time.monotonic() > deadline:
+                                    self.fail("installer did not reach destination write")
+                                time.sleep(0.01)
+                            process.terminate()
+                            process.communicate(timeout=15)
+                            self.assertTrue((root / "install-finished").exists(),
+                                            "installer exited before its child finished writing")
+                        else:
+                            process.communicate(INSTALLER.read_bytes(), timeout=15)
+                        returncode = process.returncode
                     output.seek(0)
                     diagnostics = output.read().decode(errors="replace")
             finally:
@@ -110,7 +134,7 @@ if [ "$FAILURE" = download ]; then exit 22; fi
                     os.close(master)
             success = digest in ("correct", None) and not failure and tool != "missing"
             success = success and (digest is None or tags == ("v1.2.3",))
-            self.assertEqual(result.returncode == 0, success, diagnostics)
+            self.assertEqual(returncode == 0, success and not cancel_install, diagnostics)
             self.assertEqual((dest / binary).read_bytes(), BINARY if success else b"existing installation")
             self.assertEqual((root / "extracted").exists(), success, diagnostics)
             self.assertFalse((root / "executed").exists())
@@ -152,10 +176,12 @@ if [ "$FAILURE" = download ]; then exit 22; fi
         self.run_install(downloader="wget", failure="download")
 
     def test_other_supported_architectures(self):
-        for platform, machine in (("Linux", "aarch64"), ("Darwin", "aarch64"),
-                                  ("MINGW64_NT", "i686")):
+        for platform, machine in (("Linux", "aarch64"), ("Darwin", "aarch64")):
             with self.subTest(platform=platform, machine=machine):
                 self.run_install(platform=platform, machine=machine)
+
+    def test_cancellation_waits_for_destination_write(self):
+        self.run_install(tty=True, cancel_install=True)
 
     def test_legacy_without_hash(self):
         for tags in ((), ("v1.2.3",)):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -120,6 +120,8 @@ echo finished > "$ROOT/install-finished"
                                     self.fail("installer did not reach destination write")
                                 time.sleep(0.01)
                             process.terminate()
+                            time.sleep(0.1)
+                            process.terminate()
                             process.communicate(timeout=15)
                             self.assertTrue((root / "install-finished").exists(),
                                             "installer exited before its child finished writing")

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,167 @@
+"""Offline installer regressions. Run explicitly with python3 tests/test_install.py."""
+
+import hashlib
+import io
+import os
+from pathlib import Path
+import pty
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import unittest
+import zipfile
+
+
+INSTALLER = Path(__file__).resolve().parents[1] / "install.sh"
+BINARY = b"#!/bin/sh\necho executed > \"$ROOT/executed\"\n"
+
+
+class InstallerTest(unittest.TestCase):
+    def run_install(self, *, platform="Linux", tty=False, digest="correct",
+                    tags=("v1.2.3",), tool="sha256sum", failure="", downloader="curl",
+                    machine="x86_64"):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            tools = root / "tools"
+            tools.mkdir()
+            dest = root / "destination"
+            dest.mkdir()
+            tmp = root / "tmp"
+            tmp.mkdir()
+            windows = platform == "MINGW64_NT"
+            binary = "ingestr.exe" if windows else "ingestr"
+            (dest / binary).write_bytes(b"existing installation")
+            archive = root / "archive"
+            if windows:
+                with zipfile.ZipFile(archive, "w") as output:
+                    output.writestr(binary, BINARY)
+            else:
+                with tarfile.open(archive, "w:gz") as output:
+                    entry = tarfile.TarInfo(binary)
+                    entry.size = len(BINARY)
+                    entry.mode = 0o755
+                    output.addfile(entry, io.BytesIO(BINARY))
+            expected = hashlib.sha256(archive.read_bytes()).hexdigest()
+
+            def stub(name, body):
+                path = tools / name
+                path.write_text("#!/bin/sh\nset -e\n" + body + "\n")
+                path.chmod(0o755)
+
+            for name in ("cat", "tr", "grep", "sed", "cut", "mktemp", "rm", "cp",
+                         "install", "basename", "tail", "awk", "wc", "sleep", "gzip"):
+                path = shutil.which(name)
+                self.assertIsNotNone(path, name)
+                (tools / name).symlink_to(path)
+            stub("uname", 'if [ "$1" = -s ]; then echo "$PLATFORM"; else echo "$MACHINE"; fi')
+            stub("tput", "echo 0")
+            stub(downloader, '''
+echo "$*" >> "$ROOT/requests"
+case "$*" in *-sLI*) echo 'content-length: 0'; exit 0 ;; esac
+while [ "$#" -gt 0 ]; do
+  case "$1" in -o|-O) output=$2; shift ;; esac
+  url=$1
+  shift
+done
+case "$url" in
+  */releases/download/*) cp "$ROOT/archive" "$output" ;;
+  *) printf '{"tag_name":"v1.2.3"}' > "$output" ;;
+esac
+if [ "$FAILURE" = download ]; then exit 22; fi
+''')
+            extractor = "unzip" if windows else "tar"
+            real_extractor = shutil.which(extractor)
+            self.assertIsNotNone(real_extractor)
+            stub(extractor, f'echo extracted > "$ROOT/extracted"\nexec "{real_extractor}" "$@"')
+            if tool != "missing":
+                if failure == "tool":
+                    stub(tool, f'echo "{expected}  archive"; exit 1')
+                elif failure == "output":
+                    stub(tool, "echo invalid-digest")
+                else:
+                    real_tool = shutil.which("sha256sum" if tool == "gsha256sum" else tool)
+                    self.assertIsNotNone(real_tool, tool)
+                    (tools / tool).symlink_to(real_tool)
+
+            args = ["-b", str(dest)]
+            if digest is not None:
+                value = expected.upper() if digest == "correct" else digest
+                args += ["-s", value]
+            args += list(tags)
+            env = dict(os.environ, PATH=str(tools), ROOT=str(root), TMPDIR=str(tmp),
+                       HOME=str(root), SHELL="bruin-installer", PLATFORM=platform,
+                       FAILURE=failure, TERM="xterm", MACHINE=machine)
+            master = slave = None
+            try:
+                if tty:
+                    master, slave = pty.openpty()
+                with tempfile.TemporaryFile() as output:
+                    result = subprocess.run(
+                        ["/bin/sh", "-s", "--", *args], input=INSTALLER.read_bytes(),
+                        stdout=slave if tty else output, stderr=output,
+                        env=env, timeout=15,
+                    )
+                    output.seek(0)
+                    diagnostics = output.read().decode(errors="replace")
+            finally:
+                if slave is not None:
+                    os.close(slave)
+                    os.close(master)
+            success = digest in ("correct", None) and not failure and tool != "missing"
+            success = success and (digest is None or tags == ("v1.2.3",))
+            self.assertEqual(result.returncode == 0, success, diagnostics)
+            self.assertEqual((dest / binary).read_bytes(), BINARY if success else b"existing installation")
+            self.assertEqual((root / "extracted").exists(), success, diagnostics)
+            self.assertFalse((root / "executed").exists())
+            self.assertEqual(list(tmp.iterdir()), [], diagnostics)
+            requests = (root / "requests").read_text() if (root / "requests").exists() else ""
+            if digest is not None:
+                archive_os = "Windows" if windows else platform
+                archive_arch = {"x86_64": "x86_64", "aarch64": "arm64", "i686": "i386"}[machine]
+                archive_suffix = ".zip" if windows else ".tar.gz"
+                for request in requests.splitlines():
+                    self.assertIn(f"/releases/download/v1.2.3/ingestr_{archive_os}_{archive_arch}{archive_suffix}", request)
+
+    def test_verification_before_extraction_in_both_output_paths(self):
+        for platform, tty in (("Linux", False), ("Linux", True), ("Darwin", False),
+                              ("Darwin", True), ("MINGW64_NT", False)):
+            for failure in ("", "download", "tool", "output"):
+                with self.subTest(platform=platform, tty=tty, failure=failure):
+                    self.run_install(platform=platform, tty=tty, failure=failure)
+            for digest, tool in (("0" * 64, "sha256sum"), ("correct", "missing"),
+                                 (hashlib.sha256(BINARY).hexdigest(), "sha256sum")):
+                with self.subTest(platform=platform, tty=tty, digest=digest, tool=tool):
+                    self.run_install(platform=platform, tty=tty, digest=digest, tool=tool)
+
+    def test_strict_inputs(self):
+        for digest in ("", "a" * 63, "a" * 65, "g" * 64, " " + "a" * 63,
+                       "a" * 63 + "\n", "sha256:" + "a" * 64):
+            with self.subTest(digest=digest):
+                self.run_install(digest=digest)
+        for tags in ((), ("latest",), ("1.2.3",), ("v1.2",), ("v1.2.3-rc1",),
+                     ("v1.2.3", "extra"), ("v1.2.3\nlatest",)):
+            with self.subTest(tags=tags):
+                self.run_install(tags=tags)
+
+    def test_system_hash_fallbacks_and_wget(self):
+        for tool in ("gsha256sum", "sha256sum", "shasum", "openssl"):
+            for downloader in ("curl", "wget"):
+                with self.subTest(tool=tool, downloader=downloader):
+                    self.run_install(tool=tool, downloader=downloader)
+        self.run_install(downloader="wget", failure="download")
+
+    def test_other_supported_architectures(self):
+        for platform, machine in (("Linux", "aarch64"), ("Darwin", "aarch64"),
+                                  ("MINGW64_NT", "i686")):
+            with self.subTest(platform=platform, machine=machine):
+                self.run_install(platform=platform, machine=machine)
+
+    def test_legacy_without_hash(self):
+        for tags in ((), ("v1.2.3",)):
+            with self.subTest(tags=tags):
+                self.run_install(digest=None, tags=tags)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
Add the completely optional archive-hash verification requested by @karakanb, implemented fresh on upstream main. The README addition was removed as requested; this PR changes only install.sh and tests/test_install.py. No attestation, cosign, jq, signing-tool bootstrap, or manifest changes.

## Contract
With install.sh on stdin:
```sh
SHELL=bruin-installer sh -s -- -b "$installDir" -s "$SHA256" "$VERSION"
```
The installer -s option accepts exactly 64 ASCII hexadecimal characters (either case, no prefix or whitespace). It requires exactly one stable version tag matching `^v[0-9]+\.[0-9]+\.[0-9]+$` (vMAJOR.MINOR.PATCH). Missing tags, latest, prereleases, and extra positional arguments are rejected. Hash-enabled installation downloads that exact tag directly, without tag resolution or fallback to latest. Without the option, existing flags and version selection remain supported.

The caller must supply a trusted hash of the exact per-version/platform release ARCHIVE bytes (.tar.gz or Windows .zip), not the extracted binary or installer script. Installer delivery must be trusted separately.

Both interactive and plain-output paths verify before extraction, execution, installation, or destination overwrite. Download failure, mismatch, missing/failing hash tooling, or malformed digest output fails closed with temporary-file cleanup. Reuses installed gsha256sum/sha256sum/shasum/openssl; fixes the existing OpenSSL helper and scopes strict curl failure handling to hash-enabled downloads.

## Validation
Passed non-test checks:
- sh -n install.sh
- bash -n install.sh
- Python ast.parse syntax check for tests/test_install.py (without executing it)
- git diff --check
- make format
- make lint (No changed Go packages to lint)

Local test suites, including the added offline regression suite, were NOT run, per @karakanb’s explicit instruction to avoid running tests. Added coverage includes archive/platform naming, interactive/plain paths, strict inputs, exact-version selection, download/hash-tool failure, archive-vs-binary digests, cleanup/destination protection, and legacy behavior. Runtime behavior is not locally verified.

Publication of the shared installer is separate from this PR. No merge or deployment is authorized.