### PR TITLE
Add CouchDB source with integration tests

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -104,6 +104,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               { text: "Cassandra", link: "/supported-sources/cassandra.md" },
               { text: "ClickHouse", link: "/supported-sources/clickhouse.md" },
               { text: "Couchbase", link: "/supported-sources/couchbase.md" },
+              { text: "CouchDB", link: "/supported-sources/couchdb.md" },
               { text: "CrateDB", link: "/supported-sources/cratedb.md" },
               { text: "Databricks", link: "/supported-sources/databricks.md" },
               { text: "DuckDB", link: "/supported-sources/duckdb.md" },

--- a/docs/supported-sources/couchdb.md
+++ b/docs/supported-sources/couchdb.md
@@ -22,8 +22,10 @@ documents, and deleted documents are not ingested.
 
 The default strategy is `replace`, reading all current documents. An explicit
 `merge` upserts by `_id`, but does not remove destination rows deleted from CouchDB.
-There is no native timestamp filtering or `_changes`/CDC support. User-specified
-incremental keys use the pipeline's filtering; reads still scan the database.
+There is no timestamp filtering or `_changes`/CDC support. Incremental keys and
+intervals are rejected rather than silently ignored. `--sql-limit` limits emitted documents.
+An empty replacement clears the destination using a minimal `_id` schema, since
+there are no documents from which to infer other columns.
 Pagination is sequential and is not a transactionally consistent snapshot when
 documents change during ingestion. Self-hosted CouchDB has no fixed vendor API
 quota; the client retries throttling and server errors without imposing a SaaS rate limit.

--- a/docs/supported-sources/couchdb.md
+++ b/docs/supported-sources/couchdb.md
@@ -1,0 +1,29 @@
+# CouchDB
+
+ingestr reads documents from a CouchDB database. Use the database name as `--source-table`.
+
+```sh
+ingestr ingest \
+  --source-uri 'couchdb://username:password@localhost:5984' \
+  --source-table orders \
+  --dest-uri 'duckdb:///warehouse.duckdb' \
+  --dest-table orders
+```
+
+Use `couchdb+https://username:password@host` for TLS (port 443 by default).
+The `couchdb://` scheme uses HTTP and defaults to port 5984. Credentials are optional
+for databases that permit anonymous reads. URL-encode special characters in credentials.
+The URI contains the server address, not the database name.
+
+Document fields become inferred columns, including `_id` and `_rev`. Nested objects
+and arrays remain JSON. `_id` is the default primary key. Attachment metadata is
+preserved, but attachment bodies are not downloaded. Design documents, local
+documents, and deleted documents are not ingested.
+
+The default strategy is `replace`, reading all current documents. An explicit
+`merge` upserts by `_id`, but does not remove destination rows deleted from CouchDB.
+There is no native timestamp filtering or `_changes`/CDC support. User-specified
+incremental keys use the pipeline's filtering; reads still scan the database.
+Pagination is sequential and is not a transactionally consistent snapshot when
+documents change during ingestion. Self-hosted CouchDB has no fixed vendor API
+quota; the client retries throttling and server errors without imposing a SaaS rate limit.

--- a/docs/supported-sources/couchdb.md
+++ b/docs/supported-sources/couchdb.md
@@ -1,32 +1,73 @@
 # CouchDB
 
