### PR TITLE
Fix AppLovin MAX backfill failures from hardcoded 120s CSV download timeout

### DIFF
--- a/pkg/source/applovinmax/applovinmax.go
+++ b/pkg/source/applovinmax/applovinmax.go
@@ -429,8 +429,9 @@ func (s *AppLovinMaxSource) downloadCSV(
 	return streamCSV(ctx, body, date, platform, opts, limiter, results)
 }
 
-// idleTimeoutReader cancels the request when no bytes are read within the idle
-// timeout, bounding a stalled download without capping total time.
+// idleTimeoutReader cancels the request when a single body read stalls past the
+// idle timeout. The timer is disarmed between reads so downstream backpressure
+// (a blocked flush to the results channel) is not mistaken for a network stall.
 type idleTimeoutReader struct {
 	r       io.Reader
 	timeout time.Duration
@@ -438,16 +439,20 @@ type idleTimeoutReader struct {
 }
 
 func newIdleTimeoutReader(r io.Reader, timeout time.Duration, onIdle func()) *idleTimeoutReader {
+	timer := time.AfterFunc(timeout, onIdle)
+	timer.Stop()
 	return &idleTimeoutReader{
 		r:       r,
 		timeout: timeout,
-		timer:   time.AfterFunc(timeout, onIdle),
+		timer:   timer,
 	}
 }
 
 func (r *idleTimeoutReader) Read(p []byte) (int, error) {
 	r.timer.Reset(r.timeout)
-	return r.r.Read(p)
+	n, err := r.r.Read(p)
+	r.timer.Stop()
+	return n, err
 }
 
 func (r *idleTimeoutReader) stop() {

--- a/pkg/source/applovinmax/applovinmax.go
+++ b/pkg/source/applovinmax/applovinmax.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"sort"
@@ -35,7 +36,23 @@ const (
 	workerCount    = 5
 	maxBatchRows   = 5_000
 	maxBatchBytes  = 16 << 20
+
+	csvConnectTimeout  = 30 * time.Second
+	csvHeaderTimeout   = 60 * time.Second
+	csvIdleReadTimeout = 120 * time.Second
 )
+
+// csvHTTPClient has no overall timeout so large reports can stream freely;
+// connect/header stalls are bounded here, body stalls by downloadCSV's idle timeout.
+var csvHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: csvConnectTimeout}).DialContext,
+		TLSHandshakeTimeout:   csvConnectTimeout,
+		ResponseHeaderTimeout: csvHeaderTimeout,
+		ForceAttemptHTTP2:     true,
+	},
+}
 
 var supportedTables = []string{"user_ad_revenue"}
 
@@ -388,13 +405,15 @@ func (s *AppLovinMaxSource) downloadCSV(
 	limiter *rowLimiter,
 	results chan<- source.RecordBatchResult,
 ) (int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, csvURL, nil)
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, csvURL, nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create CSV request: %w", err)
 	}
 
-	httpClient := &http.Client{Timeout: 120 * time.Second}
-	httpResp, err := httpClient.Do(req)
+	httpResp, err := csvHTTPClient.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("failed to download CSV: %w", err)
 	}
@@ -404,7 +423,35 @@ func (s *AppLovinMaxSource) downloadCSV(
 		return 0, fmt.Errorf("CSV download returned status %d", httpResp.StatusCode)
 	}
 