-ingestr reads documents from a CouchDB database. Use the database name as `--source-table`.
+[Apache CouchDB](https://couchdb.apache.org/) is an open-source document database that stores data as JSON.
 
-```sh
-ingestr ingest \
-  --source-uri 'couchdb://username:password@localhost:5984' \
-  --source-table orders \
-  --dest-uri 'duckdb:///warehouse.duckdb' \
-  --dest-table orders
+ingestr supports CouchDB as a source.
+
+## URI format
+
+### Standard format (without SSL)
+
+```plaintext
+couchdb://username:password@host:port
 ```
 
-Use `couchdb+https://username:password@host` for TLS (port 443 by default).
-The `couchdb://` scheme uses HTTP and defaults to port 5984. Credentials are optional
-for databases that permit anonymous reads. URL-encode special characters in credentials.
-The URI contains the server address, not the database name.
+### With SSL/TLS enabled
 
-Document fields become inferred columns, including `_id` and `_rev`. Nested objects
-and arrays remain JSON. `_id` is the default primary key. Attachment metadata is
-preserved, but attachment bodies are not downloaded. Design documents, local
-documents, and deleted documents are not ingested.
+```plaintext
+couchdb+https://username:password@host:port
+```
 
-The default strategy is `replace`, reading all current documents. An explicit
-`merge` upserts by `_id`, but does not remove destination rows deleted from CouchDB.
-There is no timestamp filtering or `_changes`/CDC support. Incremental keys and
-intervals are rejected rather than silently ignored. `--sql-limit` limits emitted documents.
-An empty replacement clears the destination using a minimal `_id` schema, since
-there are no documents from which to infer other columns. Custom primary-key
-columns are also included as strings in this empty fallback schema.
-Pagination is sequential and is not a transactionally consistent snapshot when
-documents change during ingestion. Self-hosted CouchDB has no fixed vendor API
-quota; the client retries throttling and server errors without imposing a SaaS rate limit.
+URI parameters:
+- `username`: the username to connect to CouchDB, optional for databases that permit anonymous reads
+- `password`: the password for the user
+- `host`: the host address of the CouchDB server
+- `port`: the port number the server is listening on, default is `5984` for HTTP and `443` for HTTPS
+
+> [!IMPORTANT]
+> Passwords containing special characters such as `@`, `/`, `#`, or `?` must be URL-encoded in the connection URI.
+
+## Source table format
+
+The `--source-table` option specifies the database to read:
+
+```plaintext
+database_name
+```
+
+> [!NOTE]
+> Do not include the database name in the URI. Use `--source-table` instead.
+
+## Using CouchDB as a source
+
+```bash
+ingestr ingest \
+  --source-uri "couchdb://admin:password@localhost:5984" \
+  --source-table "orders" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "main.orders"
+```
+
+This command reads documents from the `orders` database in CouchDB and loads them into the `main.orders` table in DuckDB.
+
+For a server using HTTPS:
+
+```bash
+ingestr ingest \
+  --source-uri "couchdb+https://username:password@couchdb.example.com" \
+  --source-table "orders" \
+  --dest-uri "duckdb:///warehouse.duckdb" \
+  --dest-table "main.orders"
+```
+
+ingestr infers columns from the documents, including `_id` and `_rev`. Nested objects and arrays are stored as JSON. The default primary key is `_id`.
+
+> [!TIP]
+> The default `replace` strategy replaces the destination with the current documents. Use `merge` to update existing rows by primary key without removing rows deleted from CouchDB.
+
+## Limitations
+
+- Incremental keys, time intervals, and change data capture (CDC) are not supported. Each run scans the database; `--sql-limit` can limit the number of documents loaded.
+- Design documents, local documents, and deleted documents are not ingested. Attachment metadata is included, but attachment contents are not downloaded.
+- Reads are not a consistent snapshot if documents change during ingestion.
+- Replacing from an empty database clears the destination and creates only `_id` and any custom primary-key columns as strings, since there are no documents from which to infer other columns.

--- a/docs/supported-sources/couchdb.md
+++ b/docs/supported-sources/couchdb.md
@@ -25,7 +25,8 @@ The default strategy is `replace`, reading all current documents. An explicit
 There is no timestamp filtering or `_changes`/CDC support. Incremental keys and
 intervals are rejected rather than silently ignored. `--sql-limit` limits emitted documents.
 An empty replacement clears the destination using a minimal `_id` schema, since
-there are no documents from which to infer other columns.
+there are no documents from which to infer other columns. Custom primary-key
+columns are also included as strings in this empty fallback schema.
 Pagination is sequential and is not a transactionally consistent snapshot when
 documents change during ingestion. Self-hosted CouchDB has no fixed vendor API
 quota; the client retries throttling and server errors without imposing a SaaS rate limit.

--- a/internal/server/connectors.go
+++ b/internal/server/connectors.go
@@ -109,6 +109,7 @@ func GetConnectors() []ConnectorType {
 			},
 		},
 		genericURIConnector("postgres-cdc", "PostgreSQL CDC", []string{"postgres+cdc", "postgresql+cdc"}, true, false),
+		genericURIConnector("couchdb", "CouchDB", []string{"couchdb", "couchdb+https"}, true, false),
 		genericURIConnector("mysql-cdc", "MySQL CDC", []string{"mysql+cdc", "mysql+pymysql+cdc", "mariadb+cdc"}, true, false),
 		genericURIConnector("vitess-cdc", "Vitess CDC", []string{"vitess+cdc"}, true, false),
 		genericURIConnector("ps_mysql-cdc", "PlanetScale MySQL CDC", []string{"ps_mysql+cdc"}, true, false),

--- a/pkg/source/couchdb/couchdb.go
+++ b/pkg/source/couchdb/couchdb.go
@@ -102,6 +102,9 @@ func (s *CouchDBSource) GetTable(ctx context.Context, req source.TableRequest) (
 	if s.client == nil {
 		return nil, fmt.Errorf("CouchDB source is not connected")
 	}
+	if req.IncrementalKey != "" {
+		return nil, fmt.Errorf("CouchDB does not support incremental keys; use a full replace or merge")
+	}
 	if req.Name == "" || strings.HasPrefix(req.Name, "_") || req.Name == "." || req.Name == ".." {
 		return nil, fmt.Errorf("CouchDB source-table must be a user database name")
 	}
@@ -121,9 +124,12 @@ func (s *CouchDBSource) GetTable(ctx context.Context, req source.TableRequest) (
 		TableName: req.Name, TablePrimaryKeys: pks, TableIncrementalKey: req.IncrementalKey,
 		TableStrategy: strategy, KnownSchema: false,
 		SchemaFn: func(context.Context) (*schema.TableSchema, error) {
-			return nil, fmt.Errorf("CouchDB requires schema inference")
+			return &schema.TableSchema{Name: req.Name, Columns: []schema.Column{{Name: "_id", DataType: schema.TypeString}}, PrimaryKeys: pks}, nil
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			if opts.IncrementalKey != "" || opts.IntervalStart != nil || opts.IntervalEnd != nil {
+				return nil, fmt.Errorf("CouchDB does not support incremental filtering; use a full replace or merge")
+			}
 			results := make(chan source.RecordBatchResult, source.RecordBatchBufferSize(opts, 2))
 			go func() {
 				defer close(results)
@@ -145,6 +151,7 @@ func (s *CouchDBSource) read(ctx context.Context, path string, opts source.ReadO
 		pageSize = opts.PageSize
 	}
 	params := url.Values{"include_docs": {"true"}, "limit": {strconv.Itoa(pageSize + 1)}}
+	count := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -202,6 +209,10 @@ func (s *CouchDBSource) read(ctx context.Context, path string, opts source.ReadO
 				size += rowBytes
 			}
 			batch = append(batch, row.Doc)
+			count++
+			if opts.Limit > 0 && count >= opts.Limit {
+				return flush()
+			}
 		}
 		if err := flush(); err != nil {
 			return err

--- a/pkg/source/couchdb/couchdb.go
+++ b/pkg/source/couchdb/couchdb.go
@@ -1,0 +1,213 @@
+package couchdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/arrowconv"
+	httpclient "github.com/bruin-data/ingestr/pkg/http"
+	"github.com/bruin-data/ingestr/pkg/schema"
+	"github.com/bruin-data/ingestr/pkg/source"
+)
+
+const maxPageSize = 1000
+
+type CouchDBSource struct {
+	client *httpclient.Client
+}
+
+func NewCouchDBSource() *CouchDBSource { return &CouchDBSource{} }
+
+func (s *CouchDBSource) Schemes() []string { return []string{"couchdb", "couchdb+https"} }
+
+func parseURI(uri string) (*url.URL, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CouchDB URI")
+	}
+	if u.Scheme != "couchdb" && u.Scheme != "couchdb+https" {
+		return nil, fmt.Errorf("unsupported CouchDB scheme: %s", u.Scheme)
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("CouchDB host is required")
+	}
+	if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return nil, fmt.Errorf("CouchDB URI must contain only host and credentials; select the database with source-table")
+	}
+	if u.Scheme == "couchdb+https" {
+		u.Scheme = "https"
+	} else {
+		u.Scheme = "http"
+		if u.Port() == "" {
+			u.Host = net.JoinHostPort(u.Hostname(), "5984")
+		}
+	}
+	u.Path = ""
+	return u, nil
+}
+
+func (s *CouchDBSource) Connect(ctx context.Context, uri string) error {
+	u, err := parseURI(uri)
+	if err != nil {
+		return err
+	}
+	credentials := u.User
+	u.User = nil
+	opts := []httpclient.Option{httpclient.WithBaseURL(u.String())}
+	if credentials != nil {
+		password, _ := credentials.Password()
+		opts = append(opts, httpclient.WithAuth(httpclient.NewBasicAuth(credentials.Username(), password)))
+	}
+	s.client = httpclient.New(opts...)
+	if err := s.get(ctx, "/_up", nil, &struct{}{}); err != nil {
+		_ = s.client.Close()
+		s.client = nil
+		return fmt.Errorf("failed to connect to CouchDB: %w", err)
+	}
+	return nil
+}
+
+func (s *CouchDBSource) Close(context.Context) error {
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
+}
+
+func (s *CouchDBSource) HandlesIncrementality() bool { return false }
+
+func (s *CouchDBSource) get(ctx context.Context, path string, params url.Values, result interface{}) error {
+	resp, err := s.client.R(ctx).SetQueryParamValues(params).Get(path)
+	if err != nil {
+		return fmt.Errorf("CouchDB GET %s: %w", path, err)
+	}
+	if !resp.IsSuccess() {
+		return fmt.Errorf("CouchDB GET %s: HTTP %d", path, resp.StatusCode())
+	}
+	decoder := json.NewDecoder(strings.NewReader(resp.String()))
+	decoder.UseNumber()
+	if err := decoder.Decode(result); err != nil {
+		return fmt.Errorf("decode CouchDB GET %s: %w", path, err)
+	}
+	return nil
+}
+
+func (s *CouchDBSource) GetTable(ctx context.Context, req source.TableRequest) (source.SourceTable, error) {
+	if s.client == nil {
+		return nil, fmt.Errorf("CouchDB source is not connected")
+	}
+	if req.Name == "" || strings.HasPrefix(req.Name, "_") || req.Name == "." || req.Name == ".." {
+		return nil, fmt.Errorf("CouchDB source-table must be a user database name")
+	}
+	path := "/" + url.PathEscape(req.Name)
+	if err := s.get(ctx, path, nil, &struct{}{}); err != nil {
+		return nil, err
+	}
+	strategy := req.Strategy
+	if strategy == "" {
+		strategy = config.StrategyReplace
+	}
+	pks := req.PrimaryKeys
+	if len(pks) == 0 {
+		pks = []string{"_id"}
+	}
+	return &source.DynamicSourceTable{
+		TableName: req.Name, TablePrimaryKeys: pks, TableIncrementalKey: req.IncrementalKey,
+		TableStrategy: strategy, KnownSchema: false,
+		SchemaFn: func(context.Context) (*schema.TableSchema, error) {
+			return nil, fmt.Errorf("CouchDB requires schema inference")
+		},
+		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
+			results := make(chan source.RecordBatchResult, source.RecordBatchBufferSize(opts, 2))
+			go func() {
+				defer close(results)
+				if err := s.read(ctx, path, opts, results); err != nil {
+					select {
+					case results <- source.RecordBatchResult{Err: err}:
+					case <-ctx.Done():
+					}
+				}
+			}()
+			return results, nil
+		},
+	}, nil
+}
+
+func (s *CouchDBSource) read(ctx context.Context, path string, opts source.ReadOptions, results chan<- source.RecordBatchResult) error {
+	pageSize := maxPageSize
+	if opts.PageSize > 0 && opts.PageSize < pageSize {
+		pageSize = opts.PageSize
+	}
+	params := url.Values{"include_docs": {"true"}, "limit": {strconv.Itoa(pageSize + 1)}}
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var page struct {
+			Rows []struct {
+				ID  string                 `json:"id"`
+				Doc map[string]interface{} `json:"doc"`
+			} `json:"rows"`
+		}
+		if err := s.get(ctx, path+"/_all_docs", params, &page); err != nil {
+			return err
+		}
+		more := len(page.Rows) > pageSize
+		if more {
+			// Resume at the lookahead row, avoiding skip=1 losing a row if the cursor document is deleted.
+			key, err := json.Marshal(page.Rows[pageSize].ID)
+			if err != nil {
+				return err
+			}
+			params.Set("startkey", string(key))
+			page.Rows = page.Rows[:pageSize]
+		}
+		var batch []map[string]interface{}
+		var size int64
+		flush := func() error {
+			if len(batch) == 0 {
+				return nil
+			}
+			record, err := arrowconv.ItemsToArrowRecordWithSchema(batch, nil, opts.ExcludeColumns)
+			if err != nil {
+				return err
+			}
+			select {
+			case results <- source.RecordBatchResult{Batch: record}:
+			case <-ctx.Done():
+				record.Release()
+				return ctx.Err()
+			}
+			batch = nil
+			size = 0
+			return nil
+		}
+		for _, row := range page.Rows {
+			if row.Doc == nil || strings.HasPrefix(row.ID, "_design/") || row.Doc["_deleted"] == true {
+				continue
+			}
+			if opts.MaxBatchBytes > 0 {
+				rowBytes := arrowconv.RowBytes(row.Doc)
+				if len(batch) > 0 && size+rowBytes > opts.MaxBatchBytes {
+					if err := flush(); err != nil {
+						return err
+					}
+				}
+				size += rowBytes
+			}
+			batch = append(batch, row.Doc)
+		}
+		if err := flush(); err != nil {
+			return err
+		}
+		if !more {
+			return nil
+		}
+	}
+}