-	return streamCSV(ctx, httpResp.Body, date, platform, opts, limiter, results)
+	body := newIdleTimeoutReader(httpResp.Body, csvIdleReadTimeout, cancel)
+	defer body.stop()
+
+	return streamCSV(ctx, body, date, platform, opts, limiter, results)
+}
+
+// idleTimeoutReader cancels the request when no bytes are read within the idle
+// timeout, bounding a stalled download without capping total time.
+type idleTimeoutReader struct {
+	r       io.Reader
+	timeout time.Duration
+	timer   *time.Timer
+}
+
+func newIdleTimeoutReader(r io.Reader, timeout time.Duration, onIdle func()) *idleTimeoutReader {
+	return &idleTimeoutReader{
+		r:       r,
+		timeout: timeout,
+		timer:   time.AfterFunc(timeout, onIdle),
+	}
+}
+
+func (r *idleTimeoutReader) Read(p []byte) (int, error) {
+	r.timer.Reset(r.timeout)
+	return r.r.Read(p)
+}
+
+func (r *idleTimeoutReader) stop() {
+	r.timer.Stop()
 }
 
 type csvFieldSource struct {

--- a/pkg/source/applovinmax/applovinmax_test.go
+++ b/pkg/source/applovinmax/applovinmax_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -451,5 +452,55 @@ func TestAppLovinMaxByteCap(t *testing.T) {
 	}
 	if offR != onR || offR != 50 {
 		t.Fatalf("row mismatch off=%d on=%d", offR, onR)
+	}
+}
+
+// blockingReader blocks on Read until release is closed, then returns io.EOF.
+type blockingReader struct{ release chan struct{} }
+
+func (b *blockingReader) Read(p []byte) (int, error) {
+	<-b.release
+	return 0, io.EOF
+}
+
+func TestIdleTimeoutReader_StalledReadFires(t *testing.T) {
+	var fired atomic.Bool
+	br := &blockingReader{release: make(chan struct{})}
+	onIdle := func() {
+		fired.Store(true)
+		close(br.release)
+	}
+
+	r := newIdleTimeoutReader(br, 50*time.Millisecond, onIdle)
+	defer r.stop()
+
+	_, _ = r.Read(make([]byte, 8))
+	if !fired.Load() {
+		t.Fatal("expected onIdle to fire when a read stalls past the idle timeout")
+	}
+}
+
+func TestIdleTimeoutReader_BackpressureGapDoesNotFire(t *testing.T) {
+	var fired atomic.Bool
+	src := strings.NewReader("hello world")
+	r := newIdleTimeoutReader(src, 50*time.Millisecond, func() { fired.Store(true) })
+	defer r.stop()
+
+	if _, err := r.Read(make([]byte, 5)); err != nil {
+		t.Fatalf("first read failed: %v", err)
+	}
+
+	// Simulate a flush blocked on downstream backpressure for longer than the
+	// idle timeout; no Read happens during this gap and the timer must stay off.
+	time.Sleep(200 * time.Millisecond)
+	if fired.Load() {
+		t.Fatal("onIdle fired during a between-reads gap; backpressure was treated as a stall")
+	}
+
+	if _, err := r.Read(make([]byte, 32)); err != nil && err != io.EOF {
+		t.Fatalf("read after gap failed: %v", err)
+	}
+	if fired.Load() {
+		t.Fatal("onIdle fired despite a healthy read after the gap")
 	}
 }


### PR DESCRIPTION
## Problem

The AppLovin MAX connector downloads each day's report CSV with a hardcoded total timeout:

```go
httpClient := &http.Client{Timeout: 120 * time.Second}
```

`http.Client.Timeout` is a **total** deadline that also covers reading the response body. On large days the report CSV takes more than 120s to stream, so healthy, progressing downloads were cancelled mid-read with:

```
context deadline exceeded (Client.Timeout or context cancellation while reading body)
```
## Fix

Replace the single total timeout with limits that bound **stalls**, not total duration:

- **No overall client timeout** — a progressing download can stream for as long as it needs.
- **Transport-level timeouts** for connect (`DialContext`), TLS handshake, and `ResponseHeaderTimeout` — a dead/unresponsive endpoint still fails fast.
- **`idleTimeoutReader`** wrapping the body — resets a timer on every `Read`; if no bytes arrive within the idle window it cancels the request context, aborting a genuinely stalled download. A slow-but-moving stream is never killed.

The client/transport is shared across downloads for connection reuse.

## Result

- Large healthy downloads (e.g. the 6.9M-row days) complete instead of being killed at 120s.
- Genuinely stalled downloads are still cancelled.
- `extract_parallelism: 1` is no longer needed as a workaround.