--- a/pkg/source/couchdb/couchdb.go
+++ b/pkg/source/couchdb/couchdb.go
@@ -124,7 +124,15 @@ func (s *CouchDBSource) GetTable(ctx context.Context, req source.TableRequest) (
 		TableName: req.Name, TablePrimaryKeys: pks, TableIncrementalKey: req.IncrementalKey,
 		TableStrategy: strategy, KnownSchema: false,
 		SchemaFn: func(context.Context) (*schema.TableSchema, error) {
-			return &schema.TableSchema{Name: req.Name, Columns: []schema.Column{{Name: "_id", DataType: schema.TypeString}}, PrimaryKeys: pks}, nil
+			columns := []schema.Column{{Name: "_id", DataType: schema.TypeString}}
+			seen := map[string]bool{"_id": true}
+			for _, key := range pks {
+				if !seen[key] {
+					columns = append(columns, schema.Column{Name: key, DataType: schema.TypeString})
+					seen[key] = true
+				}
+			}
+			return &schema.TableSchema{Name: req.Name, Columns: columns, PrimaryKeys: pks}, nil
 		},
 		ReadFn: func(ctx context.Context, opts source.ReadOptions) (<-chan source.RecordBatchResult, error) {
 			if opts.IncrementalKey != "" || opts.IntervalStart != nil || opts.IntervalEnd != nil {

--- a/pkg/source/couchdb/couchdb_test.go
+++ b/pkg/source/couchdb/couchdb_test.go
@@ -1,0 +1,38 @@
+package couchdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURI(t *testing.T) {
+	for _, tc := range []struct {
+		uri, scheme, host, user, password string
+	}{
+		{"couchdb://localhost", "http", "localhost:5984", "", ""},
+		{"couchdb://alice:p%40ss@localhost:15984/", "http", "localhost:15984", "alice", "p@ss"},
+		{"couchdb://[::1]", "http", "[::1]:5984", "", ""},
+		{"couchdb+https://db.example.com", "https", "db.example.com", "", ""},
+		{"couchdb+https://db.example.com:6984", "https", "db.example.com:6984", "", ""},
+	} {
+		t.Run(tc.uri, func(t *testing.T) {
+			u, err := parseURI(tc.uri)
+			require.NoError(t, err)
+			require.Equal(t, tc.scheme, u.Scheme)
+			require.Equal(t, tc.host, u.Host)
+			require.Equal(t, tc.user, u.User.Username())
+			password, _ := u.User.Password()
+			require.Equal(t, tc.password, password)
+		})
+	}
+	for _, uri := range []string{
+		"", "http://localhost", "couchdb:///db", "couchdb://host/database",
+		"couchdb://host?ssl=true", "couchdb://host#fragment", "couchdb://host:invalid", "couchdb://user:%zz@host",
+	} {
+		t.Run(uri, func(t *testing.T) {
+			_, err := parseURI(uri)
+			require.Error(t, err)
+		})
+	}
+}

--- a/pkg/source/couchdb/register.go
+++ b/pkg/source/couchdb/register.go
@@ -1,0 +1,7 @@
+package couchdb
+
+import "github.com/bruin-data/ingestr/internal/registry"
+
+func init() {
+	registry.RegisterSource([]string{"couchdb", "couchdb+https"}, func() interface{} { return NewCouchDBSource() })
+}

--- a/tests/integration/couchdb_test.go
+++ b/tests/integration/couchdb_test.go
@@ -1,0 +1,235 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bruin-data/ingestr/internal/config"
+	"github.com/bruin-data/ingestr/pkg/pipeline"
+	"github.com/bruin-data/ingestr/pkg/source"
+	_ "github.com/bruin-data/ingestr/pkg/source/adbc" // register adbc_generic for DuckDB read-back
+	"github.com/bruin-data/ingestr/pkg/source/couchdb"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const (
+	couchDBUser     = "ingestr_admin"
+	couchDBPassword = "synthetic_password"
+	couchDBPort     = "5984/tcp"
+	couchDBDatabase = "integration_docs"
+)
+
+func TestCouchDBToDuckDBReplace(t *testing.T) {
+	requireDocker(t)
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	container, sourceURI, httpBase := startCouchDBContainer(t, ctx)
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	couchDBRequest(t, ctx, httpBase, http.MethodPut, "/"+couchDBDatabase, nil, http.StatusCreated)
+	couchDBPutDocument(t, ctx, httpBase, "_design/ignored", map[string]any{
+		"views": map[string]any{"all": map[string]any{"map": "function (doc) { emit(doc._id, 1); }"}},
+	})
+	couchDBPutDocument(t, ctx, httpBase, "a", map[string]any{
+		"name": "alpha", "sequence": int64(9007199254740993),
+		"profile": map[string]any{"city": "Oslo", "tags": []string{"a", "b"}}, "nullable": nil, "secret": "omit-me",
+	})
+	couchDBPutDocument(t, ctx, httpBase, "b", map[string]any{
+		"name": "beta", "sequence": int64(2),
+		"profile": map[string]any{"city": "Lima", "tags": []string{"c"}}, "nullable": "present", "secret": "omit-me",
+	})
+	couchDBPutDocument(t, ctx, httpBase, "c", map[string]any{
+		"name": "gamma", "sequence": int64(3),
+		"profile": map[string]any{"city": "Tokyo", "tags": []string{}}, "nullable": nil, "secret": "omit-me",
+	})
+	deletedRevision := couchDBPutDocument(t, ctx, httpBase, "d-deleted", map[string]any{"name": "tombstone"})
+	couchDBRequest(t, ctx, httpBase, http.MethodDelete, "/"+couchDBDatabase+"/d-deleted?rev="+deletedRevision, nil, http.StatusOK)
+
+	src := couchdb.NewCouchDBSource()
+	require.NoError(t, src.Connect(ctx, sourceURI))
+	t.Cleanup(func() { _ = src.Close(context.Background()) })
+	_, err := src.GetTable(ctx, source.TableRequest{Name: "missing_database"})
+	require.ErrorContains(t, err, "HTTP 404")
+	table, err := src.GetTable(ctx, source.TableRequest{Name: couchDBDatabase})
+	require.NoError(t, err)
+	require.Equal(t, []string{"_id"}, table.PrimaryKeys())
+	for _, capBytes := range []int64{0, 1} {
+		batches, err := table.Read(ctx, source.ReadOptions{PageSize: 2, MaxBatchBytes: capBytes, ExcludeColumns: []string{"secret"}})
+		require.NoError(t, err)
+		var counts []int64
+		for result := range batches {
+			require.NoError(t, result.Err)
+			counts = append(counts, result.Batch.NumRows())
+			require.Empty(t, result.Batch.Schema().FieldIndices("secret"))
+			result.Batch.Release()
+		}
+		if capBytes == 0 {
+			require.Equal(t, []int64{1, 2}, counts)
+		} else {
+			require.Equal(t, []int64{1, 1, 1}, counts)
+		}
+	}
+	couchDBRequest(t, ctx, httpBase, http.MethodPut, "/empty_database", nil, http.StatusCreated)
+	empty, err := src.GetTable(ctx, source.TableRequest{Name: "empty_database"})
+	require.NoError(t, err)
+	batches, err := empty.Read(ctx, source.ReadOptions{})
+	require.NoError(t, err)
+	for result := range batches {
+		if result.Batch != nil {
+			result.Batch.Release()
+		}
+		t.Fatalf("expected no batches for empty database, got error %v", result.Err)
+	}
+
+	duckPath := filepath.Join(t.TempDir(), "couchdb.duckdb")
+	cfg := config.DefaultConfig()
+	cfg.SourceURI = sourceURI
+	cfg.SourceTable = couchDBDatabase
+	cfg.DestURI = "duckdb:///" + duckPath
+	cfg.DestTable = "main.documents"
+	cfg.IncrementalStrategy = config.StrategyReplace
+	cfg.IncrementalStrategyExplicit = true
+	cfg.PageSize = 2
+	cfg.MaxBatchBytes = 180
+	cfg.SQLExcludeColumns = []string{"secret"}
+	cfg.NoLoadTimestamp = true
+	cfg.NoRunID = true
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+
+	duck, err := sql.Open("adbc_generic", "driver=duckdb;path="+duckPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = duck.Close() })
+
+	assertCouchDBRows(t, ctx, duck, []string{"a", "b", "c"})
+	var sequence int64
+	var profileJSON string
+	var nullable sql.NullString
+	require.NoError(t, duck.QueryRowContext(ctx,
+		`SELECT sequence, CAST(profile AS VARCHAR), nullable FROM main.documents WHERE _id = 'a'`,
+	).Scan(&sequence, &profileJSON, &nullable))
+	require.Equal(t, int64(9007199254740993), sequence)
+	require.False(t, nullable.Valid)
+	var profile map[string]any
+	require.NoError(t, json.Unmarshal([]byte(profileJSON), &profile))
+	require.Equal(t, "Oslo", profile["city"])
+	require.Equal(t, []any{"a", "b"}, profile["tags"])
+
+	var secretColumns int
+	require.NoError(t, duck.QueryRowContext(ctx, `SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = 'main' AND table_name = 'documents' AND column_name = 'secret'`).Scan(&secretColumns))
+	require.Zero(t, secretColumns)
+
+	aRevision := couchDBDocumentRevision(t, ctx, httpBase, "a")
+	couchDBPutDocument(t, ctx, httpBase, "a", map[string]any{
+		"_rev": aRevision, "name": "alpha-updated", "sequence": int64(9007199254740993),
+		"profile": map[string]any{"city": "Bergen", "tags": []string{"updated"}}, "nullable": nil, "secret": "still-omitted",
+	})
+	bRevision := couchDBDocumentRevision(t, ctx, httpBase, "b")
+	couchDBRequest(t, ctx, httpBase, http.MethodDelete, "/"+couchDBDatabase+"/b?rev="+bRevision, nil, http.StatusOK)
+
+	require.NoError(t, duck.Close())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	duck, err = sql.Open("adbc_generic", "driver=duckdb;path="+duckPath)
+	require.NoError(t, err)
+	assertCouchDBRows(t, ctx, duck, []string{"a", "c"})
+	var name, updatedProfile string
+	require.NoError(t, duck.QueryRowContext(ctx, `SELECT name, CAST(profile AS VARCHAR) FROM main.documents WHERE _id = 'a'`).Scan(&name, &updatedProfile))
+	require.Equal(t, "alpha-updated", name)
+	require.JSONEq(t, `{"city":"Bergen","tags":["updated"]}`, updatedProfile)
+}
+
+func startCouchDBContainer(t *testing.T, ctx context.Context) (testcontainers.Container, string, string) {
+	t.Helper()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "couchdb:3.4.3",
+			ExposedPorts: []string{couchDBPort},
+			Env: map[string]string{
+				"COUCHDB_USER": couchDBUser, "COUCHDB_PASSWORD": couchDBPassword,
+			},
+			WaitingFor: wait.ForHTTP("/_up").WithPort(couchDBPort).WithBasicAuth(couchDBUser, couchDBPassword).
+				WithStatusCodeMatcher(func(status int) bool { return status == http.StatusOK }).WithStartupTimeout(2 * time.Minute),
+		},
+		Started: true,
+	})
+	require.NoError(t, err)
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, couchDBPort)
+	require.NoError(t, err)
+	address := net.JoinHostPort(host, port.Port())
+	return container, fmt.Sprintf("couchdb://%s:%s@%s", couchDBUser, couchDBPassword, address), "http://" + address
+}
+
+func couchDBPutDocument(t *testing.T, ctx context.Context, base, id string, document map[string]any) string {
+	t.Helper()
+	response := couchDBRequest(t, ctx, base, http.MethodPut, "/"+couchDBDatabase+"/"+id, document, http.StatusCreated)
+	var result struct {
+		Rev string `json:"rev"`
+	}
+	require.NoError(t, json.Unmarshal(response, &result))
+	require.NotEmpty(t, result.Rev)
+	return result.Rev
+}
+
+func couchDBDocumentRevision(t *testing.T, ctx context.Context, base, id string) string {
+	t.Helper()
+	response := couchDBRequest(t, ctx, base, http.MethodGet, "/"+couchDBDatabase+"/"+id, nil, http.StatusOK)
+	var result struct {
+		Rev string `json:"_rev"`
+	}
+	require.NoError(t, json.Unmarshal(response, &result))
+	require.NotEmpty(t, result.Rev)
+	return result.Rev
+}
+
+func couchDBRequest(t *testing.T, ctx context.Context, base, method, path string, body any, status int) []byte {
+	t.Helper()
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		require.NoError(t, err)
+		reader = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, base+path, reader)
+	require.NoError(t, err)
+	request.SetBasicAuth(couchDBUser, couchDBPassword)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	require.NoError(t, err)
+	defer func() { _ = response.Body.Close() }()
+	payload, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+	require.Equal(t, status, response.StatusCode, string(payload))
+	return payload
+}
+
+func assertCouchDBRows(t *testing.T, ctx context.Context, duck *sql.DB, expected []string) {
+	t.Helper()
+	rows, err := duck.QueryContext(ctx, `SELECT _id FROM main.documents ORDER BY _id`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var actual []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		actual = append(actual, id)
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, expected, actual)
+}

--- a/tests/integration/couchdb_test.go
+++ b/tests/integration/couchdb_test.go
@@ -69,6 +69,22 @@ func TestCouchDBToDuckDBReplace(t *testing.T) {
 	table, err := src.GetTable(ctx, source.TableRequest{Name: couchDBDatabase})
 	require.NoError(t, err)
 	require.Equal(t, []string{"_id"}, table.PrimaryKeys())
+	_, err = src.GetTable(ctx, source.TableRequest{Name: couchDBDatabase, IncrementalKey: "updated_at"})
+	require.ErrorContains(t, err, "does not support incremental keys")
+	now := time.Now()
+	for _, opts := range []source.ReadOptions{{IncrementalKey: "updated_at"}, {IntervalStart: &now}, {IntervalEnd: &now}} {
+		_, err := table.Read(ctx, opts)
+		require.ErrorContains(t, err, "does not support incremental filtering")
+	}
+	limited, err := table.Read(ctx, source.ReadOptions{PageSize: 2, Limit: 2})
+	require.NoError(t, err)
+	var limitedRows int64
+	for result := range limited {
+		require.NoError(t, result.Err)
+		limitedRows += result.Batch.NumRows()
+		result.Batch.Release()
+	}
+	require.Equal(t, int64(2), limitedRows)
 	for _, capBytes := range []int64{0, 1} {
 		batches, err := table.Read(ctx, source.ReadOptions{PageSize: 2, MaxBatchBytes: capBytes, ExcludeColumns: []string{"secret"}})
 		require.NoError(t, err)
@@ -151,6 +167,15 @@ func TestCouchDBToDuckDBReplace(t *testing.T) {
 	require.NoError(t, duck.QueryRowContext(ctx, `SELECT name, CAST(profile AS VARCHAR) FROM main.documents WHERE _id = 'a'`).Scan(&name, &updatedProfile))
 	require.Equal(t, "alpha-updated", name)
 	require.JSONEq(t, `{"city":"Bergen","tags":["updated"]}`, updatedProfile)
+	for _, id := range []string{"a", "c"} {
+		rev := couchDBDocumentRevision(t, ctx, httpBase, id)
+		couchDBRequest(t, ctx, httpBase, http.MethodDelete, "/"+couchDBDatabase+"/"+id+"?rev="+rev, nil, http.StatusOK)
+	}
+	require.NoError(t, duck.Close())
+	require.NoError(t, pipeline.New(cfg).Run(ctx))
+	duck, err = sql.Open("adbc_generic", "driver=duckdb;path="+duckPath)
+	require.NoError(t, err)
+	assertCouchDBRows(t, ctx, duck, nil)
 }
 
 func startCouchDBContainer(t *testing.T, ctx context.Context) (testcontainers.Container, string, string) {

--- a/tests/integration/couchdb_test.go
+++ b/tests/integration/couchdb_test.go
@@ -167,15 +167,23 @@ func TestCouchDBToDuckDBReplace(t *testing.T) {
 	require.NoError(t, duck.QueryRowContext(ctx, `SELECT name, CAST(profile AS VARCHAR) FROM main.documents WHERE _id = 'a'`).Scan(&name, &updatedProfile))
 	require.Equal(t, "alpha-updated", name)
 	require.JSONEq(t, `{"city":"Bergen","tags":["updated"]}`, updatedProfile)
+	customConfig := *cfg
+	customConfig.DestTable = "main.custom_documents"
+	customConfig.PrimaryKeys = []string{"_id", "name"}
+	require.NoError(t, duck.Close())
+	require.NoError(t, pipeline.New(&customConfig).Run(ctx))
 	for _, id := range []string{"a", "c"} {
 		rev := couchDBDocumentRevision(t, ctx, httpBase, id)
 		couchDBRequest(t, ctx, httpBase, http.MethodDelete, "/"+couchDBDatabase+"/"+id+"?rev="+rev, nil, http.StatusOK)
 	}
-	require.NoError(t, duck.Close())
+	require.NoError(t, pipeline.New(&customConfig).Run(ctx))
 	require.NoError(t, pipeline.New(cfg).Run(ctx))
 	duck, err = sql.Open("adbc_generic", "driver=duckdb;path="+duckPath)
 	require.NoError(t, err)
 	assertCouchDBRows(t, ctx, duck, nil)
+	var customCount int
+	require.NoError(t, duck.QueryRowContext(ctx, `SELECT COUNT(name) FROM main.custom_documents`).Scan(&customCount))
+	require.Zero(t, customCount)
 }
 
 func startCouchDBContainer(t *testing.T, ctx context.Context) (testcontainers.Container, string, string) {


### PR DESCRIPTION
## Summary
- Add CouchDB HTTP/HTTPS source with basic authentication, inferred document schema, and `_id` primary keys.
- Paginate full database reads with byte-bounded Arrow batches; exclude design documents and tombstones.
- Document replace/merge behavior and register the connector in the catalog.

## Verification
- `make format` — passed
- `make lint` — passed (0 issues)
- `make test` — passed
- `INTEGRATION_BACKENDS=couchdb go test -tags integration -run "^TestCouchDBToDuckDBReplace$" -count=1 -v ./tests/integration` — passed against CouchDB 3.4.3 and DuckDB

Integration coverage includes pagination, byte limits, excluded columns, empty/missing databases, nested JSON, nulls, integers above 2^53, and replace after update/delete.

## Scope
Full database scans, sequential pagination, no native timestamp filtering or `_changes`/CDC. Default replace; explicit merge does not propagate deletions